### PR TITLE
Remove RPH if Initialize returns error

### DIFF
--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -974,11 +974,16 @@ HRESULT CProfilerManager::Initialize(
         {
             if (m_attachedClrVersion != ClrVersion_2)
             {
-                IfFailRet(pCallback->Initialize((IUnknown*)(m_pWrappedProfilerInfo.p)));
+                IfFailLog(pCallback->Initialize((IUnknown*)(m_pWrappedProfilerInfo.p)));
             }
             else
             {
-                IfFailRet(pCallback->Initialize((IUnknown*)(m_pRealProfilerInfo.p)));
+                IfFailLog(pCallback->Initialize((IUnknown*)(m_pRealProfilerInfo.p)));
+            }
+
+            if (FAILED(hr))
+            {
+                RemoveRawProfilerHook();
             }
         }
     }


### PR DESCRIPTION
If RPH returns an error hresult, rather than failing Initialize altogether for CLRIE, this change will allow CLRIE to just remove the RPH instead.