### PR TITLE
Remove Shutdown() calls from destructors

### DIFF
--- a/src/Common.Lib/EventLoggingBase.cpp
+++ b/src/Common.Lib/EventLoggingBase.cpp
@@ -25,12 +25,6 @@ CEventLoggingBase::CEventLoggingBase() :
 
 CEventLoggingBase::~CEventLoggingBase()
 {
-    CCriticalSectionHolder holder(&m_cs);
-
-    if (m_hEventSource)
-    {
-        TerminateEventSource();
-    }
 }
 
 HRESULT CEventLoggingBase::InitializeEventSource(_In_ LPCWSTR wszEventSourceName)

--- a/src/Common.Lib/EventLoggingBase.cpp
+++ b/src/Common.Lib/EventLoggingBase.cpp
@@ -139,7 +139,10 @@ HRESULT CEventLoggingBase::TerminateEventSource()
     }
 
     // Allow thread to drain the queue
-    WaitForSingleObject(m_hEventQueueThread, INFINITE);
+    if (m_hEventQueueThread)
+    {
+        WaitForSingleObject(m_hEventQueueThread, INFINITE);
+    }
 
     // Block scope used to release critical section before end of method.
     {

--- a/src/Common.Lib/EventLoggingBase.h
+++ b/src/Common.Lib/EventLoggingBase.h
@@ -34,7 +34,6 @@ namespace CommonLib
         CCriticalSection m_cs;
         std::queue<EventLogItem> m_eventQueue;
         size_t m_eventQueueLength;
-        CEvent m_hEventQueueFinishedEvent; // Used to signal when thread is done processing items and no longer using event source.
         CEvent m_hEventQueueProcessEvent;
         CHandle m_hEventQueueThread;
         HANDLE m_hEventSource; // Not relying on RAII; this handle should be closed by DeregisterEventSource call.

--- a/src/InstrumentationEngine.Lib/EventLoggerSink.cpp
+++ b/src/InstrumentationEngine.Lib/EventLoggerSink.cpp
@@ -13,7 +13,6 @@ CEventLoggerSink::CEventLoggerSink() :
 
 CEventLoggerSink::~CEventLoggerSink()
 {
-    Shutdown();
 }
 
 HRESULT CEventLoggerSink::Initialize(_In_ CLoggerService* pLogging)

--- a/src/InstrumentationEngine.Lib/LoggerService.cpp
+++ b/src/InstrumentationEngine.Lib/LoggerService.cpp
@@ -25,7 +25,6 @@ CLoggerService::CLoggerService() :
 
 CLoggerService::~CLoggerService()
 {
-    Shutdown();
 }
 
 HRESULT CLoggerService::GetLoggingHost(_Out_ IProfilerManagerLoggingHost** ppLoggingHost)

--- a/src/InstrumentationEngine/LoggingWrapper.h
+++ b/src/InstrumentationEngine/LoggingWrapper.h
@@ -22,6 +22,10 @@ namespace MicrosoftInstrumentationEngine
 
         ~CLoggingWrapper()
         {
+            if (m_initialize.IsSuccessful())
+            {
+                CLogging::Shutdown();
+            }
         }
 
         // IUnknown Members

--- a/src/InstrumentationEngine/LoggingWrapper.h
+++ b/src/InstrumentationEngine/LoggingWrapper.h
@@ -22,10 +22,6 @@ namespace MicrosoftInstrumentationEngine
 
         ~CLoggingWrapper()
         {
-            if (m_initialize.IsSuccessful())
-            {
-                CLogging::Shutdown();
-            }
         }
 
         // IUnknown Members

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -957,6 +957,8 @@ HRESULT MicrosoftInstrumentationEngine::CProfilerManager::Shutdown()
     // to leak the reference.
     m_profilerManagerHost.Detach();
 
+    CLogging::Shutdown();
+
     PROF_CALLBACK_END
 
     return S_OK;

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -94,6 +94,7 @@ MicrosoftInstrumentationEngine::CProfilerManager::CProfilerManager() :
 MicrosoftInstrumentationEngine::CProfilerManager::~CProfilerManager()
 {
     DeleteCriticalSection(&m_cs);
+    CLogging::Shutdown();
 }
 
 HRESULT MicrosoftInstrumentationEngine::CProfilerManager::FinalConstruct()
@@ -955,8 +956,6 @@ HRESULT MicrosoftInstrumentationEngine::CProfilerManager::Shutdown()
     // of their cleanup during the Shutdown event. Detach the pointer and allow it
     // to leak the reference.
     m_profilerManagerHost.Detach();
-
-    CLogging::Shutdown();
 
     PROF_CALLBACK_END
 

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -94,7 +94,6 @@ MicrosoftInstrumentationEngine::CProfilerManager::CProfilerManager() :
 MicrosoftInstrumentationEngine::CProfilerManager::~CProfilerManager()
 {
     DeleteCriticalSection(&m_cs);
-    CLogging::Shutdown();
 }
 
 HRESULT MicrosoftInstrumentationEngine::CProfilerManager::FinalConstruct()
@@ -956,6 +955,8 @@ HRESULT MicrosoftInstrumentationEngine::CProfilerManager::Shutdown()
     // of their cleanup during the Shutdown event. Detach the pointer and allow it
     // to leak the reference.
     m_profilerManagerHost.Detach();
+
+    CLogging::Shutdown();
 
     PROF_CALLBACK_END
 


### PR DESCRIPTION
This causes deadlocking on EventLoggingBase.cpp's TerminateEventSource() which attempts to get a handle to the CCriticalSection that's been discarded prior to static deconstructor call. This fix here is to remove the static deconstructors from calling shutdown.