### PR TITLE
Fix patching xdtextensions.dll in test extension

### DIFF
--- a/build/SiteExtensions.targets
+++ b/build/SiteExtensions.targets
@@ -46,7 +46,7 @@
       <ZipTestItem Include="@(SiteExtensionContents)">
         <Destination>$(Title)\%(RootPath)\%(RecursiveDir)</Destination>
       </ZipTestItem>
-      <ZipTestItem Include="$(InputBinCfgRoot)\AnyCPU\XdtExtensions.*"
+      <ZipTestItem Include="$(BinRoot)\$(Configuration)\AnyCPU\XdtExtensions.*"
                    Condition="'$(IncludeXdtExtensions)' == 'true'">
         <Destination>$(Title)\XdtExtensions</Destination>
       </ZipTestItem>

--- a/build/SiteExtensions.targets
+++ b/build/SiteExtensions.targets
@@ -46,7 +46,7 @@
       <ZipTestItem Include="@(SiteExtensionContents)">
         <Destination>$(Title)\%(RootPath)\%(RecursiveDir)</Destination>
       </ZipTestItem>
-      <ZipTestItem Include="$(BinRoot)\$(Configuration)\AnyCPU\XdtExtensions.*"
+      <ZipTestItem Include="$(OutputPath)\XdtExtensions.*"
                    Condition="'$(IncludeXdtExtensions)' == 'true'">
         <Destination>$(Title)\XdtExtensions</Destination>
       </ZipTestItem>


### PR DESCRIPTION
$(InputBinCfgRoot) is set in the pipeline to point to the binary artifacts produced during the build binaries stage, however the xdtextensions.dll are produced in the bin\configuration path.