### PR TITLE
Disable Wpragma-pack on unix

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -149,6 +149,7 @@ macro (build_init build_language build_type)
     add_compile_options(-Wno-new-returns-null)
     add_compile_options(-Wno-deprecated-declarations)
     add_compile_options(-Wno-delete-incomplete)
+    add_compile_options(-Wno-pragma-pack)
 
     # Turn all enabled warnings into errors
     add_compile_options(-Werror)


### PR DESCRIPTION
E.g.

```
/home/hughbe/CLRInstrumentationEngine/out/Linux/CoreCLRPAL/inc/rt/pshpack1.h:36:9: note: previous '#pragma pack' directive that modifies alignment is here [Semantic Issue]
#pragma pack(1)
        ^
In file included from /home/hughbe/CLRInstrumentationEngine/src/InstrumentationEngine.Lib/ConfigurationLoader.cpp:4:
In file included from /home/hughbe/CLRInstrumentationEngine/src/InstrumentationEngine.Lib/./stdafx.h:45:
/home/hughbe/CLRInstrumentationEngine/out/Linux/CoreCLRPAL/inc/cor.h:1951:10: error: the current #pragma pack aligment value is modified in the included file [-Werror,-Wpragma-pack,Semantic Issue]
#include <poppack.h>
         ^
/home/hughbe/CLRInstrumentationEngine/out/Linux/CoreCLRPAL/inc/rt/poppack.h:37:9: note: previous '#pragma pack' directive that modifies alignment is here [Semantic Issue]
#pragma pack()
        ^
18 errors generated.
18 errors generated
```

See https://github.com/dotnet/coreclr/pull/16855/files
