### PR TITLE
Support configuration parsing for Profiler Attach

### DIFF
--- a/src/Common.Lib/Macros.h
+++ b/src/Common.Lib/Macros.h
@@ -22,6 +22,12 @@
 #define __FUNCTIONT__
 #endif
 
+    // Log an error without returning.
+#ifndef IfFailLogNoRet
+#define IfFailLogNoRet(EXPR) \
+    do { if (FAILED(hr = (EXPR))) { CLogging::LogError(_T("IfFailLogNoRet(") _T(#EXPR) _T(") failed in function ") __FUNCTIONT__ _T(": %d"), hr); } } while (false)
+#endif
+
 #ifndef IfFailRet
 #define IfFailRet(EXPR) \
     do { if (FAILED(hr = (EXPR))) { CLogging::LogError(_T("IfFailRet(") _T(#EXPR) _T(") failed in function ") __FUNCTIONT__); return hr; } } while (false)
@@ -41,6 +47,11 @@
 #ifndef IfFailRetNoLog
 #define IfFailRetNoLog(EXPR) \
     do { if (FAILED(hr = (EXPR))) { return hr; } } while (false)
+#endif
+
+#ifndef IfFalseFail
+#define IfFalseFail(EXPR) \
+    do { if (!(EXPR)) { CLogging::LogError(_T("IfFalseFail(") _T(#EXPR) _T(") failed in function ") __FUNCTIONT__); return E_FAIL; } } while (false)
 #endif
 
 // Treats errno 0 as severity=SUCCESS others to severity=ERROR, sets facility to null, and code to 16 least-significant bits of errno.

--- a/src/Common.Lib/Macros.h
+++ b/src/Common.Lib/Macros.h
@@ -23,19 +23,14 @@
 #endif
 
     // Log an error without returning.
-#ifndef IfFailLogNoRet
-#define IfFailLogNoRet(EXPR) \
-    do { if (FAILED(hr = (EXPR))) { CLogging::LogError(_T("IfFailLogNoRet(") _T(#EXPR) _T(") failed in function ") __FUNCTIONT__ _T(": %d"), hr); } } while (false)
+#ifndef IfFailLog
+#define IfFailLog(EXPR) \
+    do { if (FAILED(hr = (EXPR))) { CLogging::LogError(_T("IfFailLog(") _T(#EXPR) _T(") failed in function ") __FUNCTIONT__ _T(": %d"), hr); } } while (false)
 #endif
 
 #ifndef IfFailRet
 #define IfFailRet(EXPR) \
     do { if (FAILED(hr = (EXPR))) { CLogging::LogError(_T("IfFailRet(") _T(#EXPR) _T(") failed in function ") __FUNCTIONT__); return hr; } } while (false)
-#endif
-
-#ifndef IfFailRetNoLog
-#define IfFailRetNoLog(EXPR) \
-    do { if (FAILED(hr = (EXPR))) { return hr; } } while (false)
 #endif
 
 // Wrap errno_t result of EXPR in HRESULT and then IfFailRet.
@@ -47,11 +42,6 @@
 #ifndef IfFailRetNoLog
 #define IfFailRetNoLog(EXPR) \
     do { if (FAILED(hr = (EXPR))) { return hr; } } while (false)
-#endif
-
-#ifndef IfFalseFail
-#define IfFalseFail(EXPR) \
-    do { if (!(EXPR)) { CLogging::LogError(_T("IfFalseFail(") _T(#EXPR) _T(") failed in function ") __FUNCTIONT__); return E_FAIL; } } while (false)
 #endif
 
 // Treats errno 0 as severity=SUCCESS others to severity=ERROR, sets facility to null, and code to 16 least-significant bits of errno.

--- a/src/InstrumentationEngine.Lib/CMakeLists.txt
+++ b/src/InstrumentationEngine.Lib/CMakeLists.txt
@@ -16,6 +16,7 @@ set(src_files
     ./ConfigurationLocator.cpp
     ./ConfigurationSource.cpp
     ./DataContainer.cpp
+    ./Encoding.cpp
     ./FileLoggerSink.cpp
     ./HostLoggerSink.cpp
     ./ImplQueryInterface.cpp
@@ -25,6 +26,9 @@ set(src_files
     ./LoggerService.cpp
     ./Logging.cpp
     ./refcount.cpp
+    ./StringUtils.cpp
+    ./XmlDocWrapper.cpp
+    ./XmlNode.cpp
 )
 
 add_lib(${PROJECT_NAME}

--- a/src/InstrumentationEngine.Lib/ConfigurationLoader.cpp
+++ b/src/InstrumentationEngine.Lib/ConfigurationLoader.cpp
@@ -92,7 +92,7 @@ HRESULT CConfigurationLoaderHelper::LoadConfiguration(_In_ BSTR bstrConfigPath, 
         IfFailRet(ProcessInstrumentationMethodNode(wszConfigFolder, pCurrChildNode, methods));
     }
 
-	return hr;
+    return hr;
 }
 
 HRESULT CConfigurationLoaderHelper::ProcessInstrumentationMethodNode(_In_ BSTR bstrInstrumentationMethodFolder, _In_ IXMLDOMNode* pNode, _In_ std::vector<CInstrumentationMethod*>& methods)

--- a/src/InstrumentationEngine.Lib/Encoding.cpp
+++ b/src/InstrumentationEngine.Lib/Encoding.cpp
@@ -38,7 +38,7 @@ HRESULT CEncoding::ConvertUtf8ToUtf16(_In_ const char* utf8String, _Inout_ CAuto
 
     ++utf16BufLen;
     pUtf16String.Free();
-    IfFalseFail(pUtf16String.Allocate(utf16BufLen));
+    IfFalseRet(pUtf16String.Allocate(utf16BufLen), E_FAIL);
 
     if (pUtf16String == nullptr)
     {

--- a/src/InstrumentationEngine.Lib/Encoding.cpp
+++ b/src/InstrumentationEngine.Lib/Encoding.cpp
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "stdafx.h"
+#include "Encoding.h"
+#include "StringUtils.h"
+
+using namespace ATL;
+
+HRESULT CEncoding::ConvertUtf16ToUtf8(_In_ const WCHAR* utf16String, _Inout_ CAutoVectorPtr<char>& pUtf8String)
+{
+    HRESULT hr = S_OK;
+
+    CW2A cw2a(utf16String, CP_UTF8);
+    size_t utf8BufLen = 0;
+    IfFailRet(StringUtils::StringLen(cw2a, utf8BufLen));
+    ++utf8BufLen;
+
+    pUtf8String.Free();
+    pUtf8String.Allocate(utf8BufLen);
+
+    if (pUtf8String == nullptr)
+    {
+        return E_OUTOFMEMORY;
+    }
+    IfFailRetErrno(memcpy_s(pUtf8String, utf8BufLen * sizeof(char), static_cast<LPCSTR>(cw2a), utf8BufLen * sizeof(char)));
+
+    return S_OK;
+}
+
+HRESULT CEncoding::ConvertUtf8ToUtf16(_In_ const char* utf8String, _Inout_ CAutoVectorPtr<WCHAR>& pUtf16String)
+{
+    HRESULT hr = S_OK;
+
+    CA2W ca2w(utf8String, CP_UTF8);
+    size_t utf16BufLen = 0;
+    IfFailRet(StringUtils::WStringLen(ca2w, utf16BufLen));
+
+    ++utf16BufLen;
+    pUtf16String.Free();
+    IfFalseFail(pUtf16String.Allocate(utf16BufLen));
+
+    if (pUtf16String == nullptr)
+    {
+        return E_OUTOFMEMORY;
+    }
+
+    IfFailRetErrno(memcpy_s(pUtf16String, utf16BufLen * sizeof(WCHAR), static_cast<LPCWSTR>(ca2w), utf16BufLen * sizeof(WCHAR)));
+
+    return S_OK;
+}
+
+HRESULT CEncoding::ConvertUtf8ToUtf16Bstr(_In_ const char* utf8String, _Out_ BSTR* pUtf16String)
+{
+    HRESULT hr = S_OK;
+
+    CAutoVectorPtr<WCHAR> newStringBuffer;
+    IfFailRet(ConvertUtf8ToUtf16(utf8String, newStringBuffer));
+
+    CComBSTR bstrUtf16String = newStringBuffer.m_p; // Copy string.
+    *pUtf16String = bstrUtf16String.Detach(); // Detach so that string doesn't get cleaned up.
+
+    return S_OK;
+}

--- a/src/InstrumentationEngine.Lib/Encoding.h
+++ b/src/InstrumentationEngine.Lib/Encoding.h
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#pragma warning(push)
+#pragma warning(disable:4996) // ignore deprecated declaration.
+#include <atlbase.h>
+#pragma warning(pop)
+
+class CEncoding
+{
+public:
+    // Converts a utf-16 string to a utf-8 string allocating the resulting string
+    // with new. Callers must call delete[] on the utf8 string.
+    static HRESULT ConvertUtf16ToUtf8(_In_ const WCHAR* utf16String, _Inout_ ATL::CAutoVectorPtr<char>& pUtf8String);
+
+    // Converts a utf-8 string to a utf-16 string allocating the resulting string
+    // with new. Callers must call delete[] on the utf16 string.
+    static HRESULT ConvertUtf8ToUtf16(_In_ const char* utf8String, _Inout_ ATL::CAutoVectorPtr<WCHAR>& pUtf16String);
+
+    static HRESULT ConvertUtf8ToUtf16Bstr(_In_ const char* utf8String, _Out_ BSTR* pUtf16String);
+};

--- a/src/InstrumentationEngine.Lib/InstrumentationEngine.Lib.vcxproj
+++ b/src/InstrumentationEngine.Lib/InstrumentationEngine.Lib.vcxproj
@@ -96,6 +96,7 @@
     <ClInclude Include="ConfigurationLocator.h" />
     <ClInclude Include="ConfigurationSource.h" />
     <ClInclude Include="DataContainer.h" />
+    <ClInclude Include="Encoding.h" />
     <ClInclude Include="EnumeratorImpl.h" />
     <ClInclude Include="InstrumentationMethodAttachContext.h" />
     <ClInclude Include="InstrumentationMethodSetting.h" />
@@ -116,14 +117,18 @@
     <ClInclude Include="SharedArray.h" />
     <ClInclude Include="SignatureValidator.h" />
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="StringUtils.h" />
     <ClInclude Include="targetver.h" />
     <ClInclude Include="Util.h" />
+    <ClInclude Include="XmlDocWrapper.h" />
+    <ClInclude Include="XmlNode.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="ConfigurationLocator.cpp" />
     <ClCompile Include="ConfigurationSource.cpp" />
     <ClCompile Include="DataContainer.cpp" />
     <ClCompile Include="DebugLoggerSink.cpp" />
+    <ClCompile Include="Encoding.cpp" />
     <ClCompile Include="EventLoggerSink.cpp" />
     <ClCompile Include="ConfigurationLoader.cpp" />
     <ClCompile Include="ImplQueryInterface.cpp" />
@@ -141,6 +146,9 @@
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="StringUtils.cpp" />
+    <ClCompile Include="XmlDocWrapper.cpp" />
+    <ClCompile Include="XmlNode.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Common.Lib\Common.Lib.vcxproj">

--- a/src/InstrumentationEngine.Lib/StringUtils.cpp
+++ b/src/InstrumentationEngine.Lib/StringUtils.cpp
@@ -1,0 +1,47 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "stdafx.h"
+#include "StringUtils.h"
+
+#ifndef E_BOUNDS
+// Apparantly, Linux builds don't have E_BOUNDS defined.
+#define E_BOUNDS 0x8000000BL
+#endif
+
+// Somewhat arbitrary.
+const size_t StringUtils::MAX_STRING_LEN = 10000;
+
+HRESULT StringUtils::WStringLen(_In_ const WCHAR* wszString, _Out_ size_t& len)
+{
+    len = wcsnlen_s(wszString, MAX_STRING_LEN);
+
+    if (len >= MAX_STRING_LEN)
+    {
+        return E_BOUNDS;
+    }
+
+    return S_OK;
+}
+
+HRESULT StringUtils::StringLen(_In_ const char* szString, _Out_ size_t& len)
+{
+    len = strnlen(szString, MAX_STRING_LEN);
+
+    if (len >= MAX_STRING_LEN)
+    {
+        return E_BOUNDS;
+    }
+
+    return S_OK;
+}
+
+size_t StringUtils::WStringLen(_In_ const WCHAR* wszString)
+{
+    return wcsnlen_s(wszString, MAX_STRING_LEN);
+}
+
+size_t StringUtils::StringLen(_In_ const char* szString)
+{
+    return strnlen(szString, MAX_STRING_LEN);
+}

--- a/src/InstrumentationEngine.Lib/StringUtils.h
+++ b/src/InstrumentationEngine.Lib/StringUtils.h
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <string>
+
+#ifdef PLATFORM_UNIX
+using tstring = std::basic_string<WCHAR, std::char_traits<WCHAR>, std::allocator<WCHAR>>;
+using tstringstream = std::basic_stringstream<WCHAR>;
+using tistringstream = std::basic_istringstream<WCHAR>;
+#else
+using tstring = std::wstring;
+using tstringstream = std::wstringstream;
+using tistringstream = std::wistringstream;
+#endif
+using tofstream = std::basic_ofstream<WCHAR, std::char_traits<WCHAR>>;
+
+class StringUtils
+{
+public:
+
+    // The maximum string length. Set to 10000;
+    static const size_t MAX_STRING_LEN;
+
+    // Gets the length of the given string using the the standard wcsnlen_s.
+    // Returns E_BOUNDS if the length of wszString is greater than MAX_STRING_LEN.
+    // For use with untrusted data which may not have a null terminator.
+    static HRESULT WStringLen(_In_ const WCHAR* wszString, _Out_ size_t& len);
+
+    // Gets the length of the given string using the standard strnlen.
+    // Returns E_BOUNDS if the length of wszString is greater than MAX_STRING_LEN.
+    // For use with untrusted data which may not have a null terminator.
+    static HRESULT StringLen(_In_ const char* szString, _Out_ size_t& len);
+
+    // Gets the length of the given string using the standard wcsnlen_s.
+    // Yields the same result as calling wcsnlen_s(wszString, MAX_STRING_LEN);
+    // For use with untrusted data which may not have a null terminator.
+    static size_t WStringLen(_In_ const WCHAR* wszString);
+
+    // Gets the length of the given string using the standard strnlen.
+    // Yields the same result as calling strnlen(szString, MAX_STRING_LEN);
+    // For use with untrusted data which may not have a null terminator.
+    static size_t StringLen(_In_ const char* szString);
+};

--- a/src/InstrumentationEngine.Lib/StringUtils.h
+++ b/src/InstrumentationEngine.Lib/StringUtils.h
@@ -5,17 +5,6 @@
 
 #include <string>
 
-#ifdef PLATFORM_UNIX
-using tstring = std::basic_string<WCHAR, std::char_traits<WCHAR>, std::allocator<WCHAR>>;
-using tstringstream = std::basic_stringstream<WCHAR>;
-using tistringstream = std::basic_istringstream<WCHAR>;
-#else
-using tstring = std::wstring;
-using tstringstream = std::wstringstream;
-using tistringstream = std::wistringstream;
-#endif
-using tofstream = std::basic_ofstream<WCHAR, std::char_traits<WCHAR>>;
-
 class StringUtils
 {
 public:

--- a/src/InstrumentationEngine.Lib/XmlDocWrapper.cpp
+++ b/src/InstrumentationEngine.Lib/XmlDocWrapper.cpp
@@ -15,7 +15,7 @@ CXmlDocWrapper::CXmlDocWrapper()
 
 }
 
-HRESULT CXmlDocWrapper::LoadContent(_In_ LPCWSTR wszValue, _In_ UINT cbValue)
+HRESULT CXmlDocWrapper::LoadContent(_In_ LPCWSTR wszValue)
 {
     HRESULT hr = S_OK;
 
@@ -35,9 +35,9 @@ HRESULT CXmlDocWrapper::LoadContent(_In_ LPCWSTR wszValue, _In_ UINT cbValue)
         return E_FAIL;
     }
 
-    IfFailLogNoRet(pDocument->put_async(VARIANT_FALSE));
-    IfFailLogNoRet(pDocument->put_validateOnParse(VARIANT_FALSE));
-    IfFailLogNoRet(pDocument->put_resolveExternals(VARIANT_TRUE));
+    IfFailLog(pDocument->put_async(VARIANT_FALSE));
+    IfFailLog(pDocument->put_validateOnParse(VARIANT_FALSE));
+    IfFailLog(pDocument->put_resolveExternals(VARIANT_TRUE));
 
     VARIANT_BOOL vbResult = VARIANT_TRUE;
     hr = pDocument->loadXML(CComBSTR(wszValue), &vbResult);
@@ -102,10 +102,10 @@ HRESULT CXmlDocWrapper::LoadContent(_In_ LPCWSTR wszValue, _In_ UINT cbValue)
     // TODO: willxie Test Linux change
     xmlDoc* pDocument = xmlReadMemory(
         CW2A(wszValue, CP_UTF8),
-        cbValue + 1,    // size of the buffer
-        "",             // the base URL to use for the document
-        NULL,           // document encoding
-        0               // xmlParserOption
+        wcslen_s(wszValue), // size of the buffer
+        "",                 // the base URL to use for the document
+        NULL,               // document encoding
+        0                   // xmlParserOption
     );
 
     IfNullRet(pDocument);

--- a/src/InstrumentationEngine.Lib/XmlDocWrapper.cpp
+++ b/src/InstrumentationEngine.Lib/XmlDocWrapper.cpp
@@ -3,6 +3,8 @@
 
 #include "stdafx.h"
 #include "XmlDocWrapper.h"
+#include "Encoding.h"
+#include "StringUtils.h"
 
 using namespace ATL;
 
@@ -99,13 +101,18 @@ HRESULT CXmlDocWrapper::LoadContent(_In_ LPCWSTR wszValue)
 #else
     LIBXML_TEST_VERSION
 
-    // TODO: willxie Test Linux change
+    CAutoVectorPtr<char> utf8Value;
+    CEncoding::ConvertUtf16ToUtf8(wszValue, utf8Value);
+
+    size_t utf8BufLen = 0;
+    IfFailRet(StringUtils::StringLen(utf8Value.m_p, utf8BufLen));
+
     xmlDoc* pDocument = xmlReadMemory(
-        CW2A(wszValue, CP_UTF8),
-        wcslen_s(wszValue), // size of the buffer
-        "",                 // the base URL to use for the document
-        NULL,               // document encoding
-        0                   // xmlParserOption
+        utf8Value.m_p,  // buffer
+        utf8BufLen,     // size of the buffer
+        "",             // the base URL to use for the document
+        NULL,           // document encoding
+        0               // xmlParserOption
     );
 
     IfNullRet(pDocument);

--- a/src/InstrumentationEngine.Lib/XmlDocWrapper.cpp
+++ b/src/InstrumentationEngine.Lib/XmlDocWrapper.cpp
@@ -1,0 +1,139 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "stdafx.h"
+#include "XmlDocWrapper.h"
+
+using namespace ATL;
+
+CXmlDocWrapper::CXmlDocWrapper()
+#ifdef PLATFORM_UNIX
+    : m_cleanupDoc(),
+    m_pDocument(nullptr)
+#endif
+{
+
+}
+
+HRESULT CXmlDocWrapper::LoadContent(_In_ LPCWSTR wszValue, _In_ UINT cbValue)
+{
+    HRESULT hr = S_OK;
+
+    if (m_pDocument != nullptr)
+    {
+        CLogging::LogError(_T("Attempted to load multiple xml files into a single document."));
+        return E_FAIL;
+    }
+
+#ifndef PLATFORM_UNIX
+    // IMPORTANT: Default configuration here is safe from XXE attacks by default in MSXML 6.0 (which we are using), but not MSXML 3.0!
+    CComPtr<IXMLDOMDocument2> pDocument;
+    hr = CoCreateInstance(CLSID_DOMDocument60, NULL, CLSCTX_INPROC_SERVER, IID_IXMLDOMDocument2, (void**)&pDocument);
+    if (FAILED(hr))
+    {
+        CLogging::LogError(_T("Failed to create xml document"));
+        return E_FAIL;
+    }
+
+    IfFailLogNoRet(pDocument->put_async(VARIANT_FALSE));
+    IfFailLogNoRet(pDocument->put_validateOnParse(VARIANT_FALSE));
+    IfFailLogNoRet(pDocument->put_resolveExternals(VARIANT_TRUE));
+
+    VARIANT_BOOL vbResult = VARIANT_TRUE;
+    hr = pDocument->loadXML(CComBSTR(wszValue), &vbResult);
+    if (FAILED(hr) || vbResult == VARIANT_FALSE)
+    {
+        CComPtr<IXMLDOMParseError> pError;
+        pDocument->get_parseError(&pError);
+
+        if (pError != nullptr)
+        {
+            CComBSTR bstrReason;
+            CComBSTR bstrSrcText;
+            long lineNumber = 0;
+
+            if (!SUCCEEDED(pError->get_reason(&bstrReason)))
+            {
+                bstrReason = _T("unknown");
+            }
+
+            if (!SUCCEEDED(pError->get_srcText(&bstrSrcText)))
+            {
+                bstrSrcText = _T("unknown");
+            }
+
+            if (!SUCCEEDED(pError->get_line(&lineNumber)))
+            {
+                lineNumber = 0;
+            }
+
+            WCHAR wszLineNumber[33];
+            _itow_s(lineNumber, wszLineNumber, 33, 10);
+
+            tstring errorText = _T("Failed to load xml content.\r\n");
+
+            if (bstrReason != nullptr)
+            {
+                errorText.append(_T("\r\nReason:"));
+                errorText.append(bstrReason);
+            }
+
+            if (bstrSrcText != nullptr)
+            {
+                errorText.append(_T("Line Text:"));
+                errorText.append(bstrSrcText);
+            }
+
+            errorText.append(_T("\r\nLine Number:"));
+            errorText.append(wszLineNumber);
+
+            CLogging::LogError(errorText.c_str());
+        }
+        else
+        {
+            CLogging::LogError(_T("Failed to load xml file."));
+        }
+
+        return E_FAIL;
+    }
+#else
+    LIBXML_TEST_VERSION
+
+    // TODO: willxie Test Linux change
+    xmlDoc* pDocument = xmlReadMemory(
+        CW2A(wszValue, CP_UTF8),
+        cbValue + 1,    // size of the buffer
+        "",             // the base URL to use for the document
+        NULL,           // document encoding
+        0               // xmlParserOption
+    );
+
+    IfNullRet(pDocument);
+
+    m_cleanupDoc.Attach(pDocument);
+#endif
+
+    m_pDocument = pDocument;
+
+    return S_OK;
+}
+
+HRESULT CXmlDocWrapper::GetRootNode(_Out_ CXmlNode** ppNode)
+{
+    HRESULT hr = S_OK;
+
+    IfNullRet(ppNode);
+    *ppNode = nullptr;
+
+#ifndef PLATFORM_UNIX
+    CComPtr<IXMLDOMElement> pDocumentElement;
+    IfFailRet(m_pDocument->get_documentElement(&pDocumentElement));
+    *ppNode = new CXmlNode(pDocumentElement);
+#else
+    xmlNode* pRoot = xmlDocGetRootElement(m_pDocument);
+    IfNullRet(pRoot);
+    *ppNode = new CXmlNode(pRoot);
+#endif
+
+    return S_OK;
+}

--- a/src/InstrumentationEngine.Lib/XmlDocWrapper.h
+++ b/src/InstrumentationEngine.Lib/XmlDocWrapper.h
@@ -11,7 +11,7 @@ class CXmlDocWrapper : CModuleRefCount
 public:
     CXmlDocWrapper();
 
-    HRESULT LoadContent(_In_ LPCWSTR wszValue, _In_ UINT cbValue);
+    HRESULT LoadContent(_In_ LPCWSTR wszValue);
     HRESULT GetRootNode(_Out_ CXmlNode** ppNode);
 
     DEFINE_DELEGATED_REFCOUNT_ADDREF(CXmlDocWrapper);

--- a/src/InstrumentationEngine.Lib/XmlDocWrapper.h
+++ b/src/InstrumentationEngine.Lib/XmlDocWrapper.h
@@ -1,0 +1,60 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "stdafx.h"
+#include "XmlNode.h"
+
+class CXmlDocWrapper : CModuleRefCount
+{
+public:
+    CXmlDocWrapper();
+
+    HRESULT LoadContent(_In_ LPCWSTR wszValue, _In_ UINT cbValue);
+    HRESULT GetRootNode(_Out_ CXmlNode** ppNode);
+
+    DEFINE_DELEGATED_REFCOUNT_ADDREF(CXmlDocWrapper);
+    DEFINE_DELEGATED_REFCOUNT_RELEASE(CXmlDocWrapper);
+
+private:
+#ifndef PLATFORM_UNIX
+    CComPtr<IXMLDOMDocument2> m_pDocument;
+#else
+    class CCleanXmlDocument
+    {
+    private:
+        xmlDoc* m_pDocument;
+    public:
+        CCleanXmlDocument()
+            : m_pDocument(nullptr)
+        {}
+
+        ~CCleanXmlDocument()
+        {
+            Free();
+        }
+
+        void Attach(xmlDoc* pDocument)
+        {
+            if (m_pDocument != nullptr)
+            {
+                Free();
+            }
+
+            m_pDocument = pDocument;
+        }
+
+        void Free()
+        {
+            xmlFreeDoc(m_pDocument);
+
+            // CONSIDER: is this safe? What if someone else in the process is using the parser?
+            xmlCleanupParser();
+        }
+    };
+    CCleanXmlDocument m_cleanupDoc;
+
+    xmlDoc* m_pDocument;
+#endif
+};

--- a/src/InstrumentationEngine.Lib/XmlNode.cpp
+++ b/src/InstrumentationEngine.Lib/XmlNode.cpp
@@ -130,7 +130,6 @@ HRESULT CXmlNode::GetAttribute(_In_ const WCHAR* wszAttributeName, _Out_ BSTR* p
     CAutoVectorPtr<char> utf8AttrName;
     CEncoding::ConvertUtf16ToUtf8(wszAttributeName, utf8AttrName);
     xmlChar* utf8AttrValue = xmlGetProp(m_pNode, (const xmlChar *)utf8AttrName.m_p);
-    //xmlChar* utf8AttrValue = xmlGetProp(m_pNode, (const xmlChar *)CW2A(wszAttributeName, CP_UTF8));
 
     if (utf8AttrValue != nullptr)
     {

--- a/src/InstrumentationEngine.Lib/XmlNode.cpp
+++ b/src/InstrumentationEngine.Lib/XmlNode.cpp
@@ -1,0 +1,147 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "stdafx.h"
+#include "XmlNode.h"
+#include "Encoding.h"
+
+#ifndef PLATFORM_UNIX
+CXmlNode::CXmlNode(_In_ IXMLDOMNode* pNode)
+{
+    m_pNode = pNode;
+}
+#else
+CXmlNode::CXmlNode(_In_ xmlNode* pNode)
+{
+    m_pNode = pNode;
+}
+#endif
+
+HRESULT CXmlNode::GetChildNode(_Out_ CXmlNode** ppNode)
+{
+    HRESULT hr = S_OK;
+
+    IfNullRet(ppNode);
+    IfNullRet(m_pNode);
+    *ppNode = nullptr;
+
+#ifndef PLATFORM_UNIX
+    CComPtr<IXMLDOMNode> pNode;
+    IfFailRet(m_pNode->get_firstChild(&pNode));
+#else
+    xmlNode* pNode = m_pNode->children;
+#endif
+
+    if (pNode != nullptr)
+    {
+        *ppNode = new CXmlNode(pNode);
+    }
+
+    return S_OK;
+}
+
+CXmlNode* CXmlNode::Next()
+{
+    if (m_pNode == nullptr)
+    {
+        return nullptr;
+    }
+
+#ifndef PLATFORM_UNIX
+    CComPtr<IXMLDOMNode> pNextSibling;
+    if (SUCCEEDED(m_pNode->get_nextSibling(&pNextSibling)) &&
+        pNextSibling != nullptr)
+    {
+        return new CXmlNode(pNextSibling);
+    }
+#else
+    xmlNode* pNextSibling = m_pNode->next;
+    if (pNextSibling != nullptr)
+    {
+        return new CXmlNode(pNextSibling);
+    }
+#endif
+
+    return nullptr;
+}
+
+HRESULT CXmlNode::GetName(_Out_ BSTR* pName)
+{
+    HRESULT hr = S_OK;
+
+    IfNullRet(pName);
+    IfNullRet(m_pNode);
+
+#ifndef PLATFORM_UNIX
+    IfFailRet(m_pNode->get_nodeName(pName));
+
+    return S_OK;
+#else
+    return CEncoding::ConvertUtf8ToUtf16Bstr((const char*)m_pNode->name, pName);
+#endif
+}
+
+HRESULT CXmlNode::GetStringValue(_Out_ BSTR* pValue)
+{
+    HRESULT hr = S_OK;
+
+    IfNullRet(pValue);
+    IfNullRet(m_pNode);
+
+#ifndef PLATFORM_UNIX
+    CComVariant varNodeValue;
+    IfFailRet(m_pNode->get_nodeValue(&varNodeValue));
+
+    CComBSTR bstrNodeValue = varNodeValue.bstrVal;
+    *pValue = bstrNodeValue.Detach();
+
+    return S_OK;
+
+#else
+    return CEncoding::ConvertUtf8ToUtf16Bstr((const char*)m_pNode->content, pValue);
+#endif
+}
+
+HRESULT CXmlNode::GetAttribute(_In_ const WCHAR* wszAttributeName, _Out_ BSTR* pValue)
+{
+    HRESULT hr = S_OK;
+
+    IfNullRet(pValue);
+    IfNullRet(m_pNode);
+
+#ifndef PLATFORM_UNIX
+
+    // Get attributes
+    CComPtr<IXMLDOMNamedNodeMap> pAttributes;
+    IfFailRet(m_pNode->get_attributes(&pAttributes));
+
+    // Get specific attribute by name.
+    CComPtr<IXMLDOMNode> pAttributeNode;
+    pAttributes->getNamedItem(const_cast<BSTR>(wszAttributeName), &pAttributeNode);
+
+    // Get the attribute value.
+    CComVariant varValueAttr;
+    pAttributeNode->get_nodeValue(&varValueAttr);
+    CComBSTR bstrAttrVal = varValueAttr.bstrVal;
+    *pValue = bstrAttrVal.Detach();
+
+    return S_OK;
+#else
+    CAutoVectorPtr<char> utf8AttrName;
+    CEncoding::ConvertUtf16ToUtf8(wszAttributeName, utf8AttrName);
+    xmlChar* utf8AttrValue = xmlGetProp(m_pNode, (const xmlChar *)utf8AttrName.m_p);
+    //xmlChar* utf8AttrValue = xmlGetProp(m_pNode, (const xmlChar *)CW2A(wszAttributeName, CP_UTF8));
+
+    if (utf8AttrValue != nullptr)
+    {
+        hr = CEncoding::ConvertUtf8ToUtf16Bstr((const char*)utf8AttrValue, pValue);
+        xmlFree(utf8AttrValue);
+        return hr;
+    }
+    else
+    {
+        // TODO: willxie do something better than this if no attribute found (ie. xmlGetProp() returns NULL)
+        return E_FAIL;
+    }
+#endif
+}

--- a/src/InstrumentationEngine.Lib/XmlNode.cpp
+++ b/src/InstrumentationEngine.Lib/XmlNode.cpp
@@ -109,6 +109,8 @@ HRESULT CXmlNode::GetAttribute(_In_ const WCHAR* wszAttributeName, _Out_ BSTR* p
     IfNullRet(pValue);
     IfNullRet(m_pNode);
 
+    *pValue = nullptr;
+
 #ifndef PLATFORM_UNIX
 
     // Get attributes

--- a/src/InstrumentationEngine.Lib/XmlNode.cpp
+++ b/src/InstrumentationEngine.Lib/XmlNode.cpp
@@ -119,11 +119,14 @@ HRESULT CXmlNode::GetAttribute(_In_ const WCHAR* wszAttributeName, _Out_ BSTR* p
     CComPtr<IXMLDOMNode> pAttributeNode;
     pAttributes->getNamedItem(const_cast<BSTR>(wszAttributeName), &pAttributeNode);
 
-    // Get the attribute value.
-    CComVariant varValueAttr;
-    pAttributeNode->get_nodeValue(&varValueAttr);
-    CComBSTR bstrAttrVal = varValueAttr.bstrVal;
-    *pValue = bstrAttrVal.Detach();
+    if (pAttributeNode != nullptr)
+    {
+        // Get the attribute value.
+        CComVariant varValueAttr;
+        pAttributeNode->get_nodeValue(&varValueAttr);
+        CComBSTR bstrAttrVal = varValueAttr.bstrVal;
+        *pValue = bstrAttrVal.Detach();
+    }
 
     return S_OK;
 #else

--- a/src/InstrumentationEngine.Lib/XmlNode.h
+++ b/src/InstrumentationEngine.Lib/XmlNode.h
@@ -1,0 +1,39 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "stdafx.h"
+
+class CXmlNode : CModuleRefCount
+{
+public:
+#ifndef PLATFORM_UNIX
+    CXmlNode(_In_ IXMLDOMNode* pNode);
+#else
+    CXmlNode(_In_ xmlNode* pNode);
+#endif
+
+    HRESULT GetChildNode(_Out_ CXmlNode** ppNode);
+
+    CXmlNode* Next();
+
+    // Element Name
+    HRESULT GetName(_Out_ BSTR* pName);
+
+    // Element Value
+    HRESULT GetStringValue(_Out_ BSTR* pValue);
+
+    // Attribute Value
+    HRESULT GetAttribute(_In_ const WCHAR* wszAttributeName, _Out_ BSTR* pValue);
+
+    DEFINE_DELEGATED_REFCOUNT_ADDREF(CXmlNode);
+    DEFINE_DELEGATED_REFCOUNT_RELEASE(CXmlNode);
+
+private:
+#ifndef PLATFORM_UNIX
+    CComPtr<IXMLDOMNode> m_pNode;
+#else
+    xmlNode* m_pNode;
+#endif
+};

--- a/src/InstrumentationEngine.Lib/stdafx.h
+++ b/src/InstrumentationEngine.Lib/stdafx.h
@@ -49,6 +49,9 @@ using namespace ATL;
 #ifndef PLATFORM_UNIX
 #include <msxml6.h>
 #include <Pathcch.h>
+#else
+#include <libxml/parser.h>
+#include <libxml/tree.h>
 #endif
 
 
@@ -59,7 +62,10 @@ using namespace ATL;
 #ifdef PLATFORM_UNIX
 // pal.h defines these, but they aren't picked up for our build because std_c++ compatibility is defined
 // in CMakeFile.txt
+#define PAL_wcsnlen_s(a, b) (a != nullptr) ? PAL_wcsnlen(a, b) : 0
 #define wcsstr        PAL_wcsstr
+#define wcslen        PAL_wcslen
+#define wcsnlen_s     PAL_wcsnlen_s
 #endif
 
 #include <queue>

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -481,7 +481,7 @@ DWORD WINAPI CProfilerManager::ParseAttachConfigurationThreadProc(
 
                     for (unordered_map<tstring, tstring>::iterator it = settingsMap.begin();
                         it != settingsMap.end();
-                        it++)
+                        ++it)
                     {
                         if (wcscmp(it->first.c_str(), _T("LogLevel")) == 0)
                         {
@@ -534,7 +534,7 @@ DWORD WINAPI CProfilerManager::ParseAttachConfigurationThreadProc(
 
                             for (unordered_map<tstring, tstring>::iterator it = settingsMap.begin();
                                  it != settingsMap.end();
-                                 it++)
+                                 ++it)
                             {
                                 IfFailRet(pSource->AddSetting(it->first.c_str(), it->second.c_str()));
                             }
@@ -593,7 +593,7 @@ HRESULT CProfilerManager::ParseSettingsConfigurationNode(
 
         if (settings.find(bstrSettingName.m_str) == settings.end())
         {
-            settings.insert(std::pair<tstring, tstring>(bstrSettingName, bstrSettingValue));
+            settings.insert(std::pair<tstring, tstring>(bstrSettingName.m_str, bstrSettingValue.m_str));
         }
 
         CXmlNode* nextSetting = pSettingNode->Next();
@@ -2967,7 +2967,7 @@ HRESULT CProfilerManager::InitializeForAttach(
         cbClientData == 0)
     {
         // No configuration provided
-        return S_FALSE;
+        return E_FAIL;
     }
 
     UINT charCount = cbClientData / WCharSizeInBytes;

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -22,6 +22,8 @@ namespace MicrosoftInstrumentationEngine
 
     const GUID CLSID_CProfilerManager = { 0x324F817A, 0x7420, 0x4E6D,{ 0xB3, 0xC1, 0x14, 0x3f, 0xBE, 0xD6, 0xD8, 0x55 } };
 
+    const size_t WCharSizeInBytes = sizeof(WCHAR) / sizeof(byte);
+
     // This abstract class should be updated with new IProfilerManager interfaces.
     // Both CProfilerManager and CProfilerManagerForInstrumentationMethod inherit this class.
     class IProfilerManagerContract :
@@ -249,8 +251,7 @@ namespace MicrosoftInstrumentationEngine
         DWORD CalculateEventMask(DWORD dwAdditionalFlags);
 
         HRESULT InitializeCore(
-            _In_ IUnknown* pCorProfilerInfoUnk,
-            _In_ const vector<CComPtr<CConfigurationSource>>& configSources
+            _In_ IUnknown* pCorProfilerInfoUnk
             );
 
         // The CLR doesn't initialize com before calling the profiler, and the profiler manager cannot do so itself

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -3,6 +3,7 @@
 
 #pragma once
 
+#include "stdafx.h"
 #include "InstrumentationMethod.h"
 #include "AppDomainCollection.h"
 #include "ClrVersion.h"
@@ -11,6 +12,7 @@
 #ifndef PLATFORM_UNIX
 #include "../Common.Lib/ModuleHandle.h"
 #endif
+#include <XmlDocWrapper.h>
 
 using namespace ATL;
 
@@ -79,9 +81,6 @@ namespace MicrosoftInstrumentationEngine
 
         // The configuration xml for profiler attach.
         LPCWSTR m_wszConfigXml;
-
-        // The size of the configuration xml
-        UINT m_cbConfigXml;
 
         // list of loaded instrumentation method guids
         std::vector<GUID> m_instrumentationMethodGuids;
@@ -266,9 +265,13 @@ namespace MicrosoftInstrumentationEngine
 
         // lpParameter points to the this pointer so m_wszConfigXml can be accessed. This is safe because the thread proc
         // blocks until this is complete.
-        static DWORD WINAPI InitializeForAttachThreadProc(
+        static DWORD WINAPI ParseAttachConfigurationThreadProc(
             _In_ LPVOID lpParameter
             );
+
+        static HRESULT ParseSettingsConfigurationNode(
+            _In_ const CComPtr<CXmlNode>& parentNode,
+            _Inout_ unordered_map<tstring, tstring>& settings);
 
         HRESULT LoadInstrumentationMethods(_In_ CConfigurationSource* pConfigurationSource);
 
@@ -411,7 +414,6 @@ namespace MicrosoftInstrumentationEngine
         HRESULT AssemblyUnloadFinishedImpl(_In_ AssemblyID assemblyId, _In_ HRESULT hrStatus);
 
         HRESULT InvokeThreadRoutine(
-            _In_ const std::vector<CComPtr<CConfigurationSource>>& configSources,
             _In_ LPTHREAD_START_ROUTINE threadRoutine
             );
 

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -77,6 +77,12 @@ namespace MicrosoftInstrumentationEngine
         // list of instrumentation method configuration sources
         vector<CComPtr<CConfigurationSource>> m_configSources;
 
+        // The configuration xml for profiler attach.
+        LPCWSTR m_wszConfigXml;
+
+        // The size of the configuration xml
+        UINT m_cbConfigXml;
+
         // list of loaded instrumentation method guids
         std::vector<GUID> m_instrumentationMethodGuids;
 
@@ -252,10 +258,16 @@ namespace MicrosoftInstrumentationEngine
         // as that would screw up the com state for the application thread. This thread allows the profiler manager
         // to co create a free threaded version of msxml on a thread that it owns to avoid this.
         //
-        // lpParameter points to the this pointer so m_configFilePaths can be accessed. This is safe because the thread proc
+        // lpParameter points to the this pointer so m_configSources can be accessed. This is safe because the thread proc
         // blocks until this is complete.
         static DWORD WINAPI InstrumentationMethodThreadProc(
             _In_  LPVOID lpParameter
+            );
+
+        // lpParameter points to the this pointer so m_wszConfigXml can be accessed. This is safe because the thread proc
+        // blocks until this is complete.
+        static DWORD WINAPI InitializeForAttachThreadProc(
+            _In_ LPVOID lpParameter
             );
 
         HRESULT LoadInstrumentationMethods(_In_ CConfigurationSource* pConfigurationSource);
@@ -398,8 +410,9 @@ namespace MicrosoftInstrumentationEngine
         HRESULT AssemblyUnloadStartedImpl(_In_ AssemblyID assemblyId);
         HRESULT AssemblyUnloadFinishedImpl(_In_ AssemblyID assemblyId, _In_ HRESULT hrStatus);
 
-        HRESULT SetupInstrumentationMethods(
-            _In_ const std::vector<CComPtr<CConfigurationSource>>& configSources
+        HRESULT InvokeThreadRoutine(
+            _In_ const std::vector<CComPtr<CConfigurationSource>>& configSources,
+            _In_ LPTHREAD_START_ROUTINE threadRoutine
             );
 
 #ifndef PLATFORM_UNIX

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -22,7 +22,7 @@ namespace MicrosoftInstrumentationEngine
 
     const GUID CLSID_CProfilerManager = { 0x324F817A, 0x7420, 0x4E6D,{ 0xB3, 0xC1, 0x14, 0x3f, 0xBE, 0xD6, 0xD8, 0x55 } };
 
-    const size_t WCharSizeInBytes = sizeof(WCHAR) / sizeof(byte);
+    const size_t WCharSizeInBytes = sizeof(WCHAR) / sizeof(BYTE);
 
     // This abstract class should be updated with new IProfilerManager interfaces.
     // Both CProfilerManager and CProfilerManagerForInstrumentationMethod inherit this class.
@@ -270,6 +270,16 @@ namespace MicrosoftInstrumentationEngine
             _In_ LPVOID lpParameter
             );
 
+        /* Parses the following XML block of <Setting /> nodes into map of key-value pairs.
+         * Name and Value attributes for <Setting /> nodes are required.
+         * Duplicates are ignored.
+         *  <Settings>
+         *      <Setting Name="Key1" Value="Val1" />
+         *      <Setting Name="Key2" Value="Val2" />
+         *      <Setting Name="Key3" Value="Val3" />
+         *      ...
+         *  </Settings>
+         */
         static HRESULT ParseSettingsConfigurationNode(
             _In_ const CComPtr<CXmlNode>& parentNode,
             _Inout_ unordered_map<tstring, tstring>& settings);

--- a/src/InstrumentationEngine/stdafx.h
+++ b/src/InstrumentationEngine/stdafx.h
@@ -55,6 +55,7 @@ using namespace ATL;
 // pal.h defines these, but they aren't picked up for our build because std_c++ compatibility is defined
 // in CMakeFile.txt
 #define wcsstr        PAL_wcsstr
+#define wcscmp        PAL_wcscmp
 #endif
 
 #include <vector>


### PR DESCRIPTION
These changes are specifically the Profiler changes, which include:
* Adding XmlNode and XmlDocWrapper implementations
* Parsing the configuration xml from attach.exe for only adding instrumentation methods and configuration the engine.

The attach.exe changes will be in another PR

List of TODOs outside this PR:
* Support other portions of the configuration schema like "removing Instrumentation Method" and "attach RawProfiler"
* Test Linux changes