### PR TITLE
Fix stack overflow when destructing graph

### DIFF
--- a/src/InstrumentationEngine/Instruction.cpp
+++ b/src/InstrumentationEngine/Instruction.cpp
@@ -1769,6 +1769,14 @@ HRESULT MicrosoftInstrumentationEngine::CInstruction::Disconnect()
     {
         m_pOriginalPreviousInstruction.Release();
     }
+    if (m_pNextInstruction)
+    {
+        m_pNextInstruction.Release();
+    }
+    if (m_pOriginalNextInstruction)
+    {
+        m_pOriginalNextInstruction.Release();
+    }
     return S_OK;
 }
 

--- a/src/InstrumentationEngine/InstructionGraph.cpp
+++ b/src/InstrumentationEngine/InstructionGraph.cpp
@@ -24,28 +24,28 @@ Initial state:
 |========| <--- |========| <--- |========| <--- |========|
 
 After node 1 disconnect:
-|=node 1=| ---> |=node 2=| ---> |=node 3=| ---> |=node 4=|
+|=node 1=|      |=node 2=| ---> |=node 3=| ---> |=node 4=|
 |        |      |        |      |        |      |        |
 | ref: 2 |      | ref: 1 |      | ref: 2 |      | ref: 2 |
 |========| <--- |========| <--- |========| <--- |========|
 
 After node 2 disconnect:
-|=node 1=| ---> |=node 2=| ---> |=node 3=| ---> |=node 4=|
+|=node 1=|      |=node 2=|      |=node 3=| ---> |=node 4=|
 |        |      |        |      |        |      |        |
 | ref: 1 |      | ref: 1 |      | ref: 1 |      | ref: 2 |
-|========| <--- |========| <--- |========| <--- |========|
+|========|      |========| <--- |========| <--- |========|
 
 After node 3 disconnect:
-|=node 1=| ---> |=node 2=| ---> |=node 3=| ---> |=node 4=|
+|=node 1=|      |=node 2=|      |=node 3=|      |=node 4=|
 |        |      |        |      |        |      |        |
 | ref: 1 |      | ref: 0 |      | ref: 1 |      | ref: 1 |
-|========| <--- |========| <--- |========| <--- |========|
+|========|      |========|      |========| <--- |========|
 
 After node 4 disconnect:
-|=node 1=| ---> |=node 2=| ---> |=node 3=| ---> |=node 4=|
+|=node 1=|      |=node 2=|      |=node 3=|      |=node 4=|
 |        |      |        |      |        |      |        |
 | ref: 1 |      | ref: 0 |      | ref: 0 |      | ref: 1 |
-|========| <--- |========| <--- |========| <--- |========|
+|========|      |========|      |========|      |========|
 */
 MicrosoftInstrumentationEngine::CInstructionGraph::~CInstructionGraph()
 {

--- a/src/InstrumentationEngine/InstructionGraph.cpp
+++ b/src/InstrumentationEngine/InstructionGraph.cpp
@@ -17,6 +17,15 @@ MicrosoftInstrumentationEngine::CInstructionGraph::~CInstructionGraph()
         CCriticalSectionHolder lock(&m_cs);
 
         CComPtr<CInstruction> pInstr = (CInstruction*)m_pFirstInstruction;
+
+        m_pFirstInstruction.Release();
+        m_pOrigFirstInstruction.Release();
+        
+        if(m_pUninstrumentedFirstInstruction != nullptr)
+        {
+            m_pUninstrumentedFirstInstruction.Release();
+        }
+
         while (pInstr != nullptr)
         {
             CComPtr<CInstruction> pNextInstruction;

--- a/src/InstrumentationEngine/InstructionGraph.cpp
+++ b/src/InstrumentationEngine/InstructionGraph.cpp
@@ -17,7 +17,6 @@ MicrosoftInstrumentationEngine::CInstructionGraph::~CInstructionGraph()
         CCriticalSectionHolder lock(&m_cs);
 
         CComPtr<CInstruction> pInstr = (CInstruction*)m_pFirstInstruction;
-
         while (pInstr != nullptr)
         {
             CComPtr<CInstruction> pNextInstruction;

--- a/src/InstrumentationEngine/InstructionGraph.cpp
+++ b/src/InstrumentationEngine/InstructionGraph.cpp
@@ -18,14 +18,6 @@ MicrosoftInstrumentationEngine::CInstructionGraph::~CInstructionGraph()
 
         CComPtr<CInstruction> pInstr = (CInstruction*)m_pFirstInstruction;
 
-        m_pFirstInstruction.Release();
-        m_pOrigFirstInstruction.Release();
-        
-        if(m_pUninstrumentedFirstInstruction != nullptr)
-        {
-            m_pUninstrumentedFirstInstruction.Release();
-        }
-
         while (pInstr != nullptr)
         {
             CComPtr<CInstruction> pNextInstruction;


### PR DESCRIPTION
This commit fixes stack overflow when destructing graph with many instructions #307 

Currently when graph is deconstructed we have:
1) Removing "Previous" poiners from all instructions
2) Release all pointers in graph for example first and last instructions. This causes stack overflow as it deconstruct all instructions:
```
Instr1.Release() [deconstruct];
    -> Instr2.Release() [deconstruct];
        -> Instr3.Release() [deconstruct];
             -> Instr4.Release() [deconstruct];
                      ..............
```

This PR changes logic so we have:
1) Release all pointers in graph to first instruction.
2) Removing "Previous" pointers from all instructions, which causes that instructions are deconstructed not in cascade mode:

```
Instr1.Disconnect();
Instr2.Disconnect();
    -> Instr1.Release() [deconstruct];
Instr3.Disconnect();
    -> Instr2.Release() [deconstruct];
Instr4.Disconnect();
    -> Instr3.Release() [deconstruct];
.......
```