### PR TITLE
Fix building with MSVC v14.28 toolset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Please format the changes as follows:
 + New:
 + BugFixes:
   + Fix GetILFunctionBody call for RawProfilerHook during OnModuleLoadFinished
+  + Fix building with MSVC v14.28 by moving .h headers from ClCompile to ClInclude
 + Updates:
 
 # 1.0.32

--- a/src/ExtensionsCommon/ExtensionsCommon.vcxproj
+++ b/src/ExtensionsCommon/ExtensionsCommon.vcxproj
@@ -37,6 +37,7 @@
     <ClInclude Include="FormatMessage.h" />
     <ClInclude Include="ICodeInjector.h" />
     <ClInclude Include="ICodeInjectorFwd.h" />
+    <ClInclude Include="INativeMethodsStubs.h" />
     <ClInclude Include="InstructionDefineExtensions.h" />
     <ClInclude Include="InstrumentationEngineDefs.h" />
     <ClInclude Include="InstrumentationEngineInfraPointerDefs.h" />
@@ -75,7 +76,6 @@
     <ClCompile Include="DecorationCallbacksInfoReader.cpp" />
     <ClCompile Include="DecorationCallbacksInfoStaticReader.cpp" />
     <ClCompile Include="Exception.cpp" />
-    <ClCompile Include="INativeMethodsStubs.h" />
     <ClCompile Include="InstrumentationMethodBase.cpp" />
     <ClCompile Include="InteropInstrumentationHandler.cpp" />
     <ClCompile Include="LoadArgumentsHelper.cpp" />

--- a/tests/InstrumentationEngine.Lib.Tests/InstrumentationEngine.Lib.Tests.vcxproj
+++ b/tests/InstrumentationEngine.Lib.Tests/InstrumentationEngine.Lib.Tests.vcxproj
@@ -90,6 +90,7 @@
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
     <ClInclude Include="targetver.h" />
+    <ClInclude Include="TestLoggerService.h" />
     <ClInclude Include="TestLoggingHost.h" />
   </ItemGroup>
   <ItemGroup>
@@ -101,7 +102,6 @@
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="TestLoggerService.h" />
     <ClCompile Include="utiltests.cpp" />
   </ItemGroup>
   <ItemGroup>

--- a/tests/InstrumentationEngine.ProfilerProxy.Tests/InstrumentationEngine.ProfilerProxy.Tests.vcxproj
+++ b/tests/InstrumentationEngine.ProfilerProxy.Tests/InstrumentationEngine.ProfilerProxy.Tests.vcxproj
@@ -89,6 +89,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="stdafx.h" />
+    <ClInclude Include="TestEventLogger.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="EventLoggerTests.cpp" />
@@ -96,7 +97,6 @@
     <ClCompile Include="stdafx.cpp">
       <PrecompiledHeader>Create</PrecompiledHeader>
     </ClCompile>
-    <ClCompile Include="TestEventLogger.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\InstrumentationEngine.ProfilerProxy.Lib\InstrumentationEngine.ProfilerProxy.Lib.vcxproj">


### PR DESCRIPTION
Modify project files by moving .h header files from ClCompile to ClInclude