### PR TITLE
Fix target folder for CodeSignVerify and add exclusion list

### DIFF
--- a/build/CodeSign/certificate.ignore
+++ b/build/CodeSign/certificate.ignore
@@ -1,8 +1,18 @@
-obj\*,Ignore Intermediates
-bin\*\baselines\*.xml,Ignore Test artifacts
-bin\*\testscripts\*.xml,Ignore Test artifacts
-bin\*\intercept.2.0.1.tests\*, Ignore Test folder
-bin\*\intercept.latest.tests\*, Ignore Test folder
-bin\*\rawprofilerhook.tests\*, Ignore Test folder
-bin\*\*tests*.dll, Ignore Test assemblies
-bin\*\naglerinstrumentationmethod*, Ignore Nagler Test Method
+obj\*, Ignore Intermediates
+
+bin\*\instrumentationengine.lib.tests.dll, Ignore test assembly
+bin\*\instrumentationengine.profilerproxy.tests.dll, Ignore test assembly
+bin\*\instrenginetests_anycpu.dll, Ignore test assembly
+
+bin\*\naglerinstrumentationmethod*, Ignore naglerInstrumentationMethod
+bin\*\*.xml, Ignore xml files
+
+bin\*\intercept.2.0.1.tests\*, Ignore test folder
+bin\*\intercept.latest.tests\*, Ignore test folder
+bin\*\rawprofilerhook.tests\*, Ignore test folder
+
+bin\*\*.wixlib, Ignore wix artifact
+bin\*\*.wixpdb, Ignore wix artifact
+bin\*\*.msidir\*.cab, Ignore embedded cab files
+
+binaries-windows-release\*, Ignore downloaded binary artifacts

--- a/build/CodeSign/certificate.ignore
+++ b/build/CodeSign/certificate.ignore
@@ -1,5 +1,8 @@
 obj\*,Ignore Intermediates
 bin\*\baselines\*.xml,Ignore Test artifacts
+bin\*\testscripts\*.xml,Ignore Test artifacts
 bin\*\intercept.2.0.1.tests\*, Ignore Test folder
 bin\*\intercept.latest.tests\*, Ignore Test folder
-bin\*\*.tests*.dll, Ignore Test assemblies
+bin\*\rawprofilerhook.tests\*, Ignore Test folder
+bin\*\*tests*.dll, Ignore Test assemblies
+bin\*\naglerinstrumentationmethod*, Ignore Nagler Test Method

--- a/build/CodeSign/strongname.ignore
+++ b/build/CodeSign/strongname.ignore
@@ -1,1 +1,3 @@
 obj\*,Ignore Intermediates
+bin\*\intercept.2.0.1.tests\*, Ignore Test folder
+bin\*\intercept.latest.tests\*, Ignore Test folder

--- a/build/CodeSign/strongname.ignore
+++ b/build/CodeSign/strongname.ignore
@@ -1,3 +1,5 @@
 obj\*,Ignore Intermediates
 bin\*\intercept.2.0.1.tests\*, Ignore Test folder
 bin\*\intercept.latest.tests\*, Ignore Test folder
+bin\*\rawprofilerhook.tests\*, Ignore Test folder
+bin\*\*tests*.dll, Ignore Test assemblies

--- a/build/CodeSign/strongname.ignore
+++ b/build/CodeSign/strongname.ignore
@@ -1,5 +1,6 @@
-obj\*,Ignore Intermediates
-bin\*\intercept.2.0.1.tests\*, Ignore Test folder
-bin\*\intercept.latest.tests\*, Ignore Test folder
-bin\*\rawprofilerhook.tests\*, Ignore Test folder
-bin\*\*tests*.dll, Ignore Test assemblies
+obj\*, Ignore Intermediates
+
+bin\*\instrenginetests_anycpu.dll, Ignore test assembly
+bin\*\intercept.2.0.1.tests\*, Ignore test folder
+bin\*\intercept.latest.tests\*, Ignore test folder
+bin\*\rawprofilerhook.tests\*, Ignore test folder

--- a/build/yaml/steps/microbuild/codesignverify.yaml
+++ b/build/yaml/steps/microbuild/codesignverify.yaml
@@ -15,6 +15,6 @@ steps:
   displayName: Verify Signed Files
   condition: and(succeeded(), in(variables['SignType'], 'Real', 'Test'))
   inputs:
-    TargetFolder: $(Build.BinariesDirectory)
+    TargetFolder: $(Build.StagingDirectory)
     WhiteListPathForCerts: 'build\CodeSign\certificate.ignore'
     WhiteListPathForSigs: 'build\CodeSign\strongname.ignore'


### PR DESCRIPTION
The most important exclusion is embedded Cab files (which are generated when the installer consumes a merge module).  

According to https://docs.microsoft.com/windows/win32/msi/digital-signatures-and-windows-installer:

_With Windows Installer, digital signatures can be used with Windows Installer packages, transforms, patches, merge modules, and external cabinet files._

And https://www.advancedinstaller.com/user-guide/msm-digital-signature.html

_Advanced Installer can digitally sign all of the following files that it creates: EXE, MSI, MSP (patches) and CAB files. The EXE, MSI and MSP files are always signed while the CAB files are signed only if they are not embedded in the MSI._

Considering both the outer MSI and the internal files are signed, we felt excluding the embedded cab from being sign-verified was reasonable.