### PR TITLE
Generate private site extension XDT for attach

### DIFF
--- a/build/Scripts/PrivateXdt/GeneratePrivateXdt.ps1
+++ b/build/Scripts/PrivateXdt/GeneratePrivateXdt.ps1
@@ -27,7 +27,11 @@ param(
 
     [Parameter(Mandatory=$false)]
     [Switch]
-    $DisableSignatureValidation
+    $DisableSignatureValidation,
+
+    [Parameter(Mandatory=$false)]
+    [Switch]
+    $ForAttach
 )
 
 Import-Module "$PSScriptRoot\XdtHelper.psm1" -Force
@@ -38,11 +42,15 @@ $ErrorActionPreference = 'Stop'
 [xml]$xdtFile = Get-Content $InputXdtFilePath -Raw
 
 Write-Host "Applying changes..."
-$params = @{
+$addParams = @{
     DisableSignatureValidation = $DisableSignatureValidation
     DebugWait                  = $DebugWait
 }
-Edit-XdtContent -XdtFile $xdtFile -XmlEntries (Get-ClrieXmlEntries @params)
+$removeParams = @{
+    ForAttach = $ForAttach
+}
+
+Edit-XdtContent -XdtFile $xdtFile -XmlEntriesToAdd (Get-ClrieXmlEntriesToAdd @addParams) -XmlEntriesToRemove (Get-ClrieXmlEntriesToRemove @removeParams)
 
 Write-Host "Saving changes..."
 # This nicely formats the XML

--- a/build/Scripts/PrivateXdt/GeneratePrivateXdt.ps1
+++ b/build/Scripts/PrivateXdt/GeneratePrivateXdt.ps1
@@ -31,7 +31,11 @@ param(
 
     [Parameter(Mandatory=$false)]
     [Switch]
-    $ForAttach
+    $Attach,
+
+    [Parameter(Mandatory=$false)]
+    [Switch]
+    $Scm
 )
 
 Import-Module "$PSScriptRoot\XdtHelper.psm1" -Force
@@ -45,9 +49,11 @@ Write-Host "Applying changes..."
 $addParams = @{
     DisableSignatureValidation = $DisableSignatureValidation
     DebugWait                  = $DebugWait
+    Scm                        = $Scm
 }
 $removeParams = @{
-    ForAttach = $ForAttach
+    Attach = $Attach
+    Scm    = $Scm
 }
 
 Edit-XdtContent -XdtFile $xdtFile -XmlEntriesToAdd (Get-ClrieXmlEntriesToAdd @addParams) -XmlEntriesToRemove (Get-ClrieXmlEntriesToRemove @removeParams)

--- a/build/Scripts/PrivateXdt/XdtHelper.psm1
+++ b/build/Scripts/PrivateXdt/XdtHelper.psm1
@@ -91,6 +91,13 @@ function Get-ClrieXmlEntriesToAdd {
             destination = "configuration.'system.webServer'.runtime.environmentVariables"
         }
 
+        Write-Output @{
+            element     = 'add'
+            name        = 'MicrosoftInstrumentationEngine_LogLevel'
+            transform   = 'RemoveAll'
+            destination = "configuration.'system.webServer'.runtime.environmentVariables"
+        }
+
         if ($DebugWait) {
             Write-Output @{
                 element     = 'add'
@@ -136,6 +143,7 @@ function Get-ClrieXmlEntriesToRemove {
         Write-Output "/configuration/system.webServer/runtime/environmentVariables/add[@name='COR_PROFILER_PATH_32']"
         Write-Output "/configuration/system.webServer/runtime/environmentVariables/add[@name='COR_PROFILER_PATH_64']"
         Write-Output "/configuration/system.webServer/runtime/environmentVariables/add[@name='MicrosoftInstrumentationEngine_IsPreinstalled']"
+        Write-Output "/configuration/system.webServer/runtime/environmentVariables/add[@name='MicrosoftInstrumentationEngine_LogLevel']"
     }
 }
 

--- a/build/Scripts/PrivateXdt/XdtHelper.psm1
+++ b/build/Scripts/PrivateXdt/XdtHelper.psm1
@@ -10,91 +10,108 @@ function Get-ClrieXmlEntriesToAdd {
 
         [Parameter(Mandatory=$false)]
         [Switch]
-        $DisableSignatureValidation
+        $DisableSignatureValidation,
+
+        [Parameter(Mandatory=$false)]
+        [Switch]
+        $Scm
     )
 
-    Write-Output @{
-        element     = 'add'
-        name        = 'COR_ENABLE_PROFILING'
-        transform   = 'RemoveAll'
-        destination = "configuration.'system.webServer'.runtime.environmentVariables"
-    }
-
-    Write-Output @{
-        element     = 'add'
-        name        = 'COR_PROFILER'
-        transform   = 'RemoveAll'
-        destination = "configuration.'system.webServer'.runtime.environmentVariables"
-    }
-
-    Write-Output @{
-        element     = 'add'
-        name        = 'COR_PROFILER_PATH_32'
-        transform   = 'RemoveAll'
-        destination = "configuration.'system.webServer'.runtime.environmentVariables"
-    }
-
-    Write-Output @{
-        element     = 'add'
-        name        = 'COR_PROFILER_PATH_64'
-        transform   = 'RemoveAll'
-        destination = "configuration.'system.webServer'.runtime.environmentVariables"
-    }
-
-    Write-Output @{
-        element     = 'add'
-        name        = 'CORECLR_ENABLE_PROFILING'
-        transform   = 'RemoveAll'
-        destination = "configuration.'system.webServer'.runtime.environmentVariables"
-    }
-
-    Write-Output @{
-        element     = 'add'
-        name        = 'CORECLR_PROFILER'
-        transform   = 'RemoveAll'
-        destination = "configuration.'system.webServer'.runtime.environmentVariables"
-    }
-
-    Write-Output @{
-        element     = 'add'
-        name        = 'CORECLR_PROFILER_PATH_32'
-        transform   = 'RemoveAll'
-        destination = "configuration.'system.webServer'.runtime.environmentVariables"
-    }
-
-    Write-Output @{
-        element     = 'add'
-        name        = 'CORECLR_PROFILER_PATH_64'
-        transform   = 'RemoveAll'
-        destination = "configuration.'system.webServer'.runtime.environmentVariables"
-    }
-
-    Write-Output @{
-        element     = 'add'
-        name        = 'MicrosoftInstrumentationEngine_IsPreinstalled'
-        transform   = 'RemoveAll'
-        destination = "configuration.'system.webServer'.runtime.environmentVariables"
-    }
-
-    if ($DebugWait) {
+    if ($Scm)
+    {
         Write-Output @{
             element     = 'add'
-            name        = 'MicrosoftInstrumentationEngine_DebugWait'
-            value       = '1'
-            transform   = 'InsertIfMissing'
+            name        = 'MicrosoftInstrumentationEngine_InstallationRoot'
+            transform   = 'RemoveAll'
             destination = "configuration.'system.webServer'.runtime.environmentVariables"
         }
     }
-
-    if ($DisableSignatureValidation) {
+    else
+    {
         Write-Output @{
             element     = 'add'
-            name        = 'MicrosoftInstrumentationEngine_DisableCodeSignatureValidation'
-            value       = '1'
-            transform   = 'InsertIfMissing'
+            name        = 'COR_ENABLE_PROFILING'
+            transform   = 'RemoveAll'
             destination = "configuration.'system.webServer'.runtime.environmentVariables"
         }
+
+        Write-Output @{
+            element     = 'add'
+            name        = 'COR_PROFILER'
+            transform   = 'RemoveAll'
+            destination = "configuration.'system.webServer'.runtime.environmentVariables"
+        }
+
+        Write-Output @{
+            element     = 'add'
+            name        = 'COR_PROFILER_PATH_32'
+            transform   = 'RemoveAll'
+            destination = "configuration.'system.webServer'.runtime.environmentVariables"
+        }
+
+        Write-Output @{
+            element     = 'add'
+            name        = 'COR_PROFILER_PATH_64'
+            transform   = 'RemoveAll'
+            destination = "configuration.'system.webServer'.runtime.environmentVariables"
+        }
+
+        Write-Output @{
+            element     = 'add'
+            name        = 'CORECLR_ENABLE_PROFILING'
+            transform   = 'RemoveAll'
+            destination = "configuration.'system.webServer'.runtime.environmentVariables"
+        }
+
+        Write-Output @{
+            element     = 'add'
+            name        = 'CORECLR_PROFILER'
+            transform   = 'RemoveAll'
+            destination = "configuration.'system.webServer'.runtime.environmentVariables"
+        }
+
+        Write-Output @{
+            element     = 'add'
+            name        = 'CORECLR_PROFILER_PATH_32'
+            transform   = 'RemoveAll'
+            destination = "configuration.'system.webServer'.runtime.environmentVariables"
+        }
+
+        Write-Output @{
+            element     = 'add'
+            name        = 'CORECLR_PROFILER_PATH_64'
+            transform   = 'RemoveAll'
+            destination = "configuration.'system.webServer'.runtime.environmentVariables"
+        }
+
+        Write-Output @{
+            element     = 'add'
+            name        = 'MicrosoftInstrumentationEngine_IsPreinstalled'
+            transform   = 'RemoveAll'
+            destination = "configuration.'system.webServer'.runtime.environmentVariables"
+        }
+
+        if ($DebugWait) {
+            Write-Output @{
+                element     = 'add'
+                name        = 'MicrosoftInstrumentationEngine_DebugWait'
+                value       = '1'
+                transform   = 'InsertIfMissing'
+                destination = "configuration.'system.webServer'.runtime.environmentVariables"
+            }
+        }
+
+        if ($DisableSignatureValidation) {
+            Write-Output @{
+                element     = 'add'
+                name        = 'MicrosoftInstrumentationEngine_DisableCodeSignatureValidation'
+                value       = '1'
+                transform   = 'InsertIfMissing'
+                destination = "configuration.'system.webServer'.runtime.environmentVariables"
+            }
+        }
     }
+
 }
 
 function Get-ClrieXmlEntriesToRemove {
@@ -102,10 +119,14 @@ function Get-ClrieXmlEntriesToRemove {
     param (
         [Parameter(Mandatory=$false)]
         [Switch]
-        $ForAttach
+        $Attach,
+
+        [Parameter(Mandatory=$false)]
+        [Switch]
+        $Scm
     )
 
-    if ($ForAttach) {
+    if ($Attach -and -not $Scm) {
         Write-Output "/configuration/system.webServer/runtime/environmentVariables/add[@name='CORECLR_ENABLE_PROFILING']"
         Write-Output "/configuration/system.webServer/runtime/environmentVariables/add[@name='CORECLR_PROFILER']"
         Write-Output "/configuration/system.webServer/runtime/environmentVariables/add[@name='CORECLR_PROFILER_PATH_32']"

--- a/src/InstrumentationEngine.Preinstall/InstrumentationEngine.Preinstall.csproj
+++ b/src/InstrumentationEngine.Preinstall/InstrumentationEngine.Preinstall.csproj
@@ -92,11 +92,17 @@
   </Target>
   <Target Name="GeneratePrivateXdt">
     <PropertyGroup>
+      <GenerationPowerShellCommand>%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -ExecutionPolicy Unrestricted -Command</GenerationPowerShellCommand>
+      <GenerationScriptPath>$(BuildFilesDir)\Scripts\PrivateXdt\GeneratePrivateXdt.ps1</GenerationScriptPath>
       <XDT_DISABLESIGNATUREVALIDATION Condition=" '$(XDT_DISABLESIGNATUREVALIDATION)'=='' ">$True</XDT_DISABLESIGNATUREVALIDATION>
       <XDT_DEBUGWAIT Condition=" '$(XDT_DEBUGWAIT)'=='' ">$False</XDT_DEBUGWAIT>
+      <ApplicationHostCommonParams>-InputXdtFilePath &apos;$(MSBuildThisFileDirectory)applicationHost.xdt&apos; -DebugWait:$(XDT_DEBUGWAIT) -DisableSignatureValidation:$(XDT_DISABLESIGNATUREVALIDATION)</ApplicationHostCommonParams>
+      <ScmApplicationHostCommonParams>-InputXdtFilePath &apos;$(MSBuildThisFileDirectory)scmApplicationHost.xdt&apos; -Scm</ScmApplicationHostCommonParams>
     </PropertyGroup>
     <MakeDir Directories="$(OutDir)AttachXdt" />
-    <Exec Command="%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -executionpolicy Unrestricted -Command &quot;&amp; { &amp; $(BuildFilesDir)\Scripts\PrivateXdt\GeneratePrivateXdt.ps1 &apos;$(OutDir)applicationhost.xdt&apos; -DebugWait:$(XDT_DEBUGWAIT) -DisableSignatureValidation:$(XDT_DISABLESIGNATUREVALIDATION) } &quot;" />
-    <Exec Command="%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -executionpolicy Unrestricted -Command &quot;&amp; { &amp; $(BuildFilesDir)\Scripts\PrivateXdt\GeneratePrivateXdt.ps1 &apos;$(OutDir)AttachXdt\applicationhost.xdt&apos; -DebugWait:$(XDT_DEBUGWAIT) -DisableSignatureValidation:$(XDT_DISABLESIGNATUREVALIDATION) -ForAttach } &quot;" />
+    <Exec Command="$(GenerationPowerShellCommand) &quot;&amp; { &amp; $(GenerationScriptPath) $(ApplicationHostCommonParams) -OutputXdtFilePath &apos;$(OutDir)applicationhost.xdt&apos; } &quot;" />
+    <Exec Command="$(GenerationPowerShellCommand) &quot;&amp; { &amp; $(GenerationScriptPath) $(ApplicationHostCommonParams) -OutputXdtFilePath &apos;$(OutDir)AttachXdt\applicationhost.xdt&apos; -Attach } &quot;" />
+    <Exec Command="$(GenerationPowerShellCommand) &quot;&amp; { &amp; $(GenerationScriptPath) $(ScmApplicationHostCommonParams) -OutputXdtFilePath &apos;$(OutDir)scmApplicationhost.xdt&apos; } &quot;" />
+    <Exec Command="$(GenerationPowerShellCommand) &quot;&amp; { &amp; $(GenerationScriptPath) $(ScmApplicationHostCommonParams) -OutputXdtFilePath &apos;$(OutDir)AttachXdt\scmApplicationhost.xdt&apos; -Attach } &quot;" />
   </Target>
 </Project>

--- a/src/InstrumentationEngine.Preinstall/InstrumentationEngine.Preinstall.csproj
+++ b/src/InstrumentationEngine.Preinstall/InstrumentationEngine.Preinstall.csproj
@@ -95,6 +95,8 @@
       <XDT_DISABLESIGNATUREVALIDATION Condition=" '$(XDT_DISABLESIGNATUREVALIDATION)'=='' ">$True</XDT_DISABLESIGNATUREVALIDATION>
       <XDT_DEBUGWAIT Condition=" '$(XDT_DEBUGWAIT)'=='' ">$False</XDT_DEBUGWAIT>
     </PropertyGroup>
+    <MakeDir Directories="$(OutDir)AttachXdt" />
     <Exec Command="%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -executionpolicy Unrestricted -Command &quot;&amp; { &amp; $(BuildFilesDir)\Scripts\PrivateXdt\GeneratePrivateXdt.ps1 &apos;$(OutDir)applicationhost.xdt&apos; -DebugWait:$(XDT_DEBUGWAIT) -DisableSignatureValidation:$(XDT_DISABLESIGNATUREVALIDATION) } &quot;" />
+    <Exec Command="%WINDIR%\System32\WindowsPowerShell\v1.0\powershell.exe -NoProfile -executionpolicy Unrestricted -Command &quot;&amp; { &amp; $(BuildFilesDir)\Scripts\PrivateXdt\GeneratePrivateXdt.ps1 &apos;$(OutDir)AttachXdt\applicationhost.xdt&apos; -DebugWait:$(XDT_DEBUGWAIT) -DisableSignatureValidation:$(XDT_DISABLESIGNATUREVALIDATION) -ForAttach } &quot;" />
   </Target>
 </Project>


### PR DESCRIPTION
The private site extension XDT generation creates an XDT file that applies the engine and profiler environment variables automatically when the site extension is applied. For testing the attach scenario, we need to have an XDT that removes the environment variables in order to mimic the production scenario where the InstrumentationEngine preinstalled site extension is not enabled.