### PR TITLE
Address issue where GetILFunctionBody may be called during OnModuleLoadFinished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please format the changes as follows:
 ## 1.0.33
 + New:
 + BugFixes:
+  + Fix GetILFunctionBody call for RawProfilerHook during OnModuleLoadFinished
 + Updates:
 
 # 1.0.32

--- a/src/InstrumentationEngine/CorProfilerInfoWrapper.cpp
+++ b/src/InstrumentationEngine/CorProfilerInfoWrapper.cpp
@@ -364,6 +364,10 @@ HRESULT MicrosoftInstrumentationEngine::CCorProfilerInfoWrapper::GetILFunctionBo
 
     CComPtr<CModuleInfo> pModuleInfo;
     CComPtr<CMethodInfo> pMethodInfo;
+
+    IMAGE_COR_ILMETHOD* pMethodHeader = nullptr;
+    ULONG cbMethodSize = 0;
+
     if (SUCCEEDED(pAppDomainCollection->GetModuleInfoById(moduleId, (IModuleInfo**)&pModuleInfo)))
     {
         hr = pModuleInfo->GetMethodInfoByToken(methodToken, &pMethodInfo);
@@ -371,14 +375,18 @@ HRESULT MicrosoftInstrumentationEngine::CCorProfilerInfoWrapper::GetILFunctionBo
         {
             return pMethodInfo->GetIntermediateRenderedFunctionBody(ppMethodHeader, pcbMethodSize);
         }
+        // Method info wasn't instrumented by an instrumentation method. Ask the module info for the il.
+        // This will properly manage the cache of original il bytes.
+        IfFailRet(pModuleInfo->GetMethodIl(m_pRealCorProfilerInfo, methodToken, (IMAGE_COR_ILMETHOD**)&pMethodHeader, &cbMethodSize));
     }
-
-    IMAGE_COR_ILMETHOD* pMethodHeader = nullptr;
-    ULONG cbMethodSize = 0;
-
-    // Method info wasn't instrumented by an instrumentation method. Ask the module info for the il.
-    // This will properly manage the cache of original il bytes.
-    IfFailRet(pModuleInfo->GetMethodIl(m_pRealCorProfilerInfo, methodToken, (IMAGE_COR_ILMETHOD**)&pMethodHeader, &cbMethodSize));
+    else
+    {
+        // If this CorProfilerInfoWrapper::GetILFunctionBody() is called during OnModuleLoadFinished
+        // instead of ModuleAttachedToAssembly callback (which can happen for Raw profilers, the 
+        // assembly information does not yet exist and the ModuleInfo is not yet constructed. We will
+        // not hit our cached map of ModuleId to CModuleInfo and instead call the real profiler intead.
+        IfFailRet(m_pRealCorProfilerInfo->GetILFunctionBody(moduleId, methodToken, (LPCBYTE*)&pMethodHeader, &cbMethodSize));
+    }
 
     if (ppMethodHeader != nullptr)
     {

--- a/src/InstrumentationEngine/CorProfilerInfoWrapper.cpp
+++ b/src/InstrumentationEngine/CorProfilerInfoWrapper.cpp
@@ -382,9 +382,9 @@ HRESULT MicrosoftInstrumentationEngine::CCorProfilerInfoWrapper::GetILFunctionBo
     else
     {
         // If this CorProfilerInfoWrapper::GetILFunctionBody() is called during OnModuleLoadFinished
-        // instead of ModuleAttachedToAssembly callback (which can happen for Raw profilers, the 
+        // instead of ModuleAttachedToAssembly callback (which can happen for raw profilers), the 
         // assembly information does not yet exist and the ModuleInfo is not yet constructed. We will
-        // not hit our cached map of ModuleId to CModuleInfo and instead call the real profiler intead.
+        // not hit our cached map of ModuleId to CModuleInfo and instead call the real profiler.
         IfFailRet(m_pRealCorProfilerInfo->GetILFunctionBody(moduleId, methodToken, (LPCBYTE*)&pMethodHeader, &cbMethodSize));
     }
 

--- a/tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.vcxproj
+++ b/tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.vcxproj
@@ -108,8 +108,16 @@
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="*.cpp" Exclude="stdafx.cpp" />
-    <ClInclude Include="*.h" />
+    <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="NaglerInstrumentationMethod.cpp" />
+    <ClCompile Include="NaglerInstrumentationMethodHost.cpp" />
+    <ClInclude Include="dllmain.h" />
+    <ClInclude Include="NaglerInstrumentationMethod.h" />
+    <ClInclude Include="NaglerInstrumentMethodEntry.h" />
+    <ClInclude Include="resource.h" />
+    <ClInclude Include="stdafx.h" />
+    <ClInclude Include="targetver.h" />
+    <ClInclude Include="Util.h" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="NaglerInstrumentationMethod_x64.xml">


### PR DESCRIPTION
There are two callbacks associated with module load completion. ICorProfilerCallback::ModuleLoadFinished occurs when the module is successfully loaded and the associated moduleId is valid for use. However the module does not know its associated assembly until ICorProfilerCallback::ModuleAttachedToAssembly which occurs later.

CLRIE constructs a CModuleInfo object for each moduleId and populates a cached mapping of moduleId to moduleInfo during ModuleAttachedToAssembly. CLRIE then reports to InstrumentationMethods of the IInstrumentationMethod::OnModuleLoaded event; no event is reported to InstrumentationMethods during the actual ModuleLoadFinished callback.

The bug here is that GetILFunctionBody is valid for use during ModuleLoadFinished callback and profilers on the RawProfilerHook will still receive this callback and may start instrumentation. CLRIE presents a CorProfilerInfoWrapper to raw profilers which exposes its own GetILFunctionBody that interacts with the moduleId to moduleinfo via the cached map. During ModuleLoadFinished, there is no CModuleInfo constructed yet, so raw profilers that call GetILFunctionBody will encounter a nullptr exception.

The fix is to ignore CLRIE's cache altogether and just pass the raw profiler's request to the actual profiler's GetILFunctionBody.