### PR TITLE
Use separate event for signaling finish event logging processing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Please format the changes as follows:
 + BugFixes:
 + Updates:
 
+# 1.0.24
++ BugFixes:
+  + Avoid deadlock within CEventLoggingBase when terminating logging.
+
 # 1.0.23
 + New:
   + Added instrumentation method registration query method via new IProfilerManager5 API.

--- a/build/Version.props
+++ b/build/Version.props
@@ -12,7 +12,7 @@
     -->
     <SemanticVersionMajor>1</SemanticVersionMajor>
     <SemanticVersionMinor>0</SemanticVersionMinor>
-    <SemanticVersionPatch>23</SemanticVersionPatch>
+    <SemanticVersionPatch>24</SemanticVersionPatch>
 
     <FileVersionMajor>15</FileVersionMajor>
     <FileVersionMinor>1</FileVersionMinor>
@@ -37,7 +37,7 @@
       Date when Semantic Version was changed.
       Update for every public release.
     -->
-    <SemanticVersionDate>2019-6-26</SemanticVersionDate>
+    <SemanticVersionDate>2019-7-2</SemanticVersionDate>
 
     <!--
       Build version is used to distinguish internally built NuGet packages.

--- a/src/Common.Lib/EventLoggingBase.h
+++ b/src/Common.Lib/EventLoggingBase.h
@@ -34,7 +34,8 @@ namespace CommonLib
         CCriticalSection m_cs;
         std::queue<EventLogItem> m_eventQueue;
         size_t m_eventQueueLength;
-        CEvent m_hEventQueueEvent;
+        CEvent m_hEventQueueFinishedEvent; // Used to signal when thread is done processing items and no longer using event source.
+        CEvent m_hEventQueueProcessEvent;
         CHandle m_hEventQueueThread;
         HANDLE m_hEventSource; // Not relying on RAII; this handle should be closed by DeregisterEventSource call.
         bool m_isShutdown;

--- a/src/InstrumentationEngine.Lib/FileLoggerSink.cpp
+++ b/src/InstrumentationEngine.Lib/FileLoggerSink.cpp
@@ -116,7 +116,11 @@ HRESULT CFileLoggerSink::Reset(_In_ LoggingFlags defaultFlags, _Out_ LoggingFlag
         }
     }
 
-    *pEffectiveFlags = effectiveFlags;
+    // Only return non-None flags if the output file has been opened.
+    if (m_pOutputFile)
+    {
+        *pEffectiveFlags = effectiveFlags;
+    }
 
     return S_OK;
 }


### PR DESCRIPTION
Use separate event for signaling finish event logging processing.
Have file sink only report flags if file was opened.