### PR TITLE
Don't define builtins on newer clang versions in palrt2.h

### DIFF
--- a/src/InstrumentationEngine.Lib/refcount.cpp
+++ b/src/InstrumentationEngine.Lib/refcount.cpp
@@ -242,7 +242,7 @@ namespace MicrosoftInstrumentationEngine
 
     ULONG CModuleRefCount::GetModuleUsage(void)
     {
-        return (ULONG)_InterlockedOr((volatile PLONG)&s_ulcModuleRef, 0);
+        return (ULONG)_InterlockedOr((PLONG)&s_ulcModuleRef, 0);
     }
 
 }

--- a/src/InstrumentationEngine.Lib/refcount.cpp
+++ b/src/InstrumentationEngine.Lib/refcount.cpp
@@ -235,14 +235,14 @@ namespace MicrosoftInstrumentationEngine
     // ----------------------------------------------------------------------------
     // CModuleRefCount
 
-    ULONG CModuleRefCount::s_ulcModuleRef = 0;
+    volatile ULONG CModuleRefCount::s_ulcModuleRef = 0;
 
     // ----------------------------------------------------------------------------
     // module ref count support
 
     ULONG CModuleRefCount::GetModuleUsage(void)
     {
-        return (ULONG)_InterlockedOr((PLONG)&s_ulcModuleRef, 0);
+        return (ULONG)_InterlockedOr((volatile PLONG)&s_ulcModuleRef, 0);
     }
 
 }

--- a/src/InstrumentationEngine.Lib/refcount.h
+++ b/src/InstrumentationEngine.Lib/refcount.h
@@ -201,7 +201,7 @@ namespace MicrosoftInstrumentationEngine
         }
         static ULONG GetModuleUsage(void);
     private:
-        static ULONG s_ulcModuleRef;
+        static volatile ULONG s_ulcModuleRef;
     };
 }
 

--- a/src/unix/inc/palrt2.h
+++ b/src/unix/inc/palrt2.h
@@ -44,30 +44,40 @@ inline void * _recalloc(void *memblock, size_t num, size_t size)
 #define ULLONG_MAX    0xffffffffffffffffu       /* maximum unsigned long long int value */
 EXTERN_C PALAPI errno_t _ultow_s( unsigned long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
 
+#if !__has_builtin(_InterlockedIncrement)
 inline LONG _InterlockedIncrement(LONG volatile * _Addend)
 {
     return InterlockedIncrement(_Addend);
 }
+#endif
 
+#if !__has_builtin(_InterlockedDecrement)
 inline LONG _InterlockedDecrement(LONG volatile * _Addend)
 {
     return InterlockedDecrement(_Addend);
 }
+#endif
 
+#if !__has_builtin(_InterlockedOr)
 inline LONG _InterlockedOr(LONG volatile * Destination, LONG Value)
 {
     return InterlockedOr(Destination, Value);
 }
+#endif
 
+#if !__has_builtin(_InterlockedAnd)
 inline LONG _InterlockedAnd(LONG volatile * Destination, LONG Value)
 {
     return InterlockedAnd(Destination, Value);
 }
+#endif
 
+#if !__has_builtin(_InterlockedExchange)
 inline LONG _InterlockedExchange(LONG volatile * Target, LONG Value)
 {
     return InterlockedExchange(Target, Value);
 }
+#endif
 
 // --- guid ---
 __inline int InlineIsEqualGUID(REFGUID rguid1, REFGUID rguid2)


### PR DESCRIPTION
Avoids errors such as `error: definition of builtin function '_InterlockedIncrement`