### PR TITLE
Ensure AddNewExceptionClause stores the new clause

### DIFF
--- a/src/InstrumentationEngine/ExceptionSection.cpp
+++ b/src/InstrumentationEngine/ExceptionSection.cpp
@@ -275,7 +275,7 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::AddNewExceptionClause
     IfFailRet(FindExceptionClauseInsertionPoint(pExceptionClause, iter));
     m_exceptionClauses.insert(iter, (IExceptionClause*)pExceptionClause);
 
-    *ppExceptionClause = pExceptionClause;
+    *ppExceptionClause = pExceptionClause.Detach();
 
     CLogging::LogMessage(_T("End CExceptionSection::CreateExceptionClause"));
 

--- a/src/InstrumentationEngine/ExceptionSection.cpp
+++ b/src/InstrumentationEngine/ExceptionSection.cpp
@@ -275,6 +275,8 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::AddNewExceptionClause
     IfFailRet(FindExceptionClauseInsertionPoint(pExceptionClause, iter));
     m_exceptionClauses.insert(iter, (IExceptionClause*)pExceptionClause);
 
+    *ppExceptionClause = pExceptionClause;
+
     CLogging::LogMessage(_T("End CExceptionSection::CreateExceptionClause"));
 
     return hr;


### PR DESCRIPTION
Currently `AddNewExceptionClause` asserts if `ppExceptionClause` is a null pointer, but it doesn't assign anything to it.