### PR TITLE
Add environment variable for path to extension root.

### DIFF
--- a/src/InstrumentationEngine.Attach/Program.cs
+++ b/src/InstrumentationEngine.Attach/Program.cs
@@ -61,21 +61,26 @@ namespace Microsoft.InstrumentationEngine
             // relative to the current executable? For example, requiring the root path of the engine
             // to be passed as a parameter (which increases the difficulty of using this executable).
 
-            string? attachDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            if (null == attachDirectory || !Directory.Exists(attachDirectory))
+            string? rootDirectory = Environment.GetEnvironmentVariable("MicrosoftInstrumentationEngine_InstallationRoot");
+            if (string.IsNullOrEmpty(rootDirectory))
             {
-                WriteError(Invariant($"Directory '{attachDirectory}' does not exist."));
-                return ExitCodeFailure;
+                string? attachDirectory = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                if (null == attachDirectory || !Directory.Exists(attachDirectory))
+                {
+                    WriteError(Invariant($"Directory '{attachDirectory}' does not exist."));
+                    return ExitCodeFailure;
+                }
+
+                string? toolsDirectory = Path.GetDirectoryName(attachDirectory);
+                if (null == toolsDirectory || !Directory.Exists(toolsDirectory))
+                {
+                    WriteError(Invariant($"Directory '{toolsDirectory}' does not exist."));
+                    return ExitCodeFailure;
+                }
+
+                rootDirectory = Path.GetDirectoryName(toolsDirectory);
             }
 
-            string? toolsDirectory = Path.GetDirectoryName(attachDirectory);
-            if (null == toolsDirectory || !Directory.Exists(toolsDirectory))
-            {
-                WriteError(Invariant($"Directory '{toolsDirectory}' does not exist."));
-                return ExitCodeFailure;
-            }
-
-            string? rootDirectory = Path.GetDirectoryName(toolsDirectory);
             if (null == rootDirectory || !Directory.Exists(rootDirectory))
             {
                 WriteError(Invariant($"Directory '{rootDirectory}' does not exist."));

--- a/src/InstrumentationEngine.Preinstall/scmApplicationHost.xdt
+++ b/src/InstrumentationEngine.Preinstall/scmApplicationHost.xdt
@@ -21,7 +21,7 @@
   <system.webServer>
     <runtime xdt:Transform="InsertIfMissing">
       <environmentVariables xdt:Transform="InsertIfMissing">
-        <add name="MicrosoftInstrumentationEngine_AttachPath" value="%XDT_EXTENSIONPATH%\Tools\Attach\Microsoft.InstrumentationEngine.Attach.exe" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
+        <add name="MicrosoftInstrumentationEngine_InstallationRoot" value="%XDT_EXTENSIONPATH%" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <!-- EXPERIMENTAL: Uncomment the following to enable snapshot debugging of WebJobs -->
         <!-- <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <add name="COR_PROFILER" value="{324F817A-7420-4E6D-B3C1-143FBED6D855}" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />

--- a/src/InstrumentationEngine.Preinstall/scmApplicationHost.xdt
+++ b/src/InstrumentationEngine.Preinstall/scmApplicationHost.xdt
@@ -21,6 +21,7 @@
   <system.webServer>
     <runtime xdt:Transform="InsertIfMissing">
       <environmentVariables xdt:Transform="InsertIfMissing">
+        <add name="MicrosoftInstrumentationEngine_AttachPath" value="%XDT_EXTENSIONPATH%\Tools\Attach\Microsoft.InstrumentationEngine.Attach.exe" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <!-- EXPERIMENTAL: Uncomment the following to enable snapshot debugging of WebJobs -->
         <!-- <add name="COR_ENABLE_PROFILING" value="1" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />
         <add name="COR_PROFILER" value="{324F817A-7420-4E6D-B3C1-143FBED6D855}" xdt:Locator="Match(name)" xdt:Transform="InsertIfMissing" />


### PR DESCRIPTION
Add environment variable to allow discovering of root of the site extension. This is useful for if the site extension is already enabled (either via app setting for the preinstall site extension or via upload as a private site extension) to allow other processes to discover which engine version should be used.