### PR TITLE
Update AssemblyInfo GetModules to set IEnumModuleInfo

### DIFF
--- a/src/InstrumentationEngine/AssemblyInfo.cpp
+++ b/src/InstrumentationEngine/AssemblyInfo.cpp
@@ -168,6 +168,9 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModules(_In_ ULONG cMo
 
     pEnumerator->Initialize(vecModules);
 
+    *ppModuleInfos = (IEnumModuleInfo*)pEnumerator;
+    (*ppModuleInfos)->AddRef();
+
     CLogging::LogMessage(_T("End CAssemblyInfo::GetModules"));
 
     return hr;


### PR DESCRIPTION
`AssemblyInfo::GetModules` was always setting the provided `IEnumModuleInfo` reference to `NULL` without updating it later.