### PR TITLE
Fix copy-paste typo

### DIFF
--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -965,7 +965,7 @@ HRESULT CProfilerManager::Initialize(
     shared_ptr<CProfilerCallbackHolder> pProfilerCallbackHolder = atomic_load(&m_profilerCallbackHolder);
     if (pProfilerCallbackHolder != nullptr)
     {
-        CComPtr<ICorProfilerCallback2> pCallback = pProfilerCallbackHolder->m_CorProfilerCallback2;
+        pCallback = pProfilerCallbackHolder->m_CorProfilerCallback2;
     }
 
     if (pCallback)

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -371,7 +371,7 @@ namespace MicrosoftInstrumentationEngine
             shared_ptr<CProfilerCallbackHolder> pProfilerCallbackHolder = atomic_load(&m_profilerCallbackHolder);
             if (pProfilerCallbackHolder != nullptr)
             {
-                CComPtr<ICorProfilerCallback2> pCallback = pProfilerCallbackHolder->m_CorProfilerCallback2;
+                pCallback = pProfilerCallbackHolder->m_CorProfilerCallback2;
             }
 
             if (pCallback != nullptr)


### PR DESCRIPTION
 Warning C6246: Local declaration of 'pCallback' hides declaration of the same name in outer scope.