### PR TITLE
Make nested types report fully qualified names.

### DIFF
--- a/src/InstrumentationEngine/TokenType.cpp
+++ b/src/InstrumentationEngine/TokenType.cpp
@@ -70,7 +70,7 @@ HRESULT MicrosoftInstrumentationEngine::CTokenType::GetName(_Out_ BSTR* pbstrNam
             IfFailRet(pImport->GetTypeDefProps(m_token, nameBuffer.data(), cchLength, &cchLength, nullptr, nullptr));
             fullName += nameBuffer.data();
 
-            m_name = CComBSTR(static_cast<ULONG>(fullName.length()+1), fullName.c_str());
+            m_name = CComBSTR(fullName.c_str());
         }
         else if (TypeFromToken(m_token) == mdtTypeRef)
         {

--- a/src/InstrumentationEngine/TokenType.cpp
+++ b/src/InstrumentationEngine/TokenType.cpp
@@ -53,9 +53,9 @@ HRESULT MicrosoftInstrumentationEngine::CTokenType::GetName(_Out_ BSTR* pbstrNam
                     nameBuffer.resize(cchLength);
                 }
 
-                // Add nested class names separated by a "/".
+                // Add nested class names separated by a "+".
                 IfFailRet(pImport->GetTypeDefProps(tkEnclosing, nameBuffer.data(), cchLength, &cchLength, nullptr, nullptr));
-                fullName.insert(0, _T("/"));
+                fullName.insert(0, _T("+"));
                 fullName.insert(0, nameBuffer.data());
 
                 tkCurrent = tkEnclosing;

--- a/src/InstrumentationEngine/TokenType.h
+++ b/src/InstrumentationEngine/TokenType.h
@@ -10,36 +10,36 @@ namespace MicrosoftInstrumentationEngine
 {
     class CTokenType : public ITokenType, public CType
     {
-        friend class CTypeCreator;
+    friend class CTypeCreator;
 
-        private:
-            mdToken m_token;
-            CComPtr<IModuleInfo> m_pOwningModule;
-            CComBSTR m_name;
+    private:
+        mdToken m_token;
+        CComPtr<IModuleInfo> m_pOwningModule;
+        CComBSTR m_name;
 
-        public:
-            DEFINE_DELEGATED_REFCOUNT_ADDREF(CTokenType);
-            DEFINE_DELEGATED_REFCOUNT_RELEASE(CTokenType);
-            STDMETHOD(QueryInterface)(_In_ REFIID riid, _Out_ void **ppvObject) override
-            {
-                return ImplQueryInterface(
-                    static_cast<IType*>(this),
-                    static_cast<ITokenType*>(this),
-                    static_cast<IDataContainer*>(static_cast<CDataContainer*>(this)),
-                    riid,
-                    ppvObject
-                    );
-            }
+    public:
+        DEFINE_DELEGATED_REFCOUNT_ADDREF(CTokenType);
+        DEFINE_DELEGATED_REFCOUNT_RELEASE(CTokenType);
+        STDMETHOD(QueryInterface)(_In_ REFIID riid, _Out_ void **ppvObject) override
+        {
+            return ImplQueryInterface(
+                static_cast<IType*>(this),
+                static_cast<ITokenType*>(this),
+                static_cast<IDataContainer*>(static_cast<CDataContainer*>(this)),
+                riid,
+                ppvObject
+                );
+        }
 
-        // ITokenType methods.
-        public:
-            STDMETHOD(GetToken)(_Out_ mdToken* token) override;
-            STDMETHOD(GetOwningModule)(_Out_ IModuleInfo** ppOwningModule) override;
+    // ITokenType methods.
+    public:
+        STDMETHOD(GetToken)(_Out_ mdToken* token) override;
+        STDMETHOD(GetOwningModule)(_Out_ IModuleInfo** ppOwningModule) override;
 
-        public:
-            STDMETHOD(GetName)(_Out_ BSTR* pbstrName) override;
-            STDMETHOD(AddToSignature)(_In_ ISignatureBuilder* pSignatureBuilder) override;
-        protected:
-            CTokenType(_In_ IModuleInfo* module, _In_ mdToken token, _In_ CorElementType type);
+    public:
+        STDMETHOD(GetName)(_Out_ BSTR* pbstrName) override;
+        STDMETHOD(AddToSignature)(_In_ ISignatureBuilder* pSignatureBuilder) override;
+    protected:
+        CTokenType(_In_ IModuleInfo* module, _In_ mdToken token, _In_ CorElementType type);
     };
 }

--- a/src/InstrumentationEngine/TypeCreator.cpp
+++ b/src/InstrumentationEngine/TypeCreator.cpp
@@ -116,11 +116,7 @@ HRESULT MicrosoftInstrumentationEngine::CTypeCreator::FromSignature(_In_ DWORD c
         {
             mdToken tokenValue;
             currentSize += CorSigUncompressToken(&currentSignature[currentSize], &tokenValue);
-            createdType.Attach(new CTokenType(m_pModuleInfo, tokenValue, sigElement));
-            if (createdType == nullptr)
-            {
-                return E_OUTOFMEMORY;
-            }
+            IfFailRet(FromToken(sigElement, tokenValue, &createdType));
         }
         break;
     case ELEMENT_TYPE_PTR:


### PR DESCRIPTION
Updates CTokenType to give fully qualified names of typedefs, including nested types.

Before this change, nested types only reported the immediate type in which they were created. This change adds the nested types separated by '/' characters in the same way that ILDASM does.

This change is required by the fakes team because they need to be able to match full names of methods, especially for async code.

fixes #141 