### PR TITLE
Removed HostPath from xdt files

### DIFF
--- a/src/InstrumentationEngine.Preinstall/applicationHost.xdt
+++ b/src/InstrumentationEngine.Preinstall/applicationHost.xdt
@@ -29,7 +29,6 @@
         <add name="CORECLR_PROFILER" value="{324F817A-7420-4E6D-B3C1-143FBED6D855}" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <add name="CORECLR_PROFILER_PATH_32" value="%XDT_EXTENSIONPATH%\Instrumentation32\MicrosoftInstrumentationEngine_x86.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <add name="CORECLR_PROFILER_PATH_64" value="%XDT_EXTENSIONPATH%\Instrumentation64\MicrosoftInstrumentationEngine_x64.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
-        <add name="MicrosoftInstrumentationEngine_Host" value="{CA487940-57D2-10BF-11B2-A3AD5A13CBC0}" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <add name="MicrosoftInstrumentationEngine_LogLevel" value="Errors" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <add name="MicrosoftInstrumentationEngine_IsPreinstalled" value="1" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
       </environmentVariables>

--- a/src/InstrumentationEngine.Preinstall/scmApplicationHost.xdt
+++ b/src/InstrumentationEngine.Preinstall/scmApplicationHost.xdt
@@ -30,7 +30,6 @@
         <add name="CORECLR_PROFILER" value="{324F817A-7420-4E6D-B3C1-143FBED6D855}" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <add name="CORECLR_PROFILER_PATH_32" value="%XDT_EXTENSIONPATH%\Instrumentation32\MicrosoftInstrumentationEngine_x86.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <add name="CORECLR_PROFILER_PATH_64" value="%XDT_EXTENSIONPATH%\Instrumentation64\MicrosoftInstrumentationEngine_x64.dll" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
-        <add name="MicrosoftInstrumentationEngine_Host" value="{CA487940-57D2-10BF-11B2-A3AD5A13CBC0}" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <add name="MicrosoftInstrumentationEngine_LogLevel" value="Errors" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <add name="MicrosoftInstrumentationEngine_IsPreinstalled" value="1" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" /> -->
       </environmentVariables>


### PR DESCRIPTION
This fix is an addendum of the fold extensionsHost change. Remove HostPath variables from xdt files used by preinstalled site extension.