### PR TITLE
Fix bug where preinstalled site extension is empty

### DIFF
--- a/build/Tasks/Tasks.targets
+++ b/build/Tasks/Tasks.targets
@@ -11,6 +11,7 @@
       <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
     </ParameterGroup>
     <Task>
+      <Reference Include="System.Core" />
       <Reference Include="System.IO.Compression" />
       <Code Type="Class" Source="$(MSBuildThisFileDirectory)ZipArchiveTask.cs" />
     </Task>

--- a/build/Tasks/ZipArchiveTask.cs
+++ b/build/Tasks/ZipArchiveTask.cs
@@ -2,6 +2,7 @@
 //
 
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using System.IO;
@@ -31,6 +32,7 @@ namespace Microsoft.VisualStudio.ProductionDiagnostics.BuildTasks
             Log.LogMessage("Number of items to archive: {0}", Files.Length);
 
             bool success = true;
+            HashSet<string> uniqueFiles = new HashSet<string>(StringComparer.InvariantCultureIgnoreCase);
             try
             {
                 using (FileStream zipToOpen = new FileStream(OutputPath, FileMode.Create))
@@ -39,6 +41,14 @@ namespace Microsoft.VisualStudio.ProductionDiagnostics.BuildTasks
                     foreach (ITaskItem fileItem in Files)
                     {
                         string destinationFileName = new FileInfo(fileItem.ItemSpec).Name;
+
+                        // Prevent duplicate files from getting zipped.
+                        if (uniqueFiles.Contains(destinationFileName))
+                        {
+                            continue;
+                        }
+
+                        uniqueFiles.Add(destinationFileName);
                         string destinationFolder = fileItem.GetMetadata("Destination");
                         string type = fileItem.GetMetadata("Type");
                         if (!string.IsNullOrEmpty(destinationFolder))

--- a/src/InstrumentationEngine.Preinstall/InstrumentationEngine.Preinstall.csproj
+++ b/src/InstrumentationEngine.Preinstall/InstrumentationEngine.Preinstall.csproj
@@ -47,27 +47,29 @@
         <Destination>$(PackageVersion)</Destination>
       </ZipItem>
       <!-- Instrumentationx86Files -->
-      <ZipItem Include="$(InputBinCfgRoot)\x86\InstrumentationEngine\**"
-               Exclude="$(InputBinCfgRoot)\x86\InstrumentationEngine\**\*.pdb;$(InputBinCfgRoot)\x86\InstrumentationEngine\**\*.config;$(InputBinCfgRoot)\x86\InstrumentationEngine\**\*base*">
+      <ZipItem Include="$(InputBinCfgRoot)\x86\**\MicrosoftInstrumentationEngine_x86.dll">
         <Destination>$(PackageVersion)\Instrumentation32</Destination>
       </ZipItem>
-      <ZipItem Include="$(InputBinCfgRoot)\x86\InstrumentationEngine\**\*base*"
-               Exclude="$(InputBinCfgRoot)\x86\InstrumentationEngine\**\*.pdb">
+      <ZipItem Include="$(InputBinCfgRoot)\x86\**\Microsoft.InstrumentationEngine.Extensions.Base_x86.dll">
         <Destination>$(PackageVersion)\Instrumentation32\base</Destination>
       </ZipItem>
-      <ZipItem Include="$(InputBinCfgRoot)\x86\InstrumentationEngine\**\Microsoft.InstrumentationEngine.Extensions.config">
+      <ZipItem Include="$(InputBinCfgRoot)\x86\**\Microsoft.InstrumentationEngine.Extensions.config">
+        <Destination>$(PackageVersion)\Instrumentation32\base</Destination>
+      </ZipItem>
+      <ZipItem Include="$(InputBinCfgRoot)\AnyCPU\**\Microsoft.Diagnostics.Instrumentation.Extensions.Base.dll">
         <Destination>$(PackageVersion)\Instrumentation32\base</Destination>
       </ZipItem>
       <!-- Instrumentationx64Files -->
-      <ZipItem Include="$(InputBinCfgRoot)\x64\InstrumentationEngine\**"
-               Exclude="$(InputBinCfgRoot)\x64\InstrumentationEngine\**\*.pdb;$(InputBinCfgRoot)\x64\InstrumentationEngine\**\*.config;$(InputBinCfgRoot)\x64\InstrumentationEngine\**\*base*">
+      <ZipItem Include="$(InputBinCfgRoot)\x64\**\MicrosoftInstrumentationEngine_x64.dll">
         <Destination>$(PackageVersion)\Instrumentation64</Destination>
       </ZipItem>
-      <ZipItem Include="$(InputBinCfgRoot)\x64\InstrumentationEngine\**\*base*"
-               Exclude="$(InputBinCfgRoot)\x64\InstrumentationEngine\**\*.pdb">
+      <ZipItem Include="$(InputBinCfgRoot)\x64\**\Microsoft.InstrumentationEngine.Extensions.Base_x64.dll">
         <Destination>$(PackageVersion)\Instrumentation64\base</Destination>
       </ZipItem>
-      <ZipItem Include="$(InputBinCfgRoot)\x64\InstrumentationEngine\**\Microsoft.InstrumentationEngine.Extensions.config">
+      <ZipItem Include="$(InputBinCfgRoot)\x64\**\Microsoft.InstrumentationEngine.Extensions.config">
+        <Destination>$(PackageVersion)\Instrumentation64\base</Destination>
+      </ZipItem>
+      <ZipItem Include="$(InputBinCfgRoot)\AnyCPU\**\Microsoft.Diagnostics.Instrumentation.Extensions.Base.dll">
         <Destination>$(PackageVersion)\Instrumentation64\base</Destination>
       </ZipItem>
     </ItemGroup>

--- a/src/InstrumentationEngine.Preinstall/InstrumentationEngine.Preinstall.csproj
+++ b/src/InstrumentationEngine.Preinstall/InstrumentationEngine.Preinstall.csproj
@@ -3,6 +3,7 @@
       -->
 <Project>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), EnlistmentRoot.marker))\build\Common.props" />
+  <Import Project="$(EnlistmentRoot)\build\Packaging.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>


### PR DESCRIPTION
Without this fix, the preinstalled site extension .zip file can't resolve filepaths.