### PR TITLE
Include iconv.h in ConfigurationLoader.cpp

### DIFF
--- a/src/InstrumentationEngine.Lib/ConfigurationLoader.cpp
+++ b/src/InstrumentationEngine.Lib/ConfigurationLoader.cpp
@@ -219,6 +219,7 @@ HRESULT CConfigurationLoaderHelper::ProcessInstrumentationMethodNode(_In_ BSTR b
 #else
 
 #include <string.h>
+#include <iconv.h>
 
 HRESULT CConfigurationLoaderHelper::LoadConfiguration(_In_ BSTR bstrConfigPath, _In_ std::vector<CInstrumentationMethod*>& methods)
 {


### PR DESCRIPTION
Seems like this is implicitly included on my ubuntu WSL distro, but it isn't on mac etc.

This can get some erorrs e.g. for `iconv_t icnv = iconv_open("UTF-16LE", "UTF-8");` we get 'iconv_t' was not declared in this scope