### PR TITLE
Avoid Re-creating AssemblyInfo In AssemblyLoadFinished

### DIFF
--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -1563,7 +1563,13 @@ HRESULT CProfilerManager::AssemblyLoadFinished(
     IGNORE_IN_NET20_BEGIN
 
     CComPtr<IAssemblyInfo> pAssemblyInfo;
-    IfFailRet(ConstructAssemblyInfo(assemblyId, &pAssemblyInfo));
+    hr = m_pAppDomainCollection->GetAssemblyInfoById(assemblyId, &pAssemblyInfo);
+    if (FAILED(hr))
+    {
+        // Assembly was previously created in ConstructModuleInfo during ModuleAttachedToAssembly.
+        // NOTE: This is very common as modules often load before the assembly load finishes callback
+        IfFailRet(ConstructAssemblyInfo(assemblyId, &pAssemblyInfo));
+    }
 
     // Send event to instrumentation methods
     IfFailRet(SendEventToInstrumentationMethods(&IInstrumentationMethod::OnAssemblyLoaded, (IAssemblyInfo*)(pAssemblyInfo)));


### PR DESCRIPTION
An instance of `AssemblyInfo` is created during `ModuleLoadFinished` if it doesn't already exist. That instance is added to the `ModuleInfo` and the `AppDomainInfo`. 

`AssemblyLoadFinished` creates a new `AssemblyInfo` regardless and will overwrite the existing `AssemblyInfo` in the `AppDomainInfo` assembly collection.

This PR performs the same check for an existing `AssemblyInfo` in `AssemblyLoadFinished` and reuses the same instance.