### PR TITLE
Fix C6385 - Buffer overrun warning

### DIFF
--- a/src/InstrumentationEngine.Lib/EnumeratorImpl.h
+++ b/src/InstrumentationEngine.Lib/EnumeratorImpl.h
@@ -46,7 +46,7 @@ namespace MicrosoftInstrumentationEngine
         {
             HRESULT hr = S_OK;
 
-            if (dwLength > 0)
+            if (dwLength >= 0)
             {
                 m_members.Attach(new CComPtr<ENUM_ITEM_TYPE>[dwLength]);
                 if (!m_members)
@@ -74,7 +74,7 @@ namespace MicrosoftInstrumentationEngine
         {
             HRESULT hr = S_OK;
 
-            if (members.size() > 0)
+            if (members.size() >= 0)
             {
                 m_members.Attach(new CComPtr<ENUM_ITEM_TYPE>[members.size()]);
                 if (!m_members)

--- a/src/InstrumentationEngine.Lib/EnumeratorImpl.h
+++ b/src/InstrumentationEngine.Lib/EnumeratorImpl.h
@@ -46,7 +46,7 @@ namespace MicrosoftInstrumentationEngine
         {
             HRESULT hr = S_OK;
 
-            if (dwLength != 0)
+            if (dwLength > 0)
             {
                 m_members.Attach(new CComPtr<ENUM_ITEM_TYPE>[dwLength]);
                 if (!m_members)

--- a/src/InstrumentationEngine.Lib/EnumeratorImpl.h
+++ b/src/InstrumentationEngine.Lib/EnumeratorImpl.h
@@ -53,6 +53,7 @@ namespace MicrosoftInstrumentationEngine
                 {
                     return E_OUTOFMEMORY;
                 }
+                m_dwLength = dwLength;
 
                 for (DWORD i = 0; i < m_dwLength; i++)
                 {

--- a/src/InstrumentationEngine.Lib/EnumeratorImpl.h
+++ b/src/InstrumentationEngine.Lib/EnumeratorImpl.h
@@ -60,6 +60,10 @@ namespace MicrosoftInstrumentationEngine
                     m_members[i] = members[i];
                 }
             }
+            else
+            {
+                return E_INVALIDARG;
+            }
 
             return hr;
         }
@@ -85,6 +89,10 @@ namespace MicrosoftInstrumentationEngine
                     m_members[i] = pItem;
                     i++;
                 }
+            }
+            else
+            {
+                return E_INVALIDARG;
             }
 
             return hr;

--- a/src/InstrumentationEngine/AppDomainCollection.cpp
+++ b/src/InstrumentationEngine/AppDomainCollection.cpp
@@ -151,7 +151,7 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAppDomains(_Out
         return E_OUTOFMEMORY;
     }
 
-    pEnumerator->Initialize(vecAppDomains);
+    IfFailRet(pEnumerator->Initialize(vecAppDomains));
 
     *ppEnumAppDomains = (IEnumAppDomainInfo*)pEnumerator;
     (*ppEnumAppDomains)->AddRef();

--- a/src/InstrumentationEngine/AppDomainInfo.cpp
+++ b/src/InstrumentationEngine/AppDomainInfo.cpp
@@ -294,7 +294,7 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetAssemblies(_Out_ IEnu
         return E_OUTOFMEMORY;
     }
 
-    pEnumerator->Initialize(vecAssemblies);
+    IfFailRet(pEnumerator->Initialize(vecAssemblies));
 
     *ppAssemblyInfos = (IEnumAssemblyInfo*)pEnumerator;
     (*ppAssemblyInfos)->AddRef();
@@ -327,7 +327,7 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetModules(_Out_ IEnumMo
         return E_OUTOFMEMORY;
     }
 
-    pEnumerator->Initialize(vecModules);
+    IfFailRet(pEnumerator->Initialize(vecModules));
 
     *ppModuleInfos = (IEnumModuleInfo*)pEnumerator;
     (*ppModuleInfos)->AddRef();

--- a/src/InstrumentationEngine/AssemblyInfo.cpp
+++ b/src/InstrumentationEngine/AssemblyInfo.cpp
@@ -166,7 +166,7 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModules(_In_ ULONG cMo
         return E_OUTOFMEMORY;
     }
 
-    pEnumerator->Initialize(vecModules);
+    IfFailRet(pEnumerator->Initialize(vecModules));
 
     *ppModuleInfos = (IEnumModuleInfo*)pEnumerator;
     (*ppModuleInfos)->AddRef();

--- a/src/InstrumentationEngine/ExceptionSection.cpp
+++ b/src/InstrumentationEngine/ExceptionSection.cpp
@@ -160,7 +160,7 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::GetExceptionClauses(_
         return E_OUTOFMEMORY;
     }
 
-    pEnumerator->Initialize(m_exceptionClauses);
+    IfFailRet(pEnumerator->Initialize(m_exceptionClauses));
 
     *ppEnumExceptionClauses = pEnumerator.Detach();
 


### PR DESCRIPTION
Our CI (and PR) builds run on public Microsoft-hosted agent pools.

It appears the latest VS 2019 version now reports C6385 warning: https://dev.azure.com/ms/CLRInstrumentationEngine/_build/results?buildId=102411&view=logs&j=f206dd81-de4a-56b3-b3ee-174a7e3cd854&t=ea571755-1369-573a-2879-794004f22d5b

The issue is m_dwLength is not assigned a value during Initialize() and can cause index out of range exception. 