### PR TITLE
Create a PS script for local testing

### DIFF
--- a/build/Scripts/PrivateXdt/GeneratePrivateXdt.ps1
+++ b/build/Scripts/PrivateXdt/GeneratePrivateXdt.ps1
@@ -1,7 +1,5 @@
-<#
-    Copyright (c) Microsoft Corporation. All rights reserved.
-    Licensed under the MIT License.
-#>
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 
 <#
 .SYNOPSIS

--- a/build/Scripts/PrivateXdt/XdtHelper.psm1
+++ b/build/Scripts/PrivateXdt/XdtHelper.psm1
@@ -1,7 +1,5 @@
-<#
-    Copyright (c) Microsoft Corporation. All rights reserved.
-    Licensed under the MIT License.
-#>
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
 
 function Get-ClrieXmlEntries {
     [CmdletBinding()]

--- a/docs/test.md
+++ b/docs/test.md
@@ -1,5 +1,11 @@
 # Testing the CLR Instrumentation Engine.
 
+## Testing locally
+
+### Windows
+
+The [WindowsLocalTest.ps1](../src/Scripts/WindowsLocalTest.ps1) script requires installing the ClrInstrumentationEngine msi or msm and launches a user-specified application (or another PowerShell process) with the COR_PROFILER environment variables set. The script takes switch parameters to configure several environment variables (like DebugWait) as well as one InstrumentationMethod config path and RawProfilerHook Guid and path.
+
 ## Running unit tests locally
 
 ### Windows

--- a/src/Scripts/WindowsLocalTest.ps1
+++ b/src/Scripts/WindowsLocalTest.ps1
@@ -29,6 +29,9 @@
 .PARAMETER DebugWait
     Optional, sets MicrosoftInstrumentationEngine_DebugWait which causes the ClrInstrumentationEngine to wait for a debugger to attach.
 
+.PARAMETER DisableSignatureValidation
+    Optional, sets MicrosoftInstrumentationEngine_DisableCodeSignatureValidation which allows CLRIE to use unsigned Instrumentation Methods.
+
 .PARAMETER ProxyUseDebug
     Optional, forces the CLRIE ProfilerProxy to look at CLRIE versions with "_Debug" suffix.
 
@@ -81,52 +84,107 @@ param(
     $ProxyUsePreview
 )
 
-# COR_PROFILER variables
-$env:COR_ENABLE_PROFILING = 1
-$env:COR_PROFILER = "{324F817A-7420-4E6D-B3C1-143FBED6D855}"
-$env:COR_PROFILER_PATH_32 = "C:\Program Files (x86)\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x86.dll"
-$env:COR_PROFILER_PATH_64 = "C:\Program Files\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x64.dll"
-$env:CORECLR_ENABLE_PROFILING = 1
-$env:CORECLR_PROFILER = "{324F817A-7420-4E6D-B3C1-143FBED6D855}"
-$env:CORECLR_PROFILER_PATH_32 = "C:\Program Files (x86)\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x86.dll"
-$env:CORECLR_PROFILER_PATH_64 = "C:\Program Files\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x64.dll"
-
-# CLRIE variables
-if ($DebugWait) {
-    $env:MicrosoftInstrumentationEngine_DebugWait = 1
-} else {
-    $env:MicrosoftInstrumentationEngine_DebugWait = 0
-}
-
-if ($DisableSignatureValidation) {
-    $env:MicrosoftInstrumentationEngine_DisableCodeSignatureValidation = 1
-} else {
-    $env:MicrosoftInstrumentationEngine_DisableCodeSignatureValidation = 0
-}
-
-# ProfilerProxy variables
-if ($ProxyUseDebug) {
-    $env:InstrumentationEngineProxy_UseDebug = 1
-} else {
-    $env:InstrumentationEngineProxy_UseDebug = 0
-}
-
-if ($ProxyUsePreview) {
-    $env:InstrumentationEngineProxy_UsePreview = 1
-} else {
-    $env:InstrumentationEngineProxy_UsePreview = 0
-}
-
-# Instrumentation Method variables
-if ($PSCmdlet.ParameterSetName -ieq 'InstrumentationMethod') {
-    $env:MicrosoftInstrumentationEngine_ConfigPath32_TestMethod = $InstrumentationMethodConfigPath
-    $env:MicrosoftInstrumentationEngine_ConfigPath64_TestMethod = $InstrumentationMethodConfigPath
-}
-
-if ($PSCmdlet.ParameterSetName -ieq 'InstrumentationMethod' -or $PSCmdlet.ParameterSetName -ieq 'RawProfilerHook') {
-    $env:MicrosoftInstrumentationEngine_RawProfilerHook = $RawProfilerHookGuid
-    $env:MicrosoftInstrumentationEngine_RawProfilerHookPath_32 = $RawProfilerHookPath
-    $env:MicrosoftInstrumentationEngine_RawProfilerHookPath_64 = $RawProfilerHookPath
+# CLRIE configuration variables
+@(
+    # COR_PROFILER
+    @{
+        name   = 'COR_ENABLE_PROFILING'
+        value  = 1
+        enable = $true
+    }
+    @{
+        name   = 'COR_PROFILER'
+        value  = '{324F817A-7420-4E6D-B3C1-143FBED6D855}'
+        enable = $true
+    }
+    @{
+        name   = 'COR_PROFILER_PATH_32'
+        value  = "${env:ProgramFiles(x86)}\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x86.dll"
+        enable = $true
+    }
+    @{
+        name   = 'COR_PROFILER_PATH_64'
+        value  = "$env:ProgramFiles\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x64.dll"
+        enable = $true
+    }
+    @{
+        name   = 'CORECLR_ENABLE_PROFILING'
+        value  = 1
+        enable = $true
+    }
+    @{
+        name   = 'CORECLR_PROFILER'
+        value  = '{324F817A-7420-4E6D-B3C1-143FBED6D855}'
+        enable = $true
+    }
+    @{
+        name   = 'CORECLR_PROFILER_PATH_32'
+        value  = "${env:ProgramFiles(x86)}\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x86.dll"
+        enable = $true
+    }
+    @{
+        name   = 'CORECLR_PROFILER_PATH_64'
+        value  = "$env:ProgramFiles\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x64.dll"
+        enable = $true
+    }
+    # CLRIE-specifie
+    @{
+        name   = "MicrosoftInstrumentationEngine_DebugWait"
+        value  = 1
+        enable = $DebugWait
+    }
+    @{
+        name   = 'MicrosoftInstrumentationEngine_DisableCodeSignatureValidation'
+        value  = 1
+        enable = $DisableSignatureValidation
+    }
+    # Proxy-specific
+    @{
+        name   = 'InstrumentationEngineProxy_UseDebug'
+        value  = 1
+        enable = $ProxyUseDebug
+    }
+    @{
+        name   = 'InstrumentationEngineProxy_UsePreview'
+        value  = 1
+        enable = $ProxyUsePreview
+    }
+    # Instrumentation Method
+    @{
+        name   = 'MicrosoftInstrumentationEngine_ConfigPath32_TestMethod'
+        value  = $InstrumentationMethodConfigPath
+        enable = ($PSCmdlet.ParameterSetName -ieq 'InstrumentationMethod')
+    }
+    @{
+        name   = 'MicrosoftInstrumentationEngine_ConfigPath64_TestMethod'
+        value  = $InstrumentationMethodConfigPath
+        enable = ($PSCmdlet.ParameterSetName -ieq 'InstrumentationMethod')
+    }
+    # Raw Profiler Hook
+    @{
+        name   = 'MicrosoftInstrumentationEngine_RawProfilerHook'
+        value  = $RawProfilerHookGuid
+        enable = ($PSCmdlet.ParameterSetName -ieq 'InstrumentationMethod' -or $PSCmdlet.ParameterSetName -ieq 'RawProfilerHook')
+    }
+    @{
+        name   = 'MicrosoftInstrumentationEngine_RawProfilerHookPath_32'
+        value  = $RawProfilerHookPath
+        enable = ($PSCmdlet.ParameterSetName -ieq 'InstrumentationMethod' -or $PSCmdlet.ParameterSetName -ieq 'RawProfilerHook')
+    }
+    @{
+        name   = 'MicrosoftInstrumentationEngine_RawProfilerHookPath_64'
+        value  = $RawProfilerHookPath
+        enable = ($PSCmdlet.ParameterSetName -ieq 'InstrumentationMethod' -or $PSCmdlet.ParameterSetName -ieq 'RawProfilerHook')
+    }
+) | ForEach-Object {
+    $envVarPath = "Env:\$($_.name)"
+    if ($_.enable) {
+        Write-Verbose "Set $($_.name) = $($_.value)"
+        New-Item -Path $envVarPath -Value $_.value -Force | Out-Null
+    } elseif (Test-Path $envVarPath) {
+        Write-Verbose "Removed $($_.name)"
+        Remove-Item -Path $envVarPath
+    }
 }
 
 Start-Process $ApplicationPath

--- a/src/Scripts/WindowsLocalTest.ps1
+++ b/src/Scripts/WindowsLocalTest.ps1
@@ -127,7 +127,7 @@ param(
         value  = "$env:ProgramFiles\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x64.dll"
         enable = $true
     }
-    # CLRIE-specifie
+    # CLRIE-specific
     @{
         name   = "MicrosoftInstrumentationEngine_DebugWait"
         value  = 1

--- a/src/Scripts/WindowsLocalTest.ps1
+++ b/src/Scripts/WindowsLocalTest.ps1
@@ -1,3 +1,6 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
 <#
 .SYNOPSIS
     This script spawns a process with the COR_PROFILER environment variables set. This script assumes the ClrInstrumentationEngine msi is installed.

--- a/src/Scripts/WindowsLocalTest.ps1
+++ b/src/Scripts/WindowsLocalTest.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    This script spawns a process with the COR_PROFILER environment variables set. This script assumes the ClrInstrumentationEngine msi is installed.
+
+.PARAMETER ApplicationPath
+    Optiona, the application to run with the profiler set. By default, will spawn another PowerShell process.
+
+.PARAMETER DebugWait
+    Optional, sets MicrosoftInstrumentationEngine_DebugWait which causes the ClrInstrumentationEngine to wait for a debugger to attach.
+
+.PARAMETER ProxyUseDebug
+    Optional, forces the CLRIE ProfilerProxy to look at CLRIE versions with "_Debug" suffix.
+
+.PARAMETER ProxyUsePreview
+    Optional, allows the CLRIE ProfilerProxy to look at both release and preview (with "-build#####" suffix) versions.
+#>
+
+[CmdletBinding(DefaultParameterSetName='None')]
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [ValidateScript({ Test-Path $_ })]
+    [string]
+    $ApplicationPath = 'powershell',
+
+    [Parameter(Mandatory = $false)]
+    [Parameter(ParameterSetName='InstrumentationMethod', Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $InstrumentationMethod64ConfigPath,
+
+    [Parameter(Mandatory = $false)]
+    [Parameter(ParameterSetName='InstrumentationMethod', Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]
+    $InstrumentationMethod32ConfigPath,
+
+    [Parameter(Mandatory = $false)]
+    [switch]
+    $DebugWait,
+
+    [Parameter(Mandatory = $false)]
+    [switch]
+    $DisableSignatureValidation,
+
+    [Parameter(Mandatory = $false)]
+    [switch]
+    $ProxyUseDebug,
+
+    [Parameter(Mandatory = $false)]
+    [switch]
+    $ProxyUsePreview
+)
+
+# COR_PROFILER variables
+$env:COR_ENABLE_PROFILING = 1
+$env:COR_PROFILER = "{324F817A-7420-4E6D-B3C1-143FBED6D855}"
+$env:COR_PROFILER_PATH_32 = "C:\Program Files (x86)\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x86.dll"
+$env:COR_PROFILER_PATH_64 = "C:\Program Files\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x64.dll"
+$env:CORECLR_ENABLE_PROFILING = 1
+$env:CORECLR_PROFILER = "{324F817A-7420-4E6D-B3C1-143FBED6D855}"
+$env:CORECLR_PROFILER_PATH_32 = "C:\Program Files (x86)\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x86.dll"
+$env:CORECLR_PROFILER_PATH_64 = "C:\Program Files\Microsoft CLR Instrumentation Engine\Proxy\v1\InstrumentationEngine.ProfilerProxy_x64.dll"
+
+# CLRIE variables
+if ($DebugWait) {
+    $env:MicrosoftInstrumentationEngine_DebugWait = 1
+} else {
+    $env:MicrosoftInstrumentationEngine_DebugWait = 0
+}
+
+if ($DisableSignatureValidation) {
+    $env:MicrosoftInstrumentationEngine_DisableCodeSignatureValidation = 1
+} else {
+    $env:MicrosoftInstrumentationEngine_DisableCodeSignatureValidation = 0
+}
+
+# ProfilerProxy variables
+if ($ProxyUseDebug) {
+    $env:InstrumentationEngineProxy_UseDebug = 1
+} else {
+    $env:InstrumentationEngineProxy_UseDebug = 0
+}
+
+if ($ProxyUsePreview) {
+    $env:InstrumentationEngineProxy_UsePreview = 1
+} else {
+    $env:InstrumentationEngineProxy_UsePreview = 0
+}
+
+# Instrumentation Method variables
+if ($PSCmdlet.ParameterSetName -ieq 'InstrumentationMethod') {
+    $env:MicrosoftInstrumentationEngine_ConfigPath32_TestMethod = $InstrumentationMethod32ConfigPath
+    $env:MicrosoftInstrumentationEngine_ConfigPath64_TestMethod = $InstrumentationMethod64ConfigPath
+}
+
+Start-Process $ApplicationPath

--- a/verifyCopyrightHeaders.ps1
+++ b/verifyCopyrightHeaders.ps1
@@ -18,6 +18,7 @@ $excludedDirs =  @(
     'obj'
     'package'
     'Release'
+    'out'
 
     # external
     'atl'
@@ -50,12 +51,17 @@ $excludedFiles = @(
     'extension.xml'
 
     # generated
+    'ExtensionsHost_i.c'
+    'ExtensionsHost_i.h'
+    'ExtensionsHost_p.c'
     'HostExtension_i.c'
     'HostExtension_i.h'
     'InstrumentationEngine.h'
     'InstrumentationEngine_api.cpp'
     'RawProfilerHook_i.c'
     'RawProfilerHook_i.h'
+    'dlldata.c'
+    'build.sem'
 
     # the license itself
     'LICENSE'


### PR DESCRIPTION
This PS script assumes the ClrInstrumentationEngine MSI is installed. It launches a user-specified application (or PowerShell if none specified) with the COR_PROFILER variables as well as any configuration variable set for testing purposes.