### PR TITLE
Return effective flags from GetLoggingFlags

### DIFF
--- a/src/InstrumentationEngine.Lib/LoggerService.cpp
+++ b/src/InstrumentationEngine.Lib/LoggerService.cpp
@@ -64,7 +64,12 @@ HRESULT CLoggerService::GetLoggingFlags(_Out_ LoggingFlags* pLoggingFlags)
 
     CCriticalSectionHolder holder(&m_cs);
 
-    *pLoggingFlags = m_defaultFlags;
+    // Intentionally returning the effective flags instead of the default flags
+    // (ones set by default or by SetLoggingFlags). The GetLoggingFlags method
+    // is primarily meant for consumers external of the Instrumentation Engine
+    // assembly to determine which flags are supported rather than literally
+    // reporting what the default was or what was set by SetLoggingFlags.
+    *pLoggingFlags = m_effectiveFlags;
 
     return S_OK;
 }


### PR DESCRIPTION
This fixes an issue caused by the work ([PR](https://github.com/microsoft/CLRInstrumentationEngine/pull/50)) to fold the extension host into the main Instrumentation Engine assembly.

The problem is that the extension host used to consider the file log level if the default log level was not specified and would set the value as the default logging flags, but the changes in the PR only consider setting the default logging flags based on the default log level environment variable. Thus, if any consume got the logging flags via GetLoggingFlags and only the file logging level was set, then nothing would be logged out to the file.

The change here is to report the effective logging flags that is the union of all flags as returned by the sinks when resetting them. This allows consumers of the GetLoggingFlags method to understand which flags are effectively enabled, regardless of what the default value was or what was explicitly set by calling SetLoggingFlags.