### PR TITLE
Make environment variable names case insensitive on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.36
++ BugFixes:
+  + Make configuration environment variables case-insensitive on Windows.
 + Perf:
   + use atomic shared_ptr instead of critical section around rawprofiler handle which can bottleneck objectalloc callbacks.
 


### PR DESCRIPTION
Make environment variable names case insensitive on Windows.
This fixes [348](https://github.com/microsoft/CLRInstrumentationEngine/issues/348).  Fix is needed for internal VS issue 1264553.

The IISExpress launcher is making environment variables lower case including "cor_enable_profiling".  After discussing with @wiktork, we decided the better solution is to fix CLRInstrumentationEngine rather than the IISExpress launcher.