### PR TITLE
Build: Update NuGet to 5.8

### DIFF
--- a/build/yaml/steps/windows/nugetrestore.yaml
+++ b/build/yaml/steps/windows/nugetrestore.yaml
@@ -11,7 +11,7 @@ steps:
 # Acquires a specific version of NuGet from the internet or the tools cache and adds it to the PATH. Use this task to change the version of NuGet used in the NuGet tasks.
 - task: NuGetToolInstaller@0
   inputs:
-    versionSpec: '5.7.0'
+    versionSpec: '5.8.0'
 
 # nuget restore
 - task: NuGetCommand@2


### PR DESCRIPTION
Updated the nuget version to 5.8 to fix build issues like 

> [error]C:\Program Files\dotnet\sdk\5.0.100\Sdks\Microsoft.NET.Sdk\targets\Microsoft.PackageDependencyResolution.targets(241,5): Error NETSDK1005: Assets file 'D:\a\1\s\obj\LegacyDependencies\project.assets.json' doesn't have a target for 'net461'. Ensure that restore has run and that you have included 'net461' in the TargetFrameworks for your project.

This seems to be known issue and others have proposed the same solution: https://developercommunity2.visualstudio.com/t/msbuild-uses-net-50-sdk-or-net-core-sdks-for-net-f/1252149?viewtype=solutions