### PR TITLE
Fix deadlock between Rejit operations and AllowInline operations.

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -107,14 +107,25 @@ $VsRequirements = @(
 
 Write-Verbose -Verbose "Checking for VS installation with these installed components: `n`n$($VsRequirements | Out-String)`n"
 $vswhere = "`"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe`""
-$filterArgs = "-latest -prerelease -version `"[15.0,16.0)`" -requires $($VsRequirements -join ' ') -property installationPath"
-$installationPath = Invoke-ExpressionHelper -Executable $vswhere -Arguments $filterArgs -Activity 'Determine MSBuild location'
-if (!$installationPath)
+$filterArgs = "-latest -prerelease -requires $($VsRequirements -join ' ') -property installationPath"
+
+# Restrict the VS version if running from a context that has the VisualStudioVersion env variable (e.g. Developer Command Prompt).
+# This will make sure that VisualStudioVersion matches the VS version of MSBuild in order to avoid mismatches (e.g. using a Dev15
+# Developer Command Prompt but invoking Dev16's MSBuild).
+if ($env:VisualStudioVersion)
 {
-    Write-Error "Please check the Individual Components installed with your latest VS installation. This project requires version 10493 of the Windows 10 SDK component and both the 'Visual C++ ATL (x86/x64) with Spectre Mitigations' and 'VC++ 2017 version 15.8 v14.15 Libs for Spectre (x86 and x64)'."
+    $vsversion = [version]$($env:VisualStudioVersion)
+    # This is a version range that looks like "[15.0,16.0)"
+    $filterArgs = "$filterArgs -version `"[$($vsversion.Major).0,$($vsversion.Major + 1).0)`""
 }
 
+$installationPath = Invoke-Expression "& $vswhere $filterArgs"
 $msbuild = Join-Path $installationPath 'MSBuild\15.0\bin\MSBuild.exe'
+if (-not (Test-Path $msbuild))
+{
+    $msbuild = Join-Path $installationPath 'MSBuild\Current\bin\MSBuild.exe'
+}
+
 if (-not (Test-Path $msbuild))
 {
     $msbuild = Join-Path (Read-Host "Please enter the full path to your VS installation (eg. 'C:\Program Files (x86)\Microsoft Visual Studio\Preview\Enterprise)'`r`n") 'MSBuild\15.0\Bin\MSBuild.exe'

--- a/src/TestHostExtension/TestsHostExtension.vcxproj
+++ b/src/TestHostExtension/TestsHostExtension.vcxproj
@@ -14,13 +14,13 @@
   <Import Project="$(EnlistmentRoot)\build\Unmanaged.props" />
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(VCInstallDir)UnitTest\include;$(VCInstallDir)Auxiliary\VS\UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <AdditionalIncludeDirectories>$(EnlistmentRoot)\src;$(InstrumentationEngineApiInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <UseFullPaths>true</UseFullPaths>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
-      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(VCInstallDir)Auxiliary\VS\UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;mscoree.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;mscoree.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;mscoree.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/tests/InstrumentationEngine.Lib.Tests/InstrumentationEngine.Lib.Tests.vcxproj
+++ b/tests/InstrumentationEngine.Lib.Tests/InstrumentationEngine.Lib.Tests.vcxproj
@@ -49,7 +49,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <AdditionalIncludeDirectories>$(OutDir);..\..\src\InstrumentationEngine.Lib;$(InstrumentationEngineApiInc);$(VCInstallDir)UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(OutDir);..\..\src\InstrumentationEngine.Lib;$(InstrumentationEngineApiInc);$(VCInstallDir)UnitTest\include;$(VCInstallDir)Auxiliary\VS\UnitTest\include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
@@ -57,7 +57,7 @@
     <Link>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
-      <AdditionalLibraryDirectories>$(OutDir);..\..\inc;$(VCInstallDir)UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>$(OutDir);..\..\inc;$(VCInstallDir)UnitTest\lib;$(VCInstallDir)Auxiliary\VS\UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>InstrumentationEngine.Lib.lib;msxml6.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;%(AdditionalDependencies);PathCch.lib</AdditionalDependencies>
       <AdditionalOptions Condition="'$(Platform)'=='Win32'">/SafeSEH %(AdditionalOptions)</AdditionalOptions>
     </Link>


### PR DESCRIPTION
- Unify code for copying instrumentation methods
- Also allow building on VS 2019