### PR TITLE
Improve RPH performance by removing critical section lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.36
++ Perf:
+  + Remove critical section around rawprofiler handle which can bottleneck objectalloc callbacks.
 
 ## 1.0.35
 + New:
@@ -29,7 +31,6 @@ Please format the changes as follows:
   + Update PR/CI stage dependencies
   + Use NuGet 5.8 when restoring
   + Use IfFailLog when rawprofiler fails to initialize.
-
 
 ## 1.0.34
 + BugFixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Please format the changes as follows:
 
 ## 1.0.36
 + Perf:
-  + Remove critical section around rawprofiler handle which can bottleneck objectalloc callbacks.
+  + use atomic shared_ptr instead of critical section around rawprofiler handle which can bottleneck objectalloc callbacks.
 
 ## 1.0.35
 + New:

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -314,12 +314,7 @@ HRESULT CProfilerManager::AddRawProfilerHook(
 HRESULT CProfilerManager::RemoveRawProfilerHook(
     )
 {
-    HRESULT hr = S_OK;
-
-    CCriticalSectionHolder lock(&m_cs);
-
-    m_profilerCallbackHolder = nullptr;
-
+    // Prevent external clients from removing RawProfilerHook during lifetime of process.
     return S_OK;
 }
 
@@ -983,7 +978,7 @@ HRESULT CProfilerManager::Initialize(
 
             if (FAILED(hr))
             {
-                RemoveRawProfilerHook();
+                m_profilerCallbackHolder = nullptr;
             }
         }
     }

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -316,7 +316,6 @@ HRESULT CProfilerManager::RemoveRawProfilerHook(
     )
 {
     atomic_store(&m_profilerCallbackHolder, shared_ptr<CProfilerCallbackHolder>(nullptr));
-    //m_profilerCallbackHolder.reset();
 
     return S_OK;
 }

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -368,15 +368,9 @@ namespace MicrosoftInstrumentationEngine
 
             CComPtr<TInterfaceType> pCallback;
 
-            // Holding the lock during the callback functions is dangerous since rentrant
-            // events and calls will block. Copy the collection under the lock, then release it and finally call the callbacks
+            if (m_profilerCallbackHolder != nullptr)
             {
-                CCriticalSectionHolder lock(&m_cs);
-
-                if (m_profilerCallbackHolder != nullptr)
-                {
-                    pCallback = (TInterfaceType*)(m_profilerCallbackHolder->GetMemberForInterface(__uuidof(TInterfaceType)));
-                }
+                pCallback = (TInterfaceType*)(m_profilerCallbackHolder->GetMemberForInterface(__uuidof(TInterfaceType)));
             }
 
             if (pCallback != nullptr)

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -13,7 +13,6 @@
 #include "../Common.Lib/ModuleHandle.h"
 #endif
 #include <XmlDocWrapper.h>
-#include <shared_mutex>
 
 using namespace ATL;
 
@@ -171,8 +170,7 @@ namespace MicrosoftInstrumentationEngine
 
         // This is the client that asked to receive the raw cor profiler event
         // model rather than using the simplified instrumentation method model. .
-        unique_ptr<CProfilerCallbackHolder> m_profilerCallbackHolder;
-        mutable std::shared_mutex m_sharedMutexRawProfiler;
+        shared_ptr<CProfilerCallbackHolder> m_profilerCallbackHolder;
 
         CComPtr<CAppDomainCollection> m_pAppDomainCollection;
 
@@ -370,15 +368,11 @@ namespace MicrosoftInstrumentationEngine
 
             CComPtr<TInterfaceType> pCallback;
 
-            // Take the lock that protects the raw profiler callback and the instrumentation methods. This keeps the collection from changing out from under the iterator
+            shared_ptr<CProfilerCallbackHolder> pProfilerCallbackHolder = atomic_load(&m_profilerCallbackHolder);
+            if (pProfilerCallbackHolder != nullptr)
             {
-                std::shared_lock<std::shared_mutex> srwLock(m_sharedMutexRawProfiler);
-                if (m_profilerCallbackHolder != nullptr)
-                {
-                    pCallback = (TInterfaceType*)(m_profilerCallbackHolder->GetMemberForInterface(__uuidof(TInterfaceType)));
-                }
+                CComPtr<ICorProfilerCallback2> pCallback = pProfilerCallbackHolder->m_CorProfilerCallback2;
             }
-
 
             if (pCallback != nullptr)
             {


### PR DESCRIPTION
Callbacks for raw profiler can be bottlenecked by the critical section lock around obtaining the raw profiler.

CLRIE doesn't remove the RawProfiler during runtime (except during Initialize callback) and this change makes the public RemoveRawProfiler API to no-op for extra insurance.