### PR TITLE
Fix PDB names for extensions host and base

### DIFF
--- a/src/Extensions.Base/Extensions.Base.vcxproj
+++ b/src/Extensions.Base/Extensions.Base.vcxproj
@@ -18,7 +18,7 @@
       <PreprocessorDefinitions>_USRDLL;%(PreprocessorDefinitions);</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='Win32'">x86;%(PreprocessorDefinitions);</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(EnlistmentRoot)\src;$(NETFXKitsDir)\Include\um;$(InstrumentationEngineApiInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Midl>

--- a/src/ExtensionsHost/ExtensionsHost.vcxproj
+++ b/src/ExtensionsHost/ExtensionsHost.vcxproj
@@ -18,7 +18,7 @@
       <PreprocessorDefinitions>_USRDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='Win32'">x86;%(PreprocessorDefinitions);</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>$(EnlistmentRoot)\src;$(NETFXKitsDir)\Include\um;$(InstrumentationEngineApiInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <ProgramDataBaseFileName>$(OutDir)$(TargetName).pdb</ProgramDataBaseFileName>
+      <ProgramDataBaseFileName>$(IntDir)vc$(PlatformToolsetVersion).pdb</ProgramDataBaseFileName>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Midl>


### PR DESCRIPTION
Build does not work in VS because the Extensions.Base and ExtensionsHost projects incorrectly set pdb names for the compilation. They set the same pdb name for the C++ compilation as what is used by the linker, causing the linker to fail if you attempt to build the solution in VS. The fix is to reset the compiler pdb name back to its default value.

Note, this may have an effect on our API scan. Currently, it is unclear whether API scan was working correctly because it may have been picking up the wrong pdb. However, the linker should have always been running second, so there should be no problem there.