### PR TITLE
Fix AV that occurs when jitting dynamic methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Please format the changes as follows:
 + BugFixes:
 + Updates:
 
+# 1.0.18
++ Update
+  + Fixed bug that causes an AV when jit compiling dynamic methods.
+
 # 1.0.17
 + New
   + Added API version levels to IProfilerManager via new IProfilerManager3 api

--- a/build/Version.props
+++ b/build/Version.props
@@ -10,7 +10,7 @@
     -->
     <SemanticVersionMajor>1</SemanticVersionMajor>
     <SemanticVersionMinor>0</SemanticVersionMinor>
-    <SemanticVersionPatch>17</SemanticVersionPatch>
+    <SemanticVersionPatch>18</SemanticVersionPatch>
 
     <FileVersionMajor>15</FileVersionMajor>
     <FileVersionMinor>1</FileVersionMinor>

--- a/src/InstrumentationEngine/MethodInfo.cpp
+++ b/src/InstrumentationEngine/MethodInfo.cpp
@@ -1335,12 +1335,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::SetFinalRenderedFunctionBod
     return hr;
 }
 
-HRESULT MicrosoftInstrumentationEngine::CMethodInfo::ClearILTransformationStatus()
-{
-    m_pModuleInfo->SetMethodIsTransformed(m_tkFunction, false);
-    return S_OK;
-}
-
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::ApplyFinalInstrumentation(bool isRejit)
 {
     HRESULT hr = S_OK;

--- a/src/InstrumentationEngine/MethodInfo.h
+++ b/src/InstrumentationEngine/MethodInfo.h
@@ -181,10 +181,6 @@ namespace MicrosoftInstrumentationEngine
              return m_bIsInstrumented;
          }
 
-         // Clears the cached il transformation status of this method. This is done before any instrumentation method
-         // or raw profiler hook performs any instrumentation on the method.
-         HRESULT ClearILTransformationStatus();
-
          // Applys all IL transformations and sets the IL cached transformation status of this method to true.
          HRESULT ApplyFinalInstrumentation(bool isRejit);
 

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -890,6 +890,10 @@ namespace MicrosoftInstrumentationEngine
 
         // Registers a new instrumentation method in the profiler manager. Also calls its Initialize() method.
         HRESULT AddInstrumentationMethod(_In_ CInstrumentationMethod* method, _Out_ IInstrumentationMethod** ppInstrumentationMethod);
+
+        HRESULT ClearILTransformationStatus(_In_ FunctionID functionId);
+
+        HRESULT ClearILTransformationStatus(_In_ ModuleID, _In_ mdMethodDef functionToken);
     };
 
     class CInitializeHolder


### PR DESCRIPTION
Dynamic methods were causing AVs because MethodInfos could not be created for dynamic functions. Changed the delegation of the responsibility for clearing IL transformation status from CMethodInfo to CProfilerManager to fix the issue.