### PR TITLE
Use interlockedexchange instead of atomic shared_ptr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Please format the changes as follows:
 
 ## 1.0.36
 + Perf:
-  + use atomic shared_ptr instead of critical section around rawprofiler handle which can bottleneck objectalloc callbacks.
+  + Use interlockedexchange instead of critical sections around rawprofiler handle to address bottleneck objectalloc callbacks.
 
 ## 1.0.35
 + New:

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -186,7 +186,11 @@ HRESULT CProfilerManager::AddRawProfilerHook(
     HRESULT hr = S_OK;
     IfNullRetPointer(pUnkProfilerCallback);
 
-    shared_ptr<CProfilerCallbackHolder> pProfilerCallbackHolder = atomic_load(&m_profilerCallbackHolder);
+    CProfilerCallbackHolder* pProfilerCallbackHolder = static_cast<CProfilerCallbackHolder*>(InterlockedCompareExchangePointer(
+        (volatile PVOID*)&m_profilerCallbackHolder,
+        nullptr,
+        nullptr));
+
     if (pProfilerCallbackHolder != nullptr)
     {
         CLogging::LogError(_T("CAppDomainInfo::AddRawProfilerHook - Raw profiler hook is already initialized"));
@@ -201,7 +205,7 @@ HRESULT CProfilerManager::AddRawProfilerHook(
 
     CCriticalSectionHolder lock(&m_cs);
 
-    shared_ptr<CProfilerCallbackHolder> profilerCallbackHolder(new CProfilerCallbackHolder);
+    CProfilerCallbackHolder* profilerCallbackHolder = new CProfilerCallbackHolder;
 
     // Rather than following COM-rules and QI-ing for each specific ICorProfilerCallback version, we instead follow the implementation set by the CLR
     // where to interface inheritance, higher versioned ICorProfilerCallback## can be statically-casted to lower versioned ICorProfilerCallback##,
@@ -307,7 +311,8 @@ HRESULT CProfilerManager::AddRawProfilerHook(
         }
     }
 
-    std::atomic_store(&m_profilerCallbackHolder, profilerCallbackHolder);
+    // ICorProfiler::Initialize happens before any other callbacks so this shouldn't have any race conditions
+    InterlockedExchangePointer((void**)&m_profilerCallbackHolder, pProfilerCallbackHolder);
 
     return S_OK;
 }
@@ -315,7 +320,9 @@ HRESULT CProfilerManager::AddRawProfilerHook(
 HRESULT CProfilerManager::RemoveRawProfilerHook(
     )
 {
-    atomic_store(&m_profilerCallbackHolder, shared_ptr<CProfilerCallbackHolder>(nullptr));
+    // This doesn't causea a race condition since we are only setting null to the pointer, however this
+    // will cause a memory leak as there's no lock-free guarantees to delete the object.
+    InterlockedExchangePointer((void**)&m_profilerCallbackHolder, nullptr);
 
     return S_OK;
 }
@@ -962,7 +969,11 @@ HRESULT CProfilerManager::Initialize(
 
     CComPtr<ICorProfilerCallback2> pCallback;
 
-    shared_ptr<CProfilerCallbackHolder> pProfilerCallbackHolder = atomic_load(&m_profilerCallbackHolder);
+    CProfilerCallbackHolder* pProfilerCallbackHolder = static_cast<CProfilerCallbackHolder*>(InterlockedCompareExchangePointer(
+        (volatile PVOID*)&m_profilerCallbackHolder,
+        nullptr,
+        nullptr));
+
     if (pProfilerCallbackHolder != nullptr)
     {
         pCallback = pProfilerCallbackHolder->m_CorProfilerCallback2;
@@ -2799,7 +2810,11 @@ HRESULT CProfilerManager::COMClassicVTableCreated(
 
     CComPtr<ICorProfilerCallback> pCallback;
 
-    shared_ptr<CProfilerCallbackHolder> pProfilerCallbackHolder = atomic_load(&m_profilerCallbackHolder);
+    CProfilerCallbackHolder* pProfilerCallbackHolder = static_cast<CProfilerCallbackHolder*>(InterlockedCompareExchangePointer(
+        (volatile PVOID*)&m_profilerCallbackHolder,
+        nullptr,
+        nullptr));
+
     if (pProfilerCallbackHolder != nullptr)
     {
         pCallback = (ICorProfilerCallback*)(m_profilerCallbackHolder->GetMemberForInterface(__uuidof(ICorProfilerCallback)));
@@ -2828,7 +2843,11 @@ HRESULT CProfilerManager::COMClassicVTableDestroyed(
     // Compiler complains that these callbacks taking void* parameters are ambiguous. Can't use variadic templates on this call.
     CComPtr<ICorProfilerCallback> pCallback;
 
-    shared_ptr<CProfilerCallbackHolder> pProfilerCallbackHolder = atomic_load(&m_profilerCallbackHolder);
+    CProfilerCallbackHolder* pProfilerCallbackHolder = static_cast<CProfilerCallbackHolder*>(InterlockedCompareExchangePointer(
+        (volatile PVOID*)&m_profilerCallbackHolder,
+        nullptr,
+        nullptr));
+
     if (pProfilerCallbackHolder != nullptr)
     {
         pCallback = (ICorProfilerCallback*)(m_profilerCallbackHolder->GetMemberForInterface(__uuidof(ICorProfilerCallback)));

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -2817,7 +2817,7 @@ HRESULT CProfilerManager::COMClassicVTableCreated(
 
     if (pProfilerCallbackHolder != nullptr)
     {
-        pCallback = (ICorProfilerCallback*)(m_profilerCallbackHolder->GetMemberForInterface(__uuidof(ICorProfilerCallback)));
+        pCallback = (ICorProfilerCallback*)(pProfilerCallbackHolder->GetMemberForInterface(__uuidof(ICorProfilerCallback)));
     }
 
     if (pCallback != nullptr)
@@ -2850,7 +2850,7 @@ HRESULT CProfilerManager::COMClassicVTableDestroyed(
 
     if (pProfilerCallbackHolder != nullptr)
     {
-        pCallback = (ICorProfilerCallback*)(m_profilerCallbackHolder->GetMemberForInterface(__uuidof(ICorProfilerCallback)));
+        pCallback = (ICorProfilerCallback*)(pProfilerCallbackHolder->GetMemberForInterface(__uuidof(ICorProfilerCallback)));
     }
 
     if (pCallback != nullptr)

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -373,7 +373,11 @@ namespace MicrosoftInstrumentationEngine
 
             CComPtr<TInterfaceType> pCallback;
 
-            CProfilerCallbackHolder* pProfilerCallbackHolder = InterlockedCompareExchangePointer(&m_profilerCallbackHolder, nullptr, nullptr);
+            CProfilerCallbackHolder* pProfilerCallbackHolder = static_cast<CProfilerCallbackHolder*>(InterlockedCompareExchangePointer(
+                &m_profilerCallbackHolder,
+                nullptr,
+                nullptr));
+
             if (pProfilerCallbackHolder != nullptr)
             {
                 pCallback = pProfilerCallbackHolder->m_CorProfilerCallback2;

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -374,7 +374,7 @@ namespace MicrosoftInstrumentationEngine
             CComPtr<TInterfaceType> pCallback;
 
             CProfilerCallbackHolder* pProfilerCallbackHolder = static_cast<CProfilerCallbackHolder*>(InterlockedCompareExchangePointer(
-                &m_profilerCallbackHolder,
+                (volatile PVOID*)&m_profilerCallbackHolder,
                 nullptr,
                 nullptr));
 


### PR DESCRIPTION
It appears atomic shared_ptr functions can still cause a context switch due to the underlying spin-lock implementation on Windows. This change removes locks entirely in favor of interlockedexchange functions. However, this also means there's no lock that can guarantee proper deletion of the object which means we are left with a memory leak.