### PR TITLE
Check if token is nil before trying to get the nested class properties.

### DIFF
--- a/src/InstrumentationEngine/TokenType.cpp
+++ b/src/InstrumentationEngine/TokenType.cpp
@@ -45,7 +45,7 @@ HRESULT MicrosoftInstrumentationEngine::CTokenType::GetName(_Out_ BSTR* pbstrNam
             tstring fullName;
             vector<WCHAR> nameBuffer(100);
             ULONG cchLength = 0;
-            while ((pImport->GetNestedClassProps(tkCurrent, &tkEnclosing) == S_OK) && (tkEnclosing != mdTokenNil))
+            while (!IsNilToken(tkCurrent) && (pImport->GetNestedClassProps(tkCurrent, &tkEnclosing) == S_OK) && (tkEnclosing != mdTokenNil))
             {
                 IfFailRet(pImport->GetTypeDefProps(tkEnclosing, nullptr, 0, &cchLength, nullptr, nullptr));
                 if (nameBuffer.size() < cchLength)


### PR DESCRIPTION
Debug version of dotnet will fail fast because CLRIE passes in a nil token when calling GetNestedClassProps in order to calculate the name of a token. This fixes the by checking if the token is nil before calling the method.