### PR TITLE
Add cached logging flag

### DIFF
--- a/src/InstrumentationEngine.Lib/LoggerService.cpp
+++ b/src/InstrumentationEngine.Lib/LoggerService.cpp
@@ -133,13 +133,9 @@ void CLoggerService::SetLogToDebugPort(_In_ bool enable)
     RecalculateLoggingFlags();
 }
 
-HRESULT CLoggerService::Initialize(_In_ std::function<void(const LoggingFlags&)> callback)
+HRESULT CLoggerService::Initialize(_In_ std::function<void(const LoggingFlags&)> loggingFlagsCallback)
 {
-    if (callback != nullptr)
-    {
-        m_LoggingFlagsCallback = callback;
-    }
-
+    m_LoggingFlagsCallback = loggingFlagsCallback;
     return m_initialize.Get();
 }
 

--- a/src/InstrumentationEngine.Lib/LoggerService.cpp
+++ b/src/InstrumentationEngine.Lib/LoggerService.cpp
@@ -133,8 +133,13 @@ void CLoggerService::SetLogToDebugPort(_In_ bool enable)
     RecalculateLoggingFlags();
 }
 
-HRESULT CLoggerService::Initialize()
+HRESULT CLoggerService::Initialize(_In_ std::function<void(const LoggingFlags&)> callback)
 {
+    if (callback != nullptr)
+    {
+        m_LoggingFlagsCallback = callback;
+    }
+
     return m_initialize.Get();
 }
 
@@ -358,7 +363,10 @@ HRESULT CLoggerService::RecalculateLoggingFlags()
     }
 
     m_effectiveFlags = effectiveFlags;
-    CLogging::SetCachedLoggingFlag(effectiveFlags);
+    if (m_LoggingFlagsCallback != nullptr)
+    {
+        m_LoggingFlagsCallback(effectiveFlags);
+    }
 
     return S_OK;
 }

--- a/src/InstrumentationEngine.Lib/LoggerService.cpp
+++ b/src/InstrumentationEngine.Lib/LoggerService.cpp
@@ -358,6 +358,7 @@ HRESULT CLoggerService::RecalculateLoggingFlags()
     }
 
     m_effectiveFlags = effectiveFlags;
+    CLogging::SetCachedLoggingFlag(effectiveFlags);
 
     return S_OK;
 }

--- a/src/InstrumentationEngine.Lib/LoggerService.h
+++ b/src/InstrumentationEngine.Lib/LoggerService.h
@@ -108,7 +108,7 @@ namespace MicrosoftInstrumentationEngine
 
         static LoggingFlags ExtractLoggingFlags(_In_ LPCWSTR wszRequestedFlagNames);
 
-        HRESULT Initialize(_In_ std::function<void(const LoggingFlags&)> callback = nullptr);
+        HRESULT Initialize(_In_ std::function<void(const LoggingFlags&)> loggingFlagsCallback = nullptr);
 
         void LogMessage(_In_ LPCWSTR wszMessage, _In_ va_list argptr);
         void LogMessage(_In_ LPCWSTR wszMessage, ...);

--- a/src/InstrumentationEngine.Lib/LoggerService.h
+++ b/src/InstrumentationEngine.Lib/LoggerService.h
@@ -66,6 +66,9 @@ namespace MicrosoftInstrumentationEngine
         // the version of Clang, consider refactoring this vector of GUIDs to a set.
         std::unordered_map<LoggingFlags, std::vector<GUID>> m_loggingFlagsToInstrumentationMethodsMap;
 
+        // This function type will get invoked when the effective flags gets updated.
+        std::function<void(const LoggingFlags&)> m_LoggingFlagsCallback;
+
         bool m_fLogToDebugPort;
         CInitOnce m_initialize;
         ATL::CComPtr<IProfilerManagerLoggingHost> m_pLoggingHost;
@@ -105,7 +108,7 @@ namespace MicrosoftInstrumentationEngine
 
         static LoggingFlags ExtractLoggingFlags(_In_ LPCWSTR wszRequestedFlagNames);
 
-        HRESULT Initialize();
+        HRESULT Initialize(_In_ std::function<void(const LoggingFlags&)> callback = nullptr);
 
         void LogMessage(_In_ LPCWSTR wszMessage, _In_ va_list argptr);
         void LogMessage(_In_ LPCWSTR wszMessage, ...);

--- a/src/InstrumentationEngine.Lib/Logging.cpp
+++ b/src/InstrumentationEngine.Lib/Logging.cpp
@@ -10,6 +10,7 @@ using namespace std;
 CInitOnce CLogging::s_initialize([]() { return InitializeCore(); });
 CSingleton<CLoggerService> CLogging::s_loggerService;
 atomic_size_t CLogging::s_initCount(0);
+atomic<LoggingFlags> CLogging::s_cachedFlags(LoggingFlags_None);
 
 // static
 bool CLogging::AllowLogEntry(_In_ LoggingFlags flags)
@@ -24,7 +25,10 @@ HRESULT CLogging::GetLoggingFlags(_Out_ LoggingFlags* pLoggingFlags)
 {
     IfNotInitRetUnexpected(s_initialize);
 
-    return s_loggerService.Get()->GetLoggingFlags(pLoggingFlags);
+    IfNullRetPointerNoLog(pLoggingFlags);
+
+    *pLoggingFlags = s_cachedFlags;
+    return S_OK;
 }
 
 // static
@@ -79,7 +83,6 @@ void CLogging::LogDumpMessage(_In_ const WCHAR* wszMessage, ...)
         va_end(argptr);
     }
 }
-
 
 // static
 void CLogging::VLogMessage(_In_ const WCHAR* wszMessage, _In_ va_list argptr)
@@ -172,6 +175,15 @@ HRESULT CLogging::SetLogFileLevel(_In_ LoggingFlags fileLogFlags)
     IfNotInitRetUnexpected(s_initialize);
 
     return s_loggerService.Get()->SetLogFileLevel(fileLogFlags);
+}
+
+// static
+HRESULT CLogging::SetCachedLoggingFlag(_In_ LoggingFlags flags)
+{
+    // Do not check initialization as that can cause an infinite loop.
+
+    s_cachedFlags = flags;
+    return S_OK;
 }
 
 CLogging::XmlDumpHelper::XmlDumpHelper(const WCHAR* tag, const unsigned int indent)

--- a/src/InstrumentationEngine.Lib/Logging.cpp
+++ b/src/InstrumentationEngine.Lib/Logging.cpp
@@ -121,7 +121,7 @@ HRESULT CLogging::Initialize()
 // static
 HRESULT CLogging::InitializeCore()
 {
-    return s_loggerService.Get()->Initialize();
+    return s_loggerService.Get()->Initialize(OnLoggingFlagsUpdated);
 }
 
 // static
@@ -178,12 +178,9 @@ HRESULT CLogging::SetLogFileLevel(_In_ LoggingFlags fileLogFlags)
 }
 
 // static
-HRESULT CLogging::SetCachedLoggingFlag(_In_ LoggingFlags flags)
+void CLogging::OnLoggingFlagsUpdated(_In_ const LoggingFlags& flags)
 {
-    // Do not check initialization as that can cause an infinite loop.
-
     s_cachedFlags = flags;
-    return S_OK;
 }
 
 CLogging::XmlDumpHelper::XmlDumpHelper(const WCHAR* tag, const unsigned int indent)

--- a/src/InstrumentationEngine.Lib/Logging.h
+++ b/src/InstrumentationEngine.Lib/Logging.h
@@ -86,9 +86,10 @@ namespace MicrosoftInstrumentationEngine
         static HRESULT SetLogFilePath(_In_ LPCWSTR wszLogFilePath);
         static HRESULT SetLogFileLevel(_In_ LoggingFlags fileLogFlags);
 
-        static HRESULT SetCachedLoggingFlag(_In_ LoggingFlags flags);
-
     private:
         static HRESULT InitializeCore();
+
+        // Callback Handler
+        static void OnLoggingFlagsUpdated(_In_ const LoggingFlags& flags);
     };
 }

--- a/src/InstrumentationEngine.Lib/Logging.h
+++ b/src/InstrumentationEngine.Lib/Logging.h
@@ -52,6 +52,9 @@ namespace MicrosoftInstrumentationEngine
         static CSingleton<CLoggerService> s_loggerService;
         static std::atomic_size_t s_initCount;
 
+        // This caches the effective loggingflag of s_loggerService for performance
+        static std::atomic<LoggingFlags> s_cachedFlags;
+
     public:
         // Call this to determine if logging should be allowed for a specific log type.
         static bool AllowLogEntry(_In_ LoggingFlags flags);
@@ -82,6 +85,8 @@ namespace MicrosoftInstrumentationEngine
 
         static HRESULT SetLogFilePath(_In_ LPCWSTR wszLogFilePath);
         static HRESULT SetLogFileLevel(_In_ LoggingFlags fileLogFlags);
+
+        static HRESULT SetCachedLoggingFlag(_In_ LoggingFlags flags);
 
     private:
         static HRESULT InitializeCore();

--- a/src/InstrumentationEngine.Lib/stdafx.h
+++ b/src/InstrumentationEngine.Lib/stdafx.h
@@ -89,6 +89,8 @@ using namespace ATL;
 #include <ctime>
 #endif
 
+#include <functional>
+
 #include "Logging.h"
 #include "ImplQueryInterface.h"
 #include "refcount.h"


### PR DESCRIPTION
This allows CLogging to bypass querying the CLoggerService and use a static flag instead. On CLoggerService::RecalculateLoggingFlags(), it calls back into CLogging to update the static flag.