### PR TITLE
Initial attach executable

### DIFF
--- a/InstrumentationEngine.sln
+++ b/InstrumentationEngine.sln
@@ -65,6 +65,8 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "InstrumentationEngine.Profi
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "InstrumentationEngine.ProfilerProxy.Lib", "src\InstrumentationEngine.ProfilerProxy.Lib\InstrumentationEngine.ProfilerProxy.Lib.vcxproj", "{DAB53F24-D55A-4759-B100-5B7FEFBF6D08}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InstrumentationEngine.Attach", "src\InstrumentationEngine.Attach\InstrumentationEngine.Attach.csproj", "{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{c1aaa703-5e32-45c0-a69d-f46d1c659ae4}*SharedItemsImports = 13
@@ -300,6 +302,14 @@ Global
 		{DAB53F24-D55A-4759-B100-5B7FEFBF6D08}.Release|x64.Build.0 = Release|x64
 		{DAB53F24-D55A-4759-B100-5B7FEFBF6D08}.Release|x86.ActiveCfg = Release|Win32
 		{DAB53F24-D55A-4759-B100-5B7FEFBF6D08}.Release|x86.Build.0 = Release|Win32
+		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Release|x64.ActiveCfg = Release|Any CPU
+		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Release|x86.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/InstrumentationEngine.Attach/InstrumentationEngine.Attach.csproj
+++ b/src/InstrumentationEngine.Attach/InstrumentationEngine.Attach.csproj
@@ -7,7 +7,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
-    <AssemblyName>attach</AssemblyName>
+    <AssemblyName>Microsoft.InstrumentationEngine.Attach</AssemblyName>
     <RootNamespace>Microsoft.InstrumentationEngine</RootNamespace>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>

--- a/src/InstrumentationEngine.Attach/InstrumentationEngine.Attach.csproj
+++ b/src/InstrumentationEngine.Attach/InstrumentationEngine.Attach.csproj
@@ -1,0 +1,22 @@
+﻿<Project>
+  <PropertyGroup>
+    <SubComponent>Tools\Attach</SubComponent>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'EnlistmentRoot.marker'))\build\Managed.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <AssemblyName>attach</AssemblyName>
+    <RootNamespace>Microsoft.InstrumentationEngine</RootNamespace>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Nullable>Enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Diagnostics.NETCore.Client" Version="0.2.61701" />
+    <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(MicroBuildCoreVersion)" />
+  </ItemGroup>
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="$(EnlistmentRoot)\build\Managed.targets" />
+</Project>

--- a/src/InstrumentationEngine.Attach/NativeMethods.cs
+++ b/src/InstrumentationEngine.Attach/NativeMethods.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Microsoft.InstrumentationEngine
+{
+    internal static class NativeMethods
+    {
+        [DllImport("kernel32.dll", SetLastError = true)]
+        [return: MarshalAs(UnmanagedType.Bool)]
+        public static extern bool IsWow64Process([In] IntPtr hProcess, [Out] out bool wow64Process);
+    }
+}

--- a/src/InstrumentationEngine.Attach/Program.cs
+++ b/src/InstrumentationEngine.Attach/Program.cs
@@ -19,6 +19,13 @@ namespace Microsoft.InstrumentationEngine
         private const int ExitCodeSuccess = 0;
         private const int ExitCodeFailure = -1;
 
+        private const string Instrumentation32FolderName = "Instrumentation32";
+        private const string Instrumentation64FolderName = "Instrumentation64";
+
+        private const string InstrumentationEngineX64LinuxName = "libInstrumentationEngine.so";
+        private const string InstrumentationEngineX64WindowsName = "MicrosoftInstrumentationEngine_x64.dll";
+        private const string InstrumentationEngineX86WindowsName = "MicrosoftInstrumentationEngine_x86.dll";
+
         internal static int Main(string[] args)
         {
             // TODO: Parse command line for additional arguments such as configuration files
@@ -110,13 +117,17 @@ namespace Microsoft.InstrumentationEngine
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
             {
                 enginePath = isTargetProcess32Bit ?
-                    Path.Combine(rootDirectory, "Instrumentation32", "MicrosoftInstrumentationEngine_x86.dll") :
-                    Path.Combine(rootDirectory, "Instrumentation64", "MicrosoftInstrumentationEngine_x64.dll");
+                    Path.Combine(rootDirectory, Instrumentation32FolderName, InstrumentationEngineX86WindowsName) :
+                    Path.Combine(rootDirectory, Instrumentation64FolderName, InstrumentationEngineX64WindowsName);
+            }
+            else if (!isTargetProcess32Bit)
+            {
+                enginePath = Path.Combine(rootDirectory, Instrumentation64FolderName, InstrumentationEngineX64LinuxName);
             }
             else
             {
-                Debug.Assert(!isTargetProcess32Bit, "Only 64 bit is supported on non-Windows platforms.");
-                enginePath = Path.Combine(rootDirectory, "Instrumentation64", "libInstrumentationEngine.so");
+                WriteError("Only the 64 bit engine is supported on non-Windows platforms.");
+                return ExitCodeFailure;
             }
 
             if (!File.Exists(enginePath))

--- a/src/InstrumentationEngine.Attach/Program.cs
+++ b/src/InstrumentationEngine.Attach/Program.cs
@@ -7,8 +7,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using System.Runtime.InteropServices;
-using System.Text;
-using System.Text.Json;
 using Microsoft.Diagnostics.NETCore.Client;
 using static System.FormattableString;
 

--- a/src/InstrumentationEngine.Attach/Program.cs
+++ b/src/InstrumentationEngine.Attach/Program.cs
@@ -1,0 +1,170 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.IO;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+using Microsoft.Diagnostics.NETCore.Client;
+using static System.FormattableString;
+
+namespace Microsoft.InstrumentationEngine
+{
+    internal sealed class Program
+    {
+        private static readonly Guid InstrumentationEngineClsid = new Guid("324F817A-7420-4E6D-B3C1-143FBED6D855");
+
+        internal static void Main(string[] args)
+        {
+            // TODO: Parse command line for additional arguments such as configuration files
+            if (args.Length != 1)
+            {
+                WriteErrorJson("Expected single argument that represents the process ID to which the engine shall be attached.");
+                return;
+            }
+
+            string processIdString = args[0];
+
+            if (!Int32.TryParse(processIdString, out int processId))
+            {
+                WriteErrorJson(Invariant($"Could not parse process ID argument '{processIdString}' to integer."));
+                return;
+            }
+
+            Process process;
+            try
+            {
+                process = Process.GetProcessById(processId);
+            }
+            catch (Exception ex)
+            {
+                WriteErrorJson(ex.Message);
+                return;
+            }
+
+            // This executable should be in the [Root]\Tools\Attach directory. Get the root directory
+            // and build back to the instrumentation engine file path.
+
+            // CONSIDER: Is there a better way to get the engine path instead of building the path
+            // relative to the current executable? For example, requiring the root path of the engine
+            // to be passed as a parameter (which increases the difficulty of using this executable).
+
+            string? attachDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            if (null == attachDirectory || !Directory.Exists(attachDirectory))
+            {
+                WriteErrorJson(Invariant($"Directory '{attachDirectory}' does not exist."));
+                return;
+            }
+
+            string? toolsDirectory = Path.GetDirectoryName(attachDirectory);
+            if (null == toolsDirectory || !Directory.Exists(toolsDirectory))
+            {
+                WriteErrorJson(Invariant($"Directory '{toolsDirectory}' does not exist."));
+                return;
+            }
+
+            string? rootDirectory = Path.GetDirectoryName(toolsDirectory);
+            if (null == rootDirectory || !Directory.Exists(rootDirectory))
+            {
+                WriteErrorJson(Invariant($"Directory '{rootDirectory}' does not exist."));
+                return;
+            }
+
+            string enginePath;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                enginePath = Path.Combine(rootDirectory, "Instrumentation64", "libInstrumentationEngine.so");
+            }
+            else
+            {
+                bool isWow64;
+                try
+                {
+                    // isWow64 is true for 32-bit applications running on a 64-bit OS
+                    if (!NativeMethods.IsWow64Process(process.Handle, out isWow64))
+                    {
+                        Exception? ex = Marshal.GetExceptionForHR(Marshal.GetHRForLastWin32Error());
+                        if (null != ex)
+                        {
+                            WriteErrorJson(Invariant($"Failed to check process bitness: {ex.Message}"));
+                        }
+                        else
+                        {
+                            WriteErrorJson(Invariant($"Failed to check process bitness."));
+                        }
+                    }
+                }
+                catch (Win32Exception ex)
+                {
+                    WriteErrorJson(Invariant($"Failed to check process bitness (code: {ex.NativeErrorCode}): {ex.Message}"));
+                    return;
+                }
+
+                enginePath = isWow64 ?
+                    Path.Combine(rootDirectory, "Instrumentation32", "MicrosoftInstrumentationEngine_x86.dll") :
+                    Path.Combine(rootDirectory, "Instrumentation64", "MicrosoftInstrumentationEngine_x64.dll");
+            }
+
+            if (!File.Exists(enginePath))
+            {
+                WriteErrorJson(Invariant($"Engine path '{enginePath}' does not exist."));
+                return;
+            }
+
+            // CONSIDER: Should the engine be validated before attempting to attach it to the CLR?
+            // For example, could check the signature on the assembly (which wouldn't work on Linux).
+
+            DiagnosticsClient client = new DiagnosticsClient(processId);
+            try
+            {
+                client.AttachProfiler(TimeSpan.FromSeconds(10), InstrumentationEngineClsid, enginePath);
+            }
+            catch (ServerErrorException ex)
+            {
+                WriteErrorJson(Invariant($"Could not attach engine to process: '{ex.Message}'."));
+                return;
+            }
+
+            WriteSuccessJson();
+        }
+
+        private static void WriteErrorJson(string message)
+        {
+            Console.WriteLine(CreateResultJson("Failed", message));
+        }
+
+        private static void WriteSuccessJson()
+        {
+            Console.WriteLine(CreateResultJson("Success"));
+        }
+
+        private static string CreateResultJson(string result, string? message = null)
+        {
+            if (string.IsNullOrEmpty(result))
+            {
+                throw new ArgumentNullException(nameof(result));
+            }
+
+            string content;
+            using (var stream = new MemoryStream())
+            using (var writer = new Utf8JsonWriter(stream))
+            {
+                writer.WriteStartObject();
+                writer.WriteString("Result", result);
+                if (!string.IsNullOrWhiteSpace(message))
+                {
+                    writer.WriteString("Message", message);
+                }
+                writer.WriteEndObject();
+                writer.Flush();
+
+                content = Encoding.UTF8.GetString(stream.ToArray());
+            }
+            return content;
+        }
+    }
+}

--- a/src/InstrumentationEngine.Preinstall/InstrumentationEngine.Preinstall.csproj
+++ b/src/InstrumentationEngine.Preinstall/InstrumentationEngine.Preinstall.csproj
@@ -45,30 +45,35 @@
       <ZipItem Include="scmApplicationHost.xdt">
         <Destination>$(PackageVersion)</Destination>
       </ZipItem>
+      <!-- Tools -->
+      <ZipItem Include="$(InputBinCfgRoot)\AnyCPU\Tools\Attach\*"
+               Exclude="$(InputBinCfgRoot)\AnyCPU\Tools\Attach\*.pdb">
+        <Destination>$(PackageVersion)\Tools\Attach</Destination>
+      </ZipItem>
       <!-- Instrumentationx86Files -->
-      <ZipItem Include="$(InputBinCfgRoot)\x86\**\MicrosoftInstrumentationEngine_x86.dll">
+      <ZipItem Include="$(InputBinCfgRoot)\x86\MicrosoftInstrumentationEngine_x86.dll">
         <Destination>$(PackageVersion)\Instrumentation32</Destination>
       </ZipItem>
-      <ZipItem Include="$(InputBinCfgRoot)\x86\**\Microsoft.InstrumentationEngine.Extensions.Base_x86.dll">
+      <ZipItem Include="$(InputBinCfgRoot)\x86\Microsoft.InstrumentationEngine.Extensions.Base_x86.dll">
         <Destination>$(PackageVersion)\Instrumentation32\base</Destination>
       </ZipItem>
-      <ZipItem Include="$(InputBinCfgRoot)\x86\**\Microsoft.InstrumentationEngine.Extensions.config">
+      <ZipItem Include="$(InputBinCfgRoot)\x86\Microsoft.InstrumentationEngine.Extensions.config">
         <Destination>$(PackageVersion)\Instrumentation32\base</Destination>
       </ZipItem>
-      <ZipItem Include="$(InputBinCfgRoot)\AnyCPU\**\Microsoft.Diagnostics.Instrumentation.Extensions.Base.dll">
+      <ZipItem Include="$(InputBinCfgRoot)\AnyCPU\Microsoft.Diagnostics.Instrumentation.Extensions.Base.dll">
         <Destination>$(PackageVersion)\Instrumentation32\base</Destination>
       </ZipItem>
       <!-- Instrumentationx64Files -->
-      <ZipItem Include="$(InputBinCfgRoot)\x64\**\MicrosoftInstrumentationEngine_x64.dll">
+      <ZipItem Include="$(InputBinCfgRoot)\x64\MicrosoftInstrumentationEngine_x64.dll">
         <Destination>$(PackageVersion)\Instrumentation64</Destination>
       </ZipItem>
-      <ZipItem Include="$(InputBinCfgRoot)\x64\**\Microsoft.InstrumentationEngine.Extensions.Base_x64.dll">
+      <ZipItem Include="$(InputBinCfgRoot)\x64\Microsoft.InstrumentationEngine.Extensions.Base_x64.dll">
         <Destination>$(PackageVersion)\Instrumentation64\base</Destination>
       </ZipItem>
-      <ZipItem Include="$(InputBinCfgRoot)\x64\**\Microsoft.InstrumentationEngine.Extensions.config">
+      <ZipItem Include="$(InputBinCfgRoot)\x64\Microsoft.InstrumentationEngine.Extensions.config">
         <Destination>$(PackageVersion)\Instrumentation64\base</Destination>
       </ZipItem>
-      <ZipItem Include="$(InputBinCfgRoot)\AnyCPU\**\Microsoft.Diagnostics.Instrumentation.Extensions.Base.dll">
+      <ZipItem Include="$(InputBinCfgRoot)\AnyCPU\Microsoft.Diagnostics.Instrumentation.Extensions.Base.dll">
         <Destination>$(PackageVersion)\Instrumentation64\base</Destination>
       </ZipItem>
     </ItemGroup>


### PR DESCRIPTION
Create a .NET Core 3.1 executable that simplifies the attach process for the Instrumentation Engine. It currently only takes the process ID to which it should attach the engine. It reports errors to standard error and returns a non-zero exit code on error. Success will return zero.