### PR TITLE
Fix CComBSTR not appending the null-terminator

### DIFF
--- a/src/InstrumentationEngine/TokenType.cpp
+++ b/src/InstrumentationEngine/TokenType.cpp
@@ -70,7 +70,7 @@ HRESULT MicrosoftInstrumentationEngine::CTokenType::GetName(_Out_ BSTR* pbstrNam
             IfFailRet(pImport->GetTypeDefProps(m_token, nameBuffer.data(), cchLength, &cchLength, nullptr, nullptr));
             fullName += nameBuffer.data();
 
-            m_name = CComBSTR(fullName.c_str());
+            m_name = CComBSTR(fullName.length(), fullName.c_str());
         }
         else if (TypeFromToken(m_token) == mdtTypeRef)
         {

--- a/src/InstrumentationEngine/TokenType.cpp
+++ b/src/InstrumentationEngine/TokenType.cpp
@@ -70,7 +70,7 @@ HRESULT MicrosoftInstrumentationEngine::CTokenType::GetName(_Out_ BSTR* pbstrNam
             IfFailRet(pImport->GetTypeDefProps(m_token, nameBuffer.data(), cchLength, &cchLength, nullptr, nullptr));
             fullName += nameBuffer.data();
 
-            m_name = CComBSTR(fullName.length(), fullName.c_str());
+            m_name = CComBSTR((int)fullName.length(), fullName.c_str());
         }
         else if (TypeFromToken(m_token) == mdtTypeRef)
         {


### PR DESCRIPTION
`CComBSTR(_In_opt_z_ LPCOLESTR pSrc)` calls `SysAllocString(pSrc)` which doesn't append the null-terminator
`CComBSTR(_In_ int nSize, _In_reads_opt_(nSize) LPCOLESTR sz)` calls `SysAllocStringLen(sz, nSize)` which does append the null-terminator.