### PR TITLE
Cancel profiler activation if no attach data is provided

### DIFF
--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -2967,7 +2967,7 @@ HRESULT CProfilerManager::InitializeForAttach(
         cbClientData == 0)
     {
         // No configuration provided
-        return E_FAIL;
+        return CORPROF_E_PROFILER_CANCEL_ACTIVATION;
     }
 
     UINT charCount = cbClientData / WCharSizeInBytes;


### PR DESCRIPTION
Returning E_FAIL from InitializeForAttach will cause the CLR to return access denied, which is not informative of the problem. Changing the return value to CORPROF_E_PROFILER_CANCEL_ACTIVATION.