### PR TITLE
Add null checks for MethodName BSTRs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please format the changes as follows:
   + Build header nupkg for AnyCPU
   + Fix unicode character in bldver.rc
   + Remove nobuild property for package projects to unblock dotnet core 3
+  + Handle null methodNames from dll obfuscation
 + Updates:
   + Change EULA to MIT license for OSS
 

--- a/src/InstrumentationEngine/MethodInfo.cpp
+++ b/src/InstrumentationEngine/MethodInfo.cpp
@@ -205,7 +205,7 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeFullName()
 {
     HRESULT hr = S_OK;
 
-    if (m_bstrMethodFullName.Length() != 0)
+    if (m_bstrMethodFullName != nullptr && m_bstrMethodFullName.Length() != 0)
     {
         return S_OK;
     }
@@ -246,14 +246,24 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeFullName()
     if (m_pDeclaringType)
     {
         CComBSTR declaringTypeName;
-        if (SUCCEEDED(m_pDeclaringType->GetName(&declaringTypeName)) && declaringTypeName.Length() > 0)
+        if (SUCCEEDED(m_pDeclaringType->GetName(&declaringTypeName)) &&
+            declaringTypeName != nullptr &&
+            declaringTypeName.Length() > 0)
         {
             nameBuilder << (LPWSTR)declaringTypeName << _T(".");
         }
     }
-    nameBuilder << (LPWSTR)m_bstrMethodName;
-    m_bstrMethodFullName = nameBuilder.str().c_str();
 
+    if (m_bstrMethodName != nullptr)
+    {
+        nameBuilder << (LPWSTR)m_bstrMethodName;
+    }
+    else
+    {
+        nameBuilder << _T("");
+    }
+
+    m_bstrMethodFullName = nameBuilder.str().c_str();
     return S_OK;
 }
 

--- a/src/InstrumentationEngine/MethodInfo.cpp
+++ b/src/InstrumentationEngine/MethodInfo.cpp
@@ -205,7 +205,7 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeFullName()
 {
     HRESULT hr = S_OK;
 
-    if (m_bstrMethodFullName != nullptr && m_bstrMethodFullName.Length() != 0)
+    if (m_bstrMethodFullName.Length() != 0)
     {
         return S_OK;
     }
@@ -254,14 +254,7 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeFullName()
         }
     }
 
-    if (m_bstrMethodName != nullptr)
-    {
-        nameBuilder << (LPWSTR)m_bstrMethodName;
-    }
-    else
-    {
-        nameBuilder << _T("");
-    }
+    nameBuilder << (LPWSTR)m_bstrMethodName;
 
     m_bstrMethodFullName = nameBuilder.str().c_str();
     return S_OK;
@@ -349,7 +342,7 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeCorAttributes(_In
         IfFailRet(pMetaDataImport->GetMethodProps(m_tkFunction, nullptr, nullptr, 0, &cbMethodName, nullptr, nullptr, nullptr, nullptr, nullptr));
         std::vector<WCHAR> nameBuilder(cbMethodName);
         IfFailRet(pMetaDataImport->GetMethodProps(tkFunction, &m_tkTypeDef, nameBuilder.data(), cbMethodName, &cbMethodName, (DWORD *)&m_methodAttr, (PCCOR_SIGNATURE*)&m_pSig, &m_cbSigBlob, &m_rva, (DWORD *)&m_implFlags));
-        m_bstrMethodName = nameBuilder.data();
+        m_bstrMethodName = nameBuilder.data(); // may be null
     }
     else if (TypeFromToken(m_tkFunction) == mdtMemberRef)
     {
@@ -357,7 +350,7 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeCorAttributes(_In
         IfFailRet(pMetaDataImport->GetMemberRefProps(m_tkFunction, nullptr, nullptr, 0, &cbMethodName, nullptr, nullptr));
         std::vector<WCHAR> nameBuilder(cbMethodName);
         IfFailRet(pMetaDataImport->GetMemberRefProps(tkFunction, &m_tkTypeDef, nameBuilder.data(), cbMethodName, &cbMethodName, (PCCOR_SIGNATURE*)&m_pSig, &m_cbSigBlob));
-        m_bstrMethodName = nameBuilder.data();
+        m_bstrMethodName = nameBuilder.data(); // may be null
     }
     else
     {
@@ -365,6 +358,11 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeCorAttributes(_In
         IfFailRet(pMetaDataImport->GetMethodSpecProps(tkFunction, &tkMethodDef, nullptr, nullptr));
         // Get the method def name
         IfFailRet(InitializeCorAttributes(tkMethodDef));
+    }
+
+    if (m_bstrMethodName == nullptr)
+    {
+        m_bstrMethodName = _T("");
     }
 
     m_bCorAttributesInitialized = true;


### PR DESCRIPTION
Obfuscated dlls can caus method names to be empty -- MetadataImport::GetMethodProps() returns nullptr

Thank you Michael Baranov and the SiteCore team for helping us uncover this bug!