### PR TITLE
Support specifying CoreCLR-specific RawProfilerHook.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,10 @@ Please format the changes as follows:
 
 ## 1.0.33
 + New:
+  + Update Ubuntu build image to 18.04 and use Clang 3.9 on Ubuntu
+  + Add support for specifying a coreCLR-specific RawProfilerHook
 + BugFixes:
+  + Improve performance with logging by caching logging flags as an atomic bool in CLoggerService
 + Updates:
 
 # 1.0.32

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -50,8 +50,10 @@ The RawProfilerHook allows one additional profiler that has not yet on-boarded t
 
 | Variable | Value | Description |
 |-|-|-|
-MicrosoftInstrumentationEngine_RawProfilerHook|"{GUID}"|This would be the value set to CORECLR/COR_PROFILER.
-MicrosoftInstrumentationEngine_RawProfilerHookPath_32/64|"[FULL PATH TO raw profiler dll]"|This would be the value set to CORECLR/COR_PROFILER_PATH_32/64.
+MicrosoftInstrumentationEngine_RawProfilerHook|"{GUID}"|This would be the value set to COR_PROFILER.
+MicrosoftInstrumentationEngine_CoreRawProfilerHook|"{GUID}"|This would be the value set to CORECLR_PROFILER. Falls back to MicrosoftInstrumentationEngine_RawProfilerHook if this is not set.
+MicrosoftInstrumentationEngine_RawProfilerHookPath_32/64|"[FULL PATH TO raw profiler dll]"|This would be the value set to COR_PROFILER_PATH_32/64.
+MicrosoftInstrumentationEngine_CoreRawProfilerHookPath_32/64|"[FULL PATH TO raw profiler dll]"|This would be the value set to CORECLR_PROFILER_PATH_32/64. Only checked if MicrosoftInstrumentationEngine_CoreRawProfilerHook is set.
 
 ## Deprecated as of Version 1.0.22
 The following variables allowed custom ExtensionHosts for the InstrumentationEngine. The responsibility of the ExtensionsHost involves setting

--- a/src/InstrumentationEngine.Lib/RawProfilerHookSettingsReader.cpp
+++ b/src/InstrumentationEngine.Lib/RawProfilerHookSettingsReader.cpp
@@ -86,7 +86,6 @@ namespace MicrosoftInstrumentationEngine
             if (S_FALSE == hr)
             {
                 CLogging::LogMessage(_T("Examining desktop CLR path environment variable (no bitness): %s"), cszRawProfilerHookPathVarNameNoBitness);
-
                 IfFailRet(GetEnvironmentVariableWrapper(cszRawProfilerHookPathVarNameNoBitness, strRawProfilerHookModulePath));
             }
         }
@@ -102,14 +101,14 @@ namespace MicrosoftInstrumentationEngine
     }
 
     HRESULT CRawProfilerHookSettingsReader::GetEnvironmentVariableWrapper(
-        _In_ const std::wstring& strVarName,
+        _In_ const std::wstring& strVariableName,
         _Out_ std::wstring& strVariableValue)
     {
         const int MaxVariableSize = 1024;
         std::wstring strVariableValueTemp(1024, L'\n');
 
         auto dwCount = ::GetEnvironmentVariable(
-            strVarName.c_str(),
+            strVariableName.c_str(),
             &strVariableValueTemp[0],
             MaxVariableSize);
 

--- a/src/InstrumentationEngine.Lib/RawProfilerHookSettingsReader.h
+++ b/src/InstrumentationEngine.Lib/RawProfilerHookSettingsReader.h
@@ -12,8 +12,6 @@ namespace MicrosoftInstrumentationEngine
     public:
         CRawProfilerHookSettingsReader() noexcept;
 
-        HRESULT ReadSettings(COR_PRF_RUNTIME_TYPE runtimeType, GUID& clsidRawProfilerHookComponent, std::wstring& strRawProfilerHookModulePath);
-
         HRESULT ReadSettings(
             _In_ COR_PRF_RUNTIME_TYPE runtimeType,
             _Out_ GUID& clsidRawProfilerHookComponent,

--- a/src/InstrumentationEngine.Lib/RawProfilerHookSettingsReader.h
+++ b/src/InstrumentationEngine.Lib/RawProfilerHookSettingsReader.h
@@ -12,11 +12,14 @@ namespace MicrosoftInstrumentationEngine
     public:
         CRawProfilerHookSettingsReader() noexcept;
 
+        HRESULT ReadSettings(COR_PRF_RUNTIME_TYPE runtimeType, GUID& clsidRawProfilerHookComponent, std::wstring& strRawProfilerHookModulePath);
+
         HRESULT ReadSettings(
+            _In_ COR_PRF_RUNTIME_TYPE runtimeType,
             _Out_ GUID& clsidRawProfilerHookComponent,
             _Inout_ std::wstring& strRawProfilerHookModulePath);
     private:
-        HRESULT GetEnvironmentVariable(
+        HRESULT GetEnvironmentVariableWrapper(
             _In_ const std::wstring& strVariableName,
             _Out_ std::wstring& strVariableValue);
     }; // CRawProfilerHookLoader

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -1064,7 +1064,7 @@ HRESULT CProfilerManager::SetupRawProfiler()
     wstring wstrRawProfilerModulePath;
 
     CRawProfilerHookSettingsReader rawProfilerHookSettingsReader;
-    IfFailRet(rawProfilerHookSettingsReader.ReadSettings(guidRawProfilerClsid, wstrRawProfilerModulePath));
+    IfFailRet(rawProfilerHookSettingsReader.ReadSettings(m_runtimeType, guidRawProfilerClsid, wstrRawProfilerModulePath));
 
     if (S_OK == hr)
     {


### PR DESCRIPTION
This change introduces the ability to specify CoreCLR-specific RawProfilerHook. If the CoreCLR RPH variables are not set, CLRIE falls back to the original RPH variables.

The following variables are supported:
* MicrosoftInstrumentationEngine_CoreRawProfilerHook
* MicrosoftInstrumentationEngine_CoreRawProfilerHookPath_32
* MicrosoftInstrumentationEngine_CoreRawProfilerHookPath_64