### PR TITLE
Effort to move over to main branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,7 +24,7 @@ or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any addi
 
 Active development is happening in `develop` branch.
 
-Last released version is in `master` branch.
+Last released version is in `main` branch.
 
 ## Submitting your Pull Request:
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Develop Branch: [![Build Status](https://dev.azure.com/ms/CLRInstrumentationEngine/_apis/build/status/CI-Yaml?branchName=develop)](https://dev.azure.com/ms/CLRInstrumentationEngine/_build/latest?definitionId=275&branchName=develop)
 
-Master Branch: [![Build Status](https://devdiv.visualstudio.com/DevDiv/_apis/build/status/ClrInstrumentationEngine/GitHub/ClrInstrumentationEngine-Signed-Yaml?branchName=master)](https://devdiv.visualstudio.com/DevDiv/_build/latest?definitionId=11311&branchName=master)
+Main Branch: [![Build Status](https://devdiv.visualstudio.com/DevDiv/_apis/build/status/ClrInstrumentationEngine/GitHub/ClrInstrumentationEngine-Signed-Yaml?branchName=main)](https://devdiv.visualstudio.com/DevDiv/_build/latest?definitionId=11311&branchName=main)
 
 ## Overview
 

--- a/build/yaml/pipelines/codeanalysis.yaml
+++ b/build/yaml/pipelines/codeanalysis.yaml
@@ -15,7 +15,7 @@ schedules:
   displayName: Weekly Static Analysis
   branches:
     include:
-    - master
+    - main
 
 variables:
   TeamName: ClrInstrumentationEngine

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,6 +1,6 @@
 # Releasing the CLR Instrumentation Engine
 
-Release occurs from the Master branch. Please notify clrieowners@microsoft.com to initiate the release process.
+Release occurs from the `main` branch. Please notify clrieowners@microsoft.com to initiate the release process.
 
 ## Microsoft Internal Process
 
@@ -16,8 +16,8 @@ automatically publishes artifacts to the internal NuGet feed with a preview vers
 Based on the changes and targeted platform releases, impacted scenarios and partner teams should be involved in testing for regressions.
 
 ### Release Phase
-1.  Once testing completes, PR to merge develop branch to master branch
-2.  Manually run the [Master-Signed](https://devdiv.visualstudio.com/DevDiv/_build/index?context=allDefinitions&path=%5CClrInstrumentationEngine%5CGitHub&definitionId=10055&_a=completed) build to create release artifacts
+1.  Once testing completes, PR to merge develop branch to main branch
+2.  Manually run the [Signed](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=11311) build to create release artifacts
 3.  Manually run the
 [CLR Instrumentation Engine Release](https://devdiv.visualstudio.com/DevDiv/_releases2?view=all&definitionId=901)
 pipeline which publishes artifacts with release version (eg. 1.0.15)


### PR DESCRIPTION
See https://www.hanselman.com/blog/EasilyRenameYourGitDefaultBranchFromMasterToMain.aspx

CLRIE repo is a little strange since we use the "develop" branch as default and "master/main" as our release branch. Luckily this setup made the transition much easier.