### PR TITLE
GetSignatureInfoFromCallToken uses parent token to get method signature

### DIFF
--- a/src/InstrumentationEngine/Instruction.cpp
+++ b/src/InstrumentationEngine/Instruction.cpp
@@ -1662,6 +1662,23 @@ HRESULT MicrosoftInstrumentationEngine::CInstruction::GetSignatureInfoFromCallTo
     CComPtr<IMetaDataImport> pMetaDataImport;
     IfFailRet(pModuleInfo->GetMetaDataImport((IUnknown**)&pMetaDataImport));
 
+    // if the callToken is a methodSpec, get the parent MethodDef/MethodRef
+    // to later retrieve the actual method signature
+    if (TypeFromToken(callToken) == mdtMethodSpec)
+    {
+        CComPtr<IMetaDataImport2> pMetaDataImport2;
+        IfFailRet(pMetaDataImport->QueryInterface(IID_IMetaDataImport2, (LPVOID*)&pMetaDataImport2));
+
+        mdToken parentCallToken = mdTokenNil;
+        IfFailRet(pMetaDataImport2->GetMethodSpecProps(
+            callToken,
+            &parentCallToken,
+            NULL,
+            NULL
+        ));
+
+        callToken = parentCallToken;
+    }
 
     PCCOR_SIGNATURE pSigUntouched = nullptr;
     PCCOR_SIGNATURE pSig = nullptr;
@@ -1698,18 +1715,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstruction::GetSignatureInfoFromCallTo
             nullptr,
             nullptr,
             nullptr
-            ));
-    }
-    else if (TypeFromToken(callToken) == mdtMethodSpec)
-    {
-        CComPtr<IMetaDataImport2> pMetaDataImport2;
-        IfFailRet(pMetaDataImport->QueryInterface(IID_IMetaDataImport2, (LPVOID*)&pMetaDataImport2));
-
-        IfFailRet(pMetaDataImport2->GetMethodSpecProps(
-            callToken,
-            nullptr,
-            &pSig,
-            &sigLength
             ));
     }
     else if (TypeFromToken(callToken) == mdtSignature)

--- a/src/InstrumentationEngine/Instruction.h
+++ b/src/InstrumentationEngine/Instruction.h
@@ -144,6 +144,8 @@ namespace MicrosoftInstrumentationEngine
         HRESULT LogInstruction(_In_ BOOL ignoreTest);
 
     private:
+        // If the callee token is a MethodSpec (generic method), the parameter count and signature returned
+        // will represent the parent method declaration/reference, not the generic parameters or generic signature.
         HRESULT GetSignatureInfoFromCallToken(
             _In_ IMethodInfo* pMethodInfo,
             _Out_ PCCOR_SIGNATURE* ppSig,


### PR DESCRIPTION
The signature returned from `GetMethodSpecProps` is the GENERICINST signature - `GENRICINST GenArgCount Type Type*`. The parent methodDef/methodRef signature should be used to get the parameter count to calculate the stack impact.

Using the methodSpec signature can lead to an invalid maxStack (too low) that will cause a `System.InvalidProgramException`.

This PR uses the methodSpec token to get the parent methodRef/methodDef token to then get the method signature to eventually calculate stack impact.