### PR TITLE
Fix SAL annotations

### DIFF
--- a/src/InstrumentationEngine.Api/InstrumentationEngine.h
+++ b/src/InstrumentationEngine.Api/InstrumentationEngine.h
@@ -5503,7 +5503,7 @@ EXTERN_C const IID IID_ILocalVariableCollection;
         
         virtual HRESULT STDMETHODCALLTYPE AddLocal( 
             /* [in] */ __RPC__in_opt IType *pType,
-            /* [optional][out] */ __RPC__out DWORD *pIndex) = 0;
+            /* [optional][full][out][in] */ __RPC__inout_opt DWORD *pIndex) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE ReplaceSignature( 
             /* [in] */ __RPC__in const BYTE *pSignature,
@@ -5546,7 +5546,7 @@ EXTERN_C const IID IID_ILocalVariableCollection;
         HRESULT ( STDMETHODCALLTYPE *AddLocal )( 
             __RPC__in ILocalVariableCollection * This,
             /* [in] */ __RPC__in_opt IType *pType,
-            /* [optional][out] */ __RPC__out DWORD *pIndex);
+            /* [optional][full][out][in] */ __RPC__inout_opt DWORD *pIndex);
         
         HRESULT ( STDMETHODCALLTYPE *ReplaceSignature )( 
             __RPC__in ILocalVariableCollection * This,
@@ -6095,7 +6095,7 @@ EXTERN_C const IID IID_ITypeCreator;
             /* [in] */ DWORD cbBuffer,
             /* [in] */ __RPC__in const BYTE *pCorSignature,
             /* [out] */ __RPC__deref_out_opt IType **ppType,
-            /* [optional][out] */ __RPC__out DWORD *pdwSigSize) = 0;
+            /* [optional][full][out][in] */ __RPC__inout_opt DWORD *pdwSigSize) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE FromCorElement( 
             /* [in] */ CorElementType type,
@@ -6132,7 +6132,7 @@ EXTERN_C const IID IID_ITypeCreator;
             /* [in] */ DWORD cbBuffer,
             /* [in] */ __RPC__in const BYTE *pCorSignature,
             /* [out] */ __RPC__deref_out_opt IType **ppType,
-            /* [optional][out] */ __RPC__out DWORD *pdwSigSize);
+            /* [optional][full][out][in] */ __RPC__inout_opt DWORD *pdwSigSize);
         
         HRESULT ( STDMETHODCALLTYPE *FromCorElement )( 
             __RPC__in ITypeCreator * This,
@@ -7785,7 +7785,7 @@ EXTERN_C const IID IID_ILocalVariableCollection2;
         HRESULT ( STDMETHODCALLTYPE *AddLocal )( 
             __RPC__in ILocalVariableCollection2 * This,
             /* [in] */ __RPC__in_opt IType *pType,
-            /* [optional][out] */ __RPC__out DWORD *pIndex);
+            /* [optional][full][out][in] */ __RPC__inout_opt DWORD *pIndex);
         
         HRESULT ( STDMETHODCALLTYPE *ReplaceSignature )( 
             __RPC__in ILocalVariableCollection2 * This,
@@ -7995,25 +7995,25 @@ EXTERN_C const IID IID_ISignatureParser;
         virtual HRESULT STDMETHODCALLTYPE ParseMethodSignature( 
             /* [in] */ __RPC__in const BYTE *pSignature,
             /* [in] */ ULONG cbSignature,
-            /* [optional][out] */ __RPC__out ULONG *pCallingConvention,
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pCallingConvention,
             /* [optional][out] */ __RPC__deref_out_opt IType **ppReturnType,
             /* [optional][out] */ __RPC__deref_out_opt IEnumTypes **ppEnumParameterTypes,
-            /* [optional][out] */ __RPC__out ULONG *pcGenericTypeParameters,
-            /* [optional][out] */ __RPC__out ULONG *pcbRead) = 0;
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pcGenericTypeParameters,
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pcbRead) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE ParseLocalVarSignature( 
             /* [in] */ __RPC__in const BYTE *pSignature,
             /* [in] */ ULONG cbSignature,
-            /* [optional][out] */ __RPC__out ULONG *pCallingConvention,
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pCallingConvention,
             /* [optional][out] */ __RPC__deref_out_opt IEnumTypes **ppEnumTypes,
-            /* [optional][out] */ __RPC__out ULONG *pcbRead) = 0;
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pcbRead) = 0;
         
         virtual HRESULT STDMETHODCALLTYPE ParseTypeSequence( 
             /* [in] */ __RPC__in const BYTE *pBuffer,
             /* [in] */ ULONG cbBuffer,
             /* [in] */ ULONG cTypes,
             /* [optional][out] */ __RPC__deref_out_opt IEnumTypes **ppEnumTypes,
-            /* [optional][out] */ __RPC__out ULONG *pcbRead) = 0;
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pcbRead) = 0;
         
     };
     
@@ -8040,19 +8040,19 @@ EXTERN_C const IID IID_ISignatureParser;
             __RPC__in ISignatureParser * This,
             /* [in] */ __RPC__in const BYTE *pSignature,
             /* [in] */ ULONG cbSignature,
-            /* [optional][out] */ __RPC__out ULONG *pCallingConvention,
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pCallingConvention,
             /* [optional][out] */ __RPC__deref_out_opt IType **ppReturnType,
             /* [optional][out] */ __RPC__deref_out_opt IEnumTypes **ppEnumParameterTypes,
-            /* [optional][out] */ __RPC__out ULONG *pcGenericTypeParameters,
-            /* [optional][out] */ __RPC__out ULONG *pcbRead);
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pcGenericTypeParameters,
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pcbRead);
         
         HRESULT ( STDMETHODCALLTYPE *ParseLocalVarSignature )( 
             __RPC__in ISignatureParser * This,
             /* [in] */ __RPC__in const BYTE *pSignature,
             /* [in] */ ULONG cbSignature,
-            /* [optional][out] */ __RPC__out ULONG *pCallingConvention,
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pCallingConvention,
             /* [optional][out] */ __RPC__deref_out_opt IEnumTypes **ppEnumTypes,
-            /* [optional][out] */ __RPC__out ULONG *pcbRead);
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pcbRead);
         
         HRESULT ( STDMETHODCALLTYPE *ParseTypeSequence )( 
             __RPC__in ISignatureParser * This,
@@ -8060,7 +8060,7 @@ EXTERN_C const IID IID_ISignatureParser;
             /* [in] */ ULONG cbBuffer,
             /* [in] */ ULONG cTypes,
             /* [optional][out] */ __RPC__deref_out_opt IEnumTypes **ppEnumTypes,
-            /* [optional][out] */ __RPC__out ULONG *pcbRead);
+            /* [optional][full][out][in] */ __RPC__inout_opt ULONG *pcbRead);
         
         END_INTERFACE
     } ISignatureParserVtbl;

--- a/src/InstrumentationEngine.Api/InstrumentationEngine.idl
+++ b/src/InstrumentationEngine.Api/InstrumentationEngine.idl
@@ -1149,7 +1149,7 @@ library MicrosoftInstrumentationEngine
         HRESULT Initialize();
         HRESULT GetCorSignature([out] ISignatureBuilder** ppSignature);
         HRESULT GetCount([out]DWORD* pdwCount);
-        HRESULT AddLocal([in] IType* pType, [out, optional]DWORD* pIndex);
+        HRESULT AddLocal([in] IType* pType, [in, out, ptr, optional] DWORD* pIndex);
         HRESULT ReplaceSignature([in] const BYTE* pSignature, [in] DWORD dwSigSize);
 
         // Commits the newly added locals to the method local signature
@@ -1299,19 +1299,19 @@ library MicrosoftInstrumentationEngine
         HRESULT ParseMethodSignature(
             [in] const BYTE* pSignature,
             [in] ULONG cbSignature,
-            [out, optional] ULONG* pCallingConvention,
+            [in, out, ptr, optional] ULONG* pCallingConvention,
             [out, optional] IType** ppReturnType,
             [out, optional] IEnumTypes** ppEnumParameterTypes,
-            [out, optional] ULONG* pcGenericTypeParameters,
-            [out, optional] ULONG* pcbRead
+            [in, out, ptr, optional] ULONG* pcGenericTypeParameters,
+            [in, out, ptr, optional] ULONG* pcbRead
             );
 
         HRESULT ParseLocalVarSignature(
             [in] const BYTE* pSignature,
             [in] ULONG cbSignature,
-            [out, optional] ULONG* pCallingConvention,
+            [in, out, ptr, optional] ULONG* pCallingConvention,
             [out, optional] IEnumTypes** ppEnumTypes,
-            [out, optional] ULONG* pcbRead
+            [in, out, ptr, optional] ULONG* pcbRead
             );
 
         HRESULT ParseTypeSequence(
@@ -1319,7 +1319,7 @@ library MicrosoftInstrumentationEngine
             [in] ULONG cbBuffer,
             [in] ULONG cTypes,
             [out, optional] IEnumTypes** ppEnumTypes,
-            [out, optional] ULONG* pcbRead
+            [in, out, ptr, optional] ULONG* pcbRead
             );
     };
 
@@ -1397,7 +1397,7 @@ library MicrosoftInstrumentationEngine
     ]
     interface ITypeCreator : IUnknown
     {
-        HRESULT FromSignature([in] DWORD cbBuffer, [in] const BYTE* pCorSignature, [out] IType ** ppType, [out, optional] DWORD* pdwSigSize);
+        HRESULT FromSignature([in] DWORD cbBuffer, [in] const BYTE* pCorSignature, [out] IType ** ppType, [in, out, ptr, optional] DWORD* pdwSigSize);
         HRESULT FromCorElement([in] CorElementType type, [out] IType** ppType);
         HRESULT FromToken([in] CorElementType type, [in] mdToken token, [out] IType** ppType);
         //FromClassID


### PR DESCRIPTION
[out, optional] does not create correct SAL annotations for
basic pointer types (eg., DWORD, ULONG, etcl). Our current
annotations for interfaces, therefore, break static analysis in
our headers.

The fix is to change the annotations to [in, out, ptr]. Note,
the 'optional' annotation remains in idl, even though it doesn't
affect SAL at all. All 'optional' parameters must be grouped
at the end of the parameter list. Changing these so that they don't
have 'optional' would break the interface.

This is a fix for bug #135