### PR TITLE
Replace LoggingFlags with atomic_int

### DIFF
--- a/src/InstrumentationEngine.Lib/LoggerService.cpp
+++ b/src/InstrumentationEngine.Lib/LoggerService.cpp
@@ -67,14 +67,12 @@ HRESULT CLoggerService::GetLoggingFlags(_Out_ LoggingFlags* pLoggingFlags)
 
     IfNotInitRetUnexpected(m_initialize);
 
-    CCriticalSectionHolder holder(&m_cs);
-
     // Intentionally returning the effective flags instead of the default flags
     // (ones set by default or by SetLoggingFlags). The GetLoggingFlags method
     // is primarily meant for consumers external of the Instrumentation Engine
     // assembly to determine which flags are supported rather than literally
     // reporting what the default was or what was set by SetLoggingFlags.
-    *pLoggingFlags = m_effectiveFlags;
+    *pLoggingFlags = (LoggingFlags)m_effectiveFlags.load(std::memory_order_acquire);
 
     return S_OK;
 }
@@ -359,7 +357,8 @@ HRESULT CLoggerService::RecalculateLoggingFlags()
         effectiveFlags = static_cast<LoggingFlags>(effectiveFlags | sinkFlags);
     }
 
-    m_effectiveFlags = effectiveFlags;
+    //m_effectiveFlags = effectiveFlags;
+    m_effectiveFlags.store((int)effectiveFlags, std::memory_order_release);
 
     return S_OK;
 }

--- a/src/InstrumentationEngine.Lib/LoggerService.cpp
+++ b/src/InstrumentationEngine.Lib/LoggerService.cpp
@@ -72,7 +72,7 @@ HRESULT CLoggerService::GetLoggingFlags(_Out_ LoggingFlags* pLoggingFlags)
     // is primarily meant for consumers external of the Instrumentation Engine
     // assembly to determine which flags are supported rather than literally
     // reporting what the default was or what was set by SetLoggingFlags.
-    *pLoggingFlags = m_effectiveFlags.load();
+    *pLoggingFlags = m_effectiveFlags;
 
     return S_OK;
 }

--- a/src/InstrumentationEngine.Lib/LoggerService.cpp
+++ b/src/InstrumentationEngine.Lib/LoggerService.cpp
@@ -72,7 +72,7 @@ HRESULT CLoggerService::GetLoggingFlags(_Out_ LoggingFlags* pLoggingFlags)
     // is primarily meant for consumers external of the Instrumentation Engine
     // assembly to determine which flags are supported rather than literally
     // reporting what the default was or what was set by SetLoggingFlags.
-    *pLoggingFlags = (LoggingFlags)m_effectiveFlags.load(std::memory_order_acquire);
+    *pLoggingFlags = m_effectiveFlags.load();
 
     return S_OK;
 }
@@ -357,8 +357,7 @@ HRESULT CLoggerService::RecalculateLoggingFlags()
         effectiveFlags = static_cast<LoggingFlags>(effectiveFlags | sinkFlags);
     }
 
-    //m_effectiveFlags = effectiveFlags;
-    m_effectiveFlags.store((int)effectiveFlags, std::memory_order_release);
+    m_effectiveFlags = effectiveFlags;
 
     return S_OK;
 }

--- a/src/InstrumentationEngine.Lib/LoggerService.h
+++ b/src/InstrumentationEngine.Lib/LoggerService.h
@@ -53,7 +53,7 @@ namespace MicrosoftInstrumentationEngine
         // each of the logger sinks. This is updated each time a logger sink dependency is changed
         // e.g. calling SetLoggingFlags, SetLoggingHost, and SetLogToDebugPort.
         //
-        // We're using atomic_int here to avoid a critical section in GetLoggingFlags.
+        // We're using atomic here to avoid a critical section in GetLoggingFlags.
         std::atomic<LoggingFlags> m_effectiveFlags;
         // This is the cumulative LoggingFlags for all InstrumentationMethods
         LoggingFlags m_instrumentationMethodFlags;

--- a/src/InstrumentationEngine.Lib/LoggerService.h
+++ b/src/InstrumentationEngine.Lib/LoggerService.h
@@ -54,7 +54,7 @@ namespace MicrosoftInstrumentationEngine
         // e.g. calling SetLoggingFlags, SetLoggingHost, and SetLogToDebugPort.
         //
         // We're using atomic_int here to avoid a critical section in GetLoggingFlags.
-        std::atomic_int m_effectiveFlags;
+        std::atomic<LoggingFlags> m_effectiveFlags;
         // This is the cumulative LoggingFlags for all InstrumentationMethods
         LoggingFlags m_instrumentationMethodFlags;
 

--- a/src/InstrumentationEngine.Lib/LoggerService.h
+++ b/src/InstrumentationEngine.Lib/LoggerService.h
@@ -52,7 +52,9 @@ namespace MicrosoftInstrumentationEngine
         // The effective set of flags (flags that are in actual use) as determined by querying
         // each of the logger sinks. This is updated each time a logger sink dependency is changed
         // e.g. calling SetLoggingFlags, SetLoggingHost, and SetLogToDebugPort.
-        LoggingFlags m_effectiveFlags;
+        //
+        // We're using atomic_int here to avoid a critical section in GetLoggingFlags.
+        std::atomic_int m_effectiveFlags;
         // This is the cumulative LoggingFlags for all InstrumentationMethods
         LoggingFlags m_instrumentationMethodFlags;
 


### PR DESCRIPTION
To reduce the load of our logging infrastructure for InstrumentationMethods, this change allows us to remove the use of critical sections when getting the effective logging flags (which should not change very often). 