### PR TITLE
Enable Nagler tests on .NET Core

### DIFF
--- a/InstrumentationEngine.sln
+++ b/InstrumentationEngine.sln
@@ -5,7 +5,7 @@ VisualStudioVersion = 16.0.28727.205
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "InstrEngineTests", "InstrEngineTests", "{B4ADF020-7ACF-4A2B-B3FE-731006C1F30F}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "InstrEngineTests", "tests\InstrEngineTests\InstrEngineTests\InstrEngineTests.csproj", "{DFC9E517-AF1A-4087-BB27-AD1A09602F4F}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InstrEngineTests", "tests\InstrEngineTests\InstrEngineTests\InstrEngineTests.csproj", "{DFC9E517-AF1A-4087-BB27-AD1A09602F4F}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NaglerInstrumentationMethod", "tests\InstrEngineTests\NaglerInstrumentationMethod\NaglerInstrumentationMethod.vcxproj", "{939151FA-8324-4197-B5B4-EAE927BD2AEE}"
 	ProjectSection(ProjectDependencies) = postProject
@@ -66,6 +66,8 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "InstrumentationEngine.ProfilerProxy.Lib", "src\InstrumentationEngine.ProfilerProxy.Lib\InstrumentationEngine.ProfilerProxy.Lib.vcxproj", "{DAB53F24-D55A-4759-B100-5B7FEFBF6D08}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InstrumentationEngine.Attach", "src\InstrumentationEngine.Attach\InstrumentationEngine.Attach.csproj", "{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestAppRunner", "tests\InstrEngineTests\TestAppRunner\TestAppRunner.csproj", "{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -494,6 +496,30 @@ Global
 		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Release|x64.ActiveCfg = Release|Any CPU
 		{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}.Release|x86.ActiveCfg = Release|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Managed|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Managed|Any CPU.Build.0 = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Managed|x64.ActiveCfg = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Managed|x64.Build.0 = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Managed|x86.ActiveCfg = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Managed|x86.Build.0 = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Native|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Native|Any CPU.Build.0 = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Native|x64.ActiveCfg = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Native|x64.Build.0 = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Native|x86.ActiveCfg = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.CodeAnalysis.Native|x86.Build.0 = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|x64.Build.0 = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|x86.Build.0 = Debug|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|x64.ActiveCfg = Release|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|x64.Build.0 = Release|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|x86.ActiveCfg = Release|Any CPU
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -508,6 +534,7 @@ Global
 		{7080E6B4-E73B-4D69-852A-3ADACDD4C065} = {D78E4349-0436-4C90-B2F3-70F19451EC16}
 		{278F7EB8-4AE3-4F39-BF84-D481A353478B} = {7080E6B4-E73B-4D69-852A-3ADACDD4C065}
 		{AFC55CC1-567F-4C8A-A801-638A673AFEB8} = {7080E6B4-E73B-4D69-852A-3ADACDD4C065}
+		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708} = {B4ADF020-7ACF-4A2B-B3FE-731006C1F30F}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {16628EC2-6C46-4DEF-B260-8848FC916254}

--- a/InstrumentationEngine.sln
+++ b/InstrumentationEngine.sln
@@ -67,7 +67,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "InstrumentationEngine.Profi
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "InstrumentationEngine.Attach", "src\InstrumentationEngine.Attach\InstrumentationEngine.Attach.csproj", "{8F446E35-5683-4ABF-8F42-1C8EB5797A5B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestAppRunner", "tests\InstrEngineTests\TestAppRunner\TestAppRunner.csproj", "{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TestAppRunner", "tests\InstrEngineTests\TestAppRunner\TestAppRunner.csproj", "{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
@@ -101,7 +101,6 @@ Global
 		{DFC9E517-AF1A-4087-BB27-AD1A09602F4F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{DFC9E517-AF1A-4087-BB27-AD1A09602F4F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DFC9E517-AF1A-4087-BB27-AD1A09602F4F}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{DFC9E517-AF1A-4087-BB27-AD1A09602F4F}.Debug|x64.Build.0 = Debug|Any CPU
 		{DFC9E517-AF1A-4087-BB27-AD1A09602F4F}.Debug|x86.ActiveCfg = Debug|Any CPU
 		{DFC9E517-AF1A-4087-BB27-AD1A09602F4F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DFC9E517-AF1A-4087-BB27-AD1A09602F4F}.Release|Any CPU.Build.0 = Release|Any CPU
@@ -511,15 +510,11 @@ Global
 		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|x64.Build.0 = Debug|Any CPU
 		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Debug|x86.Build.0 = Debug|Any CPU
 		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|Any CPU.Build.0 = Release|Any CPU
 		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|x64.ActiveCfg = Release|Any CPU
-		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|x64.Build.0 = Release|Any CPU
 		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|x86.ActiveCfg = Release|Any CPU
-		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/build/yaml/jobs/tests.yaml
+++ b/build/yaml/jobs/tests.yaml
@@ -13,6 +13,7 @@ jobs:
 - template: windows/tests.yaml
   parameters:
     IsMicroBuildInternal: ${{ parameters.IsMicroBuildInternal }}
+    TestType: 'Native'
     MatrixStrategy:
       ${{ if or( eq(parameters.Configuration, 'Both'), eq(parameters.Configuration, 'Debug') )}}:
         Debug_x86:
@@ -23,6 +24,13 @@ jobs:
           Configuration: 'Debug'
           Platform: 'x64'
           RunSettingsFile: 'x64.runsettings'
+
+- template: windows/tests.yaml
+  parameters:
+    IsMicroBuildInternal: ${{ parameters.IsMicroBuildInternal }}
+    TestType: 'Managed'
+    MatrixStrategy:
+      ${{ if or( eq(parameters.Configuration, 'Both'), eq(parameters.Configuration, 'Debug') )}}:
         Debug_AnyCPU:
           Configuration: 'Debug'
           Platform: 'AnyCPU'

--- a/build/yaml/jobs/windows/tests.yaml
+++ b/build/yaml/jobs/windows/tests.yaml
@@ -71,8 +71,8 @@ jobs:
     - template: ../../steps/windows/tests.yaml
       parameters:
         Platform: $(Platform)
-        TestType: ${{ parameters.TestType }}
         SubFolder: '**\'
+        RunTitle: '$(Build.BuildNumber)_Windows_Native_$(Configuration)_$(Platform)'
   
   # All of the .NET tests need to be run separately
   # otherwise vstest will fallback to running
@@ -82,25 +82,25 @@ jobs:
     - template: ../../steps/windows/tests.yaml
       parameters:
         Platform: $(Platform)
-        TestType: ${{ parameters.TestType }}
+        RunTitle: '$(Build.BuildNumber)_Windows_NetFx_$(Configuration)_$(Platform)'
 
     - template: ../../steps/windows/tests.yaml
       parameters:
         Platform: $(Platform)
-        TestType: ${{ parameters.TestType }}
         SubFolder: 'net4*\'
+        RunTitle: '$(Build.BuildNumber)_Windows_Net4X_$(Configuration)_$(Platform)'
 
     - template: ../../steps/windows/tests.yaml
       parameters:
         Platform: $(Platform)
-        TestType: ${{ parameters.TestType }}
         SubFolder: 'netcoreapp3.1\'
+        RunTitle: '$(Build.BuildNumber)_Windows_Core31_$(Configuration)_$(Platform)'
     
     - template: ../../steps/windows/tests.yaml
       parameters:
         Platform: $(Platform)
-        TestType: ${{ parameters.TestType }}
         SubFolder: 'net50\'
+        RunTitle: '$(Build.BuildNumber)_Windows_Net50_$(Configuration)_$(Platform)'
 
   - ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
     - template: ../../steps/microbuild/cleanup.yaml

--- a/build/yaml/jobs/windows/tests.yaml
+++ b/build/yaml/jobs/windows/tests.yaml
@@ -36,6 +36,35 @@ jobs:
     parameters:
       ArtifactName: binaries-windows-$(Configuration)
 
+  # The UseDotNet task is not sufficient because it will only install the X64 runtimes
+  # whereas the tests require both X64 and X86 since they test different bitnesses.
+  - ${{ if eq('Managed', parameters.TestType) }}:
+    - powershell: |
+        # Get install script
+        $scriptDir = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath ([Guid]::NewGuid())
+        $scriptPath = Join-Path -Path $scriptDir -ChildPath 'dotnet-install.ps1'
+        New-Item -Path $scriptDir -ItemType 'Directory' | Out-Null
+        Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile $scriptPath
+        # Install runtimes
+        $dotnetDir = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath ([Guid]::NewGuid())
+        New-Item -Path $dotnetDir -ItemType 'Directory' | Out-Null
+        # Install x64 runtimes
+        $dotnetX64Dir = Join-Path -Path $dotnetDir -ChildPath 'x64'
+        New-Item -Path $dotnetX64Dir -ItemType 'Directory' | Out-Null
+        & $scriptPath -Runtime 'dotnet' -Channel '3.1' -Architecture 'x64' -InstallDir $dotnetX64Dir
+        & $scriptPath -Runtime 'dotnet' -Channel '5.0' -Architecture 'x64' -InstallDir $dotnetX64Dir
+        $dotnetX64Path = Join-Path -Path $dotnetX64Dir -ChildPath 'dotnet.exe' -Resolve
+        # Install x86 runtimes
+        $dotnetX86Dir = Join-Path -Path $dotnetDir -ChildPath 'x86'
+        New-Item -Path $dotnetX86Dir -ItemType 'Directory' | Out-Null
+        & $scriptPath -Runtime 'dotnet' -Channel '3.1' -Architecture 'x86' -InstallDir $dotnetX86Dir
+        & $scriptPath -Runtime 'dotnet' -Channel '5.0' -Architecture 'x86' -InstallDir $dotnetX86Dir
+        $dotnetX86Path = Join-Path -Path $dotnetX86Dir -ChildPath 'dotnet.exe' -Resolve
+        # Set job variables
+        Write-Host "##vso[task.setvariable variable=DOTNET_EXE_X64;]$dotnetX64Path"
+        Write-Host "##vso[task.setvariable variable=DOTNET_EXE_X86;]$dotnetX86Path"
+      displayName: 'Get Dotnet Runtimes'
+
   # When running native tests, include all tests
   # from all folders recursively
   - ${{ if eq('Native', parameters.TestType) }}:

--- a/build/yaml/jobs/windows/tests.yaml
+++ b/build/yaml/jobs/windows/tests.yaml
@@ -6,10 +6,11 @@
 parameters:
   IsMicroBuildInternal: false
   MatrixStrategy: {}
+  TestType: 'Native'
 
 jobs:
-- job: Test_Windows_Binaries
-  displayName: Windows Tests
+- job: Test_Windows_Binaries_${{ parameters.TestType }}
+  displayName: Windows Tests ${{ parameters.TestType }}
 
   strategy:
     matrix:
@@ -31,26 +32,46 @@ jobs:
   - checkout: self
     clean: true
 
-  - task: UseDotNet@2
-    displayName: Install .NET Core 3.1 Runtime
-    inputs:
-      packageType: 'runtime'
-      version: '3.1.x'
-
-  - task: UseDotNet@2
-    displayName: Install .NET 5.0 Runtime
-    inputs:
-      packageType: 'runtime'
-      version: '5.0.x'
-
   - template: ../../steps/azuredevops/downloadbuildartifacts.yaml
     parameters:
       ArtifactName: binaries-windows-$(Configuration)
 
-  - template: ../../steps/windows/tests.yaml
-    parameters:
-      WindowsBinRoot: $(Build.ArtifactStagingDirectory)\binaries-windows-$(Configuration)
-      Platform: $(Platform)
+  # When running native tests, include all tests
+  # from all folders recursively
+  - ${{ if eq('Native', parameters.TestType) }}:
+    - template: ../../steps/windows/tests.yaml
+      parameters:
+        Platform: $(Platform)
+        TestType: ${{ parameters.TestType }}
+        SubFolder: '**\'
+  
+  # All of the .NET tests need to be run separately
+  # otherwise vstest will fallback to running
+  # .NET Framework tests only. Minimize by grouping
+  # by their runtime version.
+  - ${{ if eq('Managed', parameters.TestType) }}:
+    - template: ../../steps/windows/tests.yaml
+      parameters:
+        Platform: $(Platform)
+        TestType: ${{ parameters.TestType }}
+
+    - template: ../../steps/windows/tests.yaml
+      parameters:
+        Platform: $(Platform)
+        TestType: ${{ parameters.TestType }}
+        SubFolder: 'net4*\'
+
+    - template: ../../steps/windows/tests.yaml
+      parameters:
+        Platform: $(Platform)
+        TestType: ${{ parameters.TestType }}
+        SubFolder: 'netcoreapp3.1\'
+    
+    - template: ../../steps/windows/tests.yaml
+      parameters:
+        Platform: $(Platform)
+        TestType: ${{ parameters.TestType }}
+        SubFolder: 'net50\'
 
   - ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
     - template: ../../steps/microbuild/cleanup.yaml

--- a/build/yaml/jobs/windows/tests.yaml
+++ b/build/yaml/jobs/windows/tests.yaml
@@ -36,9 +36,23 @@ jobs:
     parameters:
       ArtifactName: binaries-windows-$(Configuration)
 
-  # The UseDotNet task is not sufficient because it will only install the X64 runtimes
-  # whereas the tests require both X64 and X86 since they test different bitnesses.
   - ${{ if eq('Managed', parameters.TestType) }}:
+    # Install dotnet runtimes to allow .NET Core and .NET 5+ based unit tests to run.
+    - task: UseDotNet@2
+      displayName: Install .NET Core 3.1 Runtime
+      inputs:
+        packageType: 'runtime'
+        version: '3.1.x'
+
+    - task: UseDotNet@2
+      displayName: Install .NET 5.0 Runtime
+      inputs:
+        packageType: 'runtime'
+        version: '5.0.x'
+
+    # The UseDotNet task is not sufficient because it will only install the X64 runtimes
+    # whereas the tests require both X64 and X86 since they run the test apps with different,
+    # specified bitnesses.
     - powershell: |
         # Get install script
         $scriptDir = Join-Path -Path $env:AGENT_TEMPDIRECTORY -ChildPath ([Guid]::NewGuid())
@@ -63,7 +77,7 @@ jobs:
         # Set job variables
         Write-Host "##vso[task.setvariable variable=DOTNET_EXE_X64;]$dotnetX64Path"
         Write-Host "##vso[task.setvariable variable=DOTNET_EXE_X86;]$dotnetX86Path"
-      displayName: 'Get Dotnet Runtimes'
+      displayName: 'Get .NET Runtimes'
 
   # When running native tests, include all tests
   # from all folders recursively

--- a/build/yaml/jobs/windows/tests.yaml
+++ b/build/yaml/jobs/windows/tests.yaml
@@ -31,6 +31,18 @@ jobs:
   - checkout: self
     clean: true
 
+  - task: UseDotNet@2
+    displayName: Install .NET Core 3.1 Runtime
+    inputs:
+      packageType: 'runtime'
+      version: '3.1.x'
+
+  - task: UseDotNet@2
+    displayName: Install .NET 5.0 Runtime
+    inputs:
+      packageType: 'runtime'
+      version: '5.0.x'
+
   - template: ../../steps/azuredevops/downloadbuildartifacts.yaml
     parameters:
       ArtifactName: binaries-windows-$(Configuration)

--- a/build/yaml/steps/windows/tests.yaml
+++ b/build/yaml/steps/windows/tests.yaml
@@ -8,14 +8,11 @@ parameters:
   Platform: ''
 
 steps:
-  # Temporarily disable running tests for .NET Core and .NET 5
 - task: VSTest@2
   displayName: 'Test Assemblies $(Build.ArtifactStagingDirectory)\binaries-windows-$(Configuration)\**\$(Platform)\**\*Tests*.dll'
   inputs:
     testAssemblyVer2: |
      **\$(Platform)\**\*Tests*.dll
-     !**\netcoreapp3.1\**
-     !**\net50\**
      !**\*TestAdapter.dll
      !**\obj\**
     searchFolder: '$(Build.ArtifactStagingDirectory)\binaries-windows-$(Configuration)'

--- a/build/yaml/steps/windows/tests.yaml
+++ b/build/yaml/steps/windows/tests.yaml
@@ -5,8 +5,8 @@
 
 parameters:
   Platform: ''
-  TestType: ''
   SubFolder: ''
+  RunTitle: ''
 
 steps:
 - task: VSTest@2
@@ -21,5 +21,5 @@ steps:
     runInParallel: false
     codeCoverageEnabled: false
     runSettingsFile: tests/TestSettings/$(RunSettingsFile)
-    testRunTitle: '$(Build.BuildNumber)_Windows_${{ parameters.TestType }}_$(Configuration)_$(Platform)'
+    testRunTitle: ${{ parameters.RunTitle }}
   condition: succeededOrFailed()

--- a/build/yaml/steps/windows/tests.yaml
+++ b/build/yaml/steps/windows/tests.yaml
@@ -4,15 +4,16 @@
 # Step Template: Test Windows Binaries
 
 parameters:
-  WindowsBinRoot: ''
   Platform: ''
+  TestType: ''
+  SubFolder: ''
 
 steps:
 - task: VSTest@2
-  displayName: 'Test Assemblies $(Build.ArtifactStagingDirectory)\binaries-windows-$(Configuration)\**\$(Platform)\**\*Tests*.dll'
+  displayName: 'Run Tests: **\$(Platform)\${{ parameters.SubFolder }}*Tests*.dll'
   inputs:
     testAssemblyVer2: |
-     **\$(Platform)\**\*Tests*.dll
+     **\$(Platform)\${{ parameters.SubFolder }}*Tests*.dll
      !**\*TestAdapter.dll
      !**\obj\**
     searchFolder: '$(Build.ArtifactStagingDirectory)\binaries-windows-$(Configuration)'
@@ -20,3 +21,5 @@ steps:
     runInParallel: false
     codeCoverageEnabled: false
     runSettingsFile: tests/TestSettings/$(RunSettingsFile)
+    testRunTitle: '$(Build.BuildNumber)_Windows_${{ parameters.TestType }}_$(Configuration)_$(Platform)'
+  condition: succeededOrFailed()

--- a/tests/InstrEngineTests/Baselines/RuntimeExceptionCallbacks.xml
+++ b/tests/InstrEngineTests/Baselines/RuntimeExceptionCallbacks.xml
@@ -1,9 +1,9 @@
 <ExceptionTrace>
     <ExceptionThrown>
-        <MethodName>ThrowSomeExceptions3</MethodName>
-        <MethodName>ThrowSomeExceptions2</MethodName>
-        <MethodName>ThrowSomeExceptions1</MethodName>
-        <MethodName>Main</MethodName>
+        <MethodName>RuntimeExceptionCallbacks_Debug_x64.exe!ThrowSomeExceptions3</MethodName>
+        <MethodName>RuntimeExceptionCallbacks_Debug_x64.exe!ThrowSomeExceptions2</MethodName>
+        <MethodName>RuntimeExceptionCallbacks_Debug_x64.exe!ThrowSomeExceptions1</MethodName>
+        <MethodName>RuntimeExceptionCallbacks_Debug_x64.exe!Main</MethodName>
     </ExceptionThrown>
     <ExceptionSearchFunctionEnter>TestRuntimeExceptionCallbacks.Program.ThrowSomeExceptions3</ExceptionSearchFunctionEnter>
     <ExceptionSearchFunctionLeave/>

--- a/tests/InstrEngineTests/InstrEngineTests/EmbeddedResources/DynamicCodeTests.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/EmbeddedResources/DynamicCodeTests.cs
@@ -46,7 +46,7 @@ namespace CompiledCode
         private static void CallCompiledAssembly()
         {
             string assemblyPath = Path.Combine(
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                Path.GetDirectoryName(Assembly.GetEntryAssembly().Location),
                 "DynamicCodeAssembly.dll");
 
             using FileStream assemblyStream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read);

--- a/tests/InstrEngineTests/InstrEngineTests/InstrEngineTests.csproj
+++ b/tests/InstrEngineTests/InstrEngineTests/InstrEngineTests.csproj
@@ -18,10 +18,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.8.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.1.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.1.1" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+    <PackageReference Include="coverlet.collector" Version="3.0.2" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\Baselines\AddBranchTargets_ArrayForeachTest.xml">

--- a/tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
@@ -1,13 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Reflection;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace InstrEngineTests
 {
@@ -20,10 +15,10 @@ namespace InstrEngineTests
         // All paths are relative to the AnyCPU binaries directory e.g. bin\Debug\AnyCPU
         public const string BaselinesBinPath = @".\" + BaselinesFolder;
         public const string TestScriptsBinPath = @".\" + TestScriptsFolder;
-        public const string InstrumentationEngineX64BinPath = @"..\..\x64";
-        public const string InstrumentationEngineX86BinPath = @"..\..\x86";
-        public const string InstrumentationConfigX64BinPath = @"..\..\x64\NaglerInstrumentationMethod_x64.xml";
-        public const string InstrumentationConfigX86BinPath = @"..\..\x86\NaglerInstrumentationMethod_x86.xml";
+        public const string InstrumentationEngineX64BinPath = @"..\..\x64\MicrosoftInstrumentationEngine_x64.dll";
+        public const string InstrumentationEngineX86BinPath = @"..\..\x86\MicrosoftInstrumentationEngine_x86.dll";
+        public const string NaglerInstrumentationConfigX64BinPath = @"..\..\x64\NaglerInstrumentationMethod_x64.xml";
+        public const string NaglerInstrumentationConfigX86BinPath = @"..\..\x86\NaglerInstrumentationMethod_x86.xml";
         public const string NaglerInstrumentationMethodX64BinPath = @"..\..\x64\NaglerInstrumentationMethod_x64.dll";
         public const string NaglerInstrumentationMethodX86BinPath = @"..\..\x86\NaglerInstrumentationMethod_x86.dll";
 

--- a/tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -38,6 +37,19 @@ namespace InstrEngineTests
         private const string TestOutputFileEnvName = "MicrosoftInstrumentationEngine_FileLogPath";
         private const string IsRejitEnvName = "Nagler_IsRejit";
 
+#if NETCOREAPP
+        private const string EnableProfilingEnvVarName = "CORECLR_ENABLE_PROFILING";
+        private const string ProfilerEnvVarName = "CORECLR_PROFILER";
+        private const string ProfilerPathEnvVarName = "CORECLR_PROFILER_PATH";
+#else
+        private const string EnableProfilingEnvVarName = "COR_ENABLE_PROFILING";
+        private const string ProfilerEnvVarName = "COR_PROFILER";
+        private const string ProfilerPathEnvVarName = "COR_PROFILER_PATH";
+#endif
+
+        private const string DotnetExeX64EnvVarName = "DOTNET_EXE_X64";
+        private const string DotnetExeX86EnvVarName = "DOTNET_EXE_X86";
+
         #endregion
 
         public const int TestAppTimeoutMs = 10000;
@@ -52,16 +64,6 @@ namespace InstrEngineTests
 
         // Enable ref recording to track down memory leaks. For debug only.
         private static bool EnableRefRecording = false;
-
-#if NETCOREAPP
-        private const string EnableProfilingEnvVarName = "CORECLR_ENABLE_PROFILING";
-        private const string ProfilerEnvVarName = "CORECLR_PROFILER";
-        private const string ProfilerPathEnvVarName = "CORECLR_PROFILER_PATH";
-#else
-        private const string EnableProfilingEnvVarName = "COR_ENABLE_PROFILING";
-        private const string ProfilerEnvVarName = "COR_PROFILER";
-        private const string ProfilerPathEnvVarName = "COR_PROFILER_PATH";
-#endif
 
         public static void LaunchAppAndCompareResult(TestParameters parameters, string testApp, string fileName, string args = null, bool regexCompare = false, int timeoutMs = TestAppTimeoutMs)
         {
@@ -183,25 +185,29 @@ namespace InstrEngineTests
             psi.EnvironmentVariables.Add(TestOutputFileEnvName, outputPath);
             psi.EnvironmentVariables.Add(IsRejitEnvName, isRejit ? "True" : "False");
 
-            string appPath = Path.Combine(PathUtils.GetAssetsPath(), testApp);
+            string appPathWithoutExtension = Path.Combine(PathUtils.GetAssetsPath(), testApp);
 #if NETCOREAPP
-            string hostPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFiles), "dotnet", "dotnet.exe");
-            if (is32bitTest)
+            string dotnetExeEnvVarName = is32bitTest ? DotnetExeX86EnvVarName : DotnetExeX64EnvVarName;
+            string hostPath = Environment.GetEnvironmentVariable(dotnetExeEnvVarName);
+            if (string.IsNullOrEmpty(hostPath))
             {
-                hostPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "dotnet", "dotnet.exe");
+                Environment.SpecialFolder programFilesFolder = is32bitTest ?
+                    Environment.SpecialFolder.ProgramFilesX86 :
+                    Environment.SpecialFolder.ProgramFiles;
+
+                hostPath = Path.Combine(Environment.GetFolderPath(programFilesFolder), "dotnet", "dotnet.exe");
             }
+            Assert.IsTrue(File.Exists(hostPath), "dotnet.exe path '{0}' does not exist.", hostPath);
 
             // The compiled test apps cannot be run directly by dotnet.exe because they are missing
             // the *.runtimeconfig.json files that contain framework version and dependency information.
             // Use a pre-compiled executable to bootstrap executing these assemblies.
-            string runnerPath = Path.Combine(
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-                "TestAppRunner.dll");
+            string runnerPath = Path.Combine(PathUtils.GetAssetsPath(), "TestAppRunner.dll");
 
             psi.FileName = hostPath;
-            psi.Arguments = $"\"{runnerPath}\" \"{appPath}.dll\" {args}";
+            psi.Arguments = $"\"{runnerPath}\" \"{appPathWithoutExtension}.dll\" {args}";
 #else
-            psi.FileName = $"{appPath}.exe";
+            psi.FileName = $"{appPathWithoutExtension}.exe";
             psi.Arguments = args;
 #endif
 

--- a/tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -189,8 +190,16 @@ namespace InstrEngineTests
             {
                 hostPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "dotnet", "dotnet.exe");
             }
+
+            // The compiled test apps cannot be run directly by dotnet.exe because they are missing
+            // the *.runtimeconfig.json files that contain framework version and dependency information.
+            // Use a pre-compiled executable to bootstrap executing these assemblies.
+            string runnerPath = Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                "TestAppRunner.dll");
+
             psi.FileName = hostPath;
-            psi.Arguments = $"{appPath}.dll {args}";
+            psi.Arguments = $"\"{runnerPath}\" \"{appPath}.dll\" {args}";
 #else
             psi.FileName = $"{appPath}.exe";
             psi.Arguments = args;

--- a/tests/InstrEngineTests/InstrEngineTests/RuntimeExceptionCallbacks.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/RuntimeExceptionCallbacks.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class RuntimeExceptionCallbacks

--- a/tests/InstrEngineTests/InstrEngineTests/TestAddExceptionHandler.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestAddExceptionHandler.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestAddExceptionHandler

--- a/tests/InstrEngineTests/InstrEngineTests/TestAddInstruction.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestAddInstruction.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestAddInstruction

--- a/tests/InstrEngineTests/InstrEngineTests/TestDynamicCode.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestDynamicCode.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestDynamicCode

--- a/tests/InstrEngineTests/InstrEngineTests/TestException.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestException.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestException

--- a/tests/InstrEngineTests/InstrEngineTests/TestHttpMethods.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestHttpMethods.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestHttpMethods

--- a/tests/InstrEngineTests/InstrEngineTests/TestInjectToMscorlib.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestInjectToMscorlib.cs
@@ -5,6 +5,7 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace InstrEngineTests
 {
+#if !NETCOREAPP
     [TestClass]
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
@@ -44,4 +45,5 @@ namespace InstrEngineTests
                 "InjectToMscorlibTest32.xml");
         }
     }
+#endif
 }

--- a/tests/InstrEngineTests/InstrEngineTests/TestInjectToMscorlib.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestInjectToMscorlib.cs
@@ -11,8 +11,8 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestInjectToMscorlib

--- a/tests/InstrEngineTests/InstrEngineTests/TestInstruOperations.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestInstruOperations.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestInstruOperations

--- a/tests/InstrEngineTests/InstrEngineTests/TestInstrumentationMethodLogging.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestInstrumentationMethodLogging.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestInstrumentationMethodLogging

--- a/tests/InstrEngineTests/InstrEngineTests/TestLocals.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestLocals.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestLocals

--- a/tests/InstrEngineTests/InstrEngineTests/TestMethodReplacement.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestMethodReplacement.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class MethodReplacement

--- a/tests/InstrEngineTests/InstrEngineTests/TestMultiReturn.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestMultiReturn.cs
@@ -5,14 +5,20 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace InstrEngineTests
 {
-
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestMultiReturn

--- a/tests/InstrEngineTests/InstrEngineTests/TestOperand.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestOperand.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class AddOperands

--- a/tests/InstrEngineTests/InstrEngineTests/TestRejit.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestRejit.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestRejit

--- a/tests/InstrEngineTests/InstrEngineTests/TestRoundTrip.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestRoundTrip.cs
@@ -6,12 +6,19 @@ using Microsoft.VisualStudio.TestTools.UnitTesting;
 namespace InstrEngineTests
 {
     [TestClass]
+    // "dotnet test" runs tests in-place (instead of copying them to a deployment
+    // directory). DeploymentItems that copy from a source path to a destination
+    // that is the same location are not necessary and cause file locking issues
+    // when initializing the tests. Only use DeploymentItem for paths with different
+    // destinations for .NET Core test assemblies.
+#if !NETCOREAPP
     [DeploymentItem(PathUtils.BaselinesBinPath, PathUtils.BaselinesBinPath)]
     [DeploymentItem(PathUtils.TestScriptsBinPath, PathUtils.TestScriptsBinPath)]
+#endif
     [DeploymentItem(PathUtils.InstrumentationEngineX64BinPath)]
     [DeploymentItem(PathUtils.InstrumentationEngineX86BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX64BinPath)]
-    [DeploymentItem(PathUtils.InstrumentationConfigX86BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
     public class TestRoundTrip

--- a/tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.cpp
+++ b/tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.cpp
@@ -750,6 +750,9 @@ HRESULT CInstrumentationMethod::OnModuleLoaded(_In_ IModuleInfo* pModuleInfo)
             BOOL bIsRejit = FALSE;
             IfFailRet(pInstrumentMethodEntry->GetIsRejit(&bIsRejit));
 
+            // Only request ReJIT if the method will modify code on ReJIT. On .NET Core, the runtime will
+            // only callback into the profiler for the ReJIT of the method if ReJIT is requested whereas the
+            // appropriate callbacks are made for both JIT and ReJIT on .NET Framework.
             if (bIsRejit)
             {
                 MicrosoftInstrumentationEngine::CMetadataEnumCloser<IMetaDataImport2> spTypeDefEnum(pMetadataImport, nullptr);

--- a/tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.cpp
+++ b/tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.cpp
@@ -747,21 +747,26 @@ HRESULT CInstrumentationMethod::OnModuleLoaded(_In_ IModuleInfo* pModuleInfo)
             CComPtr<IMetaDataImport2> pMetadataImport;
             IfFailRet(pModuleInfo->GetMetaDataImport((IUnknown**)&pMetadataImport));
 
+            BOOL bIsRejit = FALSE;
+            IfFailRet(pInstrumentMethodEntry->GetIsRejit(&bIsRejit));
 
-            MicrosoftInstrumentationEngine::CMetadataEnumCloser<IMetaDataImport2> spTypeDefEnum(pMetadataImport, nullptr);
-            mdTypeDef typeDef = mdTypeDefNil;
-            ULONG cTokens = 0;
-            while (S_OK == (hr = pMetadataImport->EnumTypeDefs(spTypeDefEnum.Get(), &typeDef, 1, &cTokens)))
+            if (bIsRejit)
             {
-                MicrosoftInstrumentationEngine::CMetadataEnumCloser<IMetaDataImport2> spMethodEnum(pMetadataImport, nullptr);
-                mdToken methodDefs[16];
-                ULONG cMethod = 0;
-                pMetadataImport->EnumMethodsWithName(spMethodEnum.Get(), typeDef, bstrMethodName, methodDefs, _countof(methodDefs), &cMethod);
-
-                if (cMethod > 0)
+                MicrosoftInstrumentationEngine::CMetadataEnumCloser<IMetaDataImport2> spTypeDefEnum(pMetadataImport, nullptr);
+                mdTypeDef typeDef = mdTypeDefNil;
+                ULONG cTokens = 0;
+                while (S_OK == (hr = pMetadataImport->EnumTypeDefs(spTypeDefEnum.Get(), &typeDef, 1, &cTokens)))
                 {
-                    pModuleInfo->RequestRejit(methodDefs[0]);
-                    break;
+                    MicrosoftInstrumentationEngine::CMetadataEnumCloser<IMetaDataImport2> spMethodEnum(pMetadataImport, nullptr);
+                    mdToken methodDefs[16];
+                    ULONG cMethod = 0;
+                    pMetadataImport->EnumMethodsWithName(spMethodEnum.Get(), typeDef, bstrMethodName, methodDefs, _countof(methodDefs), &cMethod);
+
+                    if (cMethod > 0)
+                    {
+                        pModuleInfo->RequestRejit(methodDefs[0]);
+                        break;
+                    }
                 }
             }
         }
@@ -1612,10 +1617,25 @@ HRESULT CInstrumentationMethod::HandleStackSnapshotCallbackExceptionThrown(
     CComBSTR bstrMethodName;
     IfFailRet(pMethodInfo->GetName(&bstrMethodName));
 
+    CComPtr<IModuleInfo> pModuleInfo;
+    IfFailRet(pMethodInfo->GetModuleInfo(&pModuleInfo));
+
+    CComBSTR bstrModuleName;
+    IfFailRet(pModuleInfo->GetModuleName(&bstrModuleName));
+
     CComPtr<IProfilerManagerLogging> spLogger;
     m_pProfilerManager->GetLoggingInstance(&spLogger);
 
-    tstring strMessage(_T("        <MethodName>"));
+    tstring strMessage;
+    // Add [TestIgnore] for the TestAppRunner. This module is used for bootstrapping
+    // .NET Core test assemblies and is not intended to be used in test baselines.
+    if (wcscmp(bstrModuleName, _T("TestAppRunner.dll")) == 0)
+    {
+        strMessage.append(_T("[TestIgnore]"));
+    }
+    strMessage.append(_T("        <MethodName>"));
+    strMessage.append(bstrModuleName);
+    strMessage.append(_T("!"));
     strMessage.append(bstrMethodName);
     strMessage.append(_T("</MethodName>"));
 
@@ -1623,8 +1643,6 @@ HRESULT CInstrumentationMethod::HandleStackSnapshotCallbackExceptionThrown(
 
     // verify other code paths that don't contribute to actual baseline
     // This is just to get coverage on althernative code paths to obtain method infos
-    CComPtr<IModuleInfo> pModuleInfo;
-    IfFailRet(pMethodInfo->GetModuleInfo(&pModuleInfo));
     mdToken methodToken;
     IfFailRet(pMethodInfo->GetMethodToken(&methodToken));
 

--- a/tests/InstrEngineTests/TestAppRunner/Program.cs
+++ b/tests/InstrEngineTests/TestAppRunner/Program.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+
+namespace TestAppRunner
+{
+    /// <summary>
+    /// Purpose is to bootstrap assemblies that cannot be run directly. For example,
+    /// test apps that are compiled by Microsoft.CodeAnalysis do not have runtimeconfig.json
+    /// files so they cannot be run by dotnet.exe directly.
+    /// </summary>
+    class Program
+    {
+        static int Main(string[] args)
+        {
+            if (args.Length == 0)
+            {
+                throw new InvalidOperationException("Expected at least one argument with name of assembly to execute.");
+            }
+
+            string assemblyName = args[0];
+            string assemblyPath = Path.Combine(
+                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
+                assemblyName);
+
+            using FileStream assemblyStream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read);
+            using BinaryReader assemblyReader = new BinaryReader(assemblyStream);
+            byte[] assemblyData = assemblyReader.ReadBytes((int)assemblyStream.Length);
+
+            Assembly assembly = AppDomain.CurrentDomain.Load(assemblyData);
+
+            if (null == assembly.EntryPoint)
+            {
+                throw new InvalidOperationException("Specified assembly does not have an entry point.");
+            }
+
+            // Pass remaining arguments to assembly entry point.
+            string[] entryPointArgs = args.Skip(1).ToArray();
+
+            // Create a delegate for the entry point and invoke it. This allows
+            // direct invocation of the entry point and avoids putting more frames
+            // on the callstack (important for exception tests).
+            if (assembly.EntryPoint.ReturnType == typeof(void))
+            {
+                Action<string[]> entryPointDelegate = (Action<string[]>)assembly.EntryPoint
+                    .CreateDelegate(typeof(Action<string[]>));
+
+                entryPointDelegate(entryPointArgs);
+
+                return 0;
+            }
+            else
+            {
+                Func<string[], int> entryPointDelegate = (Func<string[], int>)assembly.EntryPoint
+                    .CreateDelegate(typeof(Func<string[], int>));
+
+                return entryPointDelegate(entryPointArgs);
+            }
+            
+        }
+    }
+}

--- a/tests/InstrEngineTests/TestAppRunner/Program.cs
+++ b/tests/InstrEngineTests/TestAppRunner/Program.cs
@@ -19,10 +19,7 @@ namespace TestAppRunner
                 throw new InvalidOperationException("Expected at least one argument with name of assembly to execute.");
             }
 
-            string assemblyName = args[0];
-            string assemblyPath = Path.Combine(
-                Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location),
-                assemblyName);
+            string assemblyPath = args[0];
 
             using FileStream assemblyStream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read);
             using BinaryReader assemblyReader = new BinaryReader(assemblyStream);

--- a/tests/InstrEngineTests/TestAppRunner/Program.cs
+++ b/tests/InstrEngineTests/TestAppRunner/Program.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;

--- a/tests/InstrEngineTests/TestAppRunner/Program.cs
+++ b/tests/InstrEngineTests/TestAppRunner/Program.cs
@@ -38,6 +38,9 @@ namespace TestAppRunner
             // Create a delegate for the entry point and invoke it. This allows
             // direct invocation of the entry point and avoids putting more frames
             // on the callstack (important for exception tests).
+            // NOTE: All current test app entry points only return void or int. If one is
+            // added that returns Task, then the delegate creation and TestAppRunner entry
+            // point need to be updated to handle async method invocation.
             if (assembly.EntryPoint.ReturnType == typeof(void))
             {
                 Action<string[]> entryPointDelegate = (Action<string[]>)assembly.EntryPoint

--- a/tests/InstrEngineTests/TestAppRunner/TestAppRunner.csproj
+++ b/tests/InstrEngineTests/TestAppRunner/TestAppRunner.csproj
@@ -1,0 +1,16 @@
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+     Licensed under the MIT License. -->
+<Project>
+  <PropertyGroup>
+    <GenerateAdditionalSources>false</GenerateAdditionalSources>
+    <SubComponent>$(TargetFramework)</SubComponent>
+  </PropertyGroup>
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'EnlistmentRoot.marker'))\build\Managed.props" />
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp3.1;net50</TargetFrameworks>
+  </PropertyGroup>
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+  <Import Project="$(EnlistmentRoot)\build\Managed.targets" />
+</Project>


### PR DESCRIPTION
These changes enable running the Nagler tests on .NET Core 3.1 and .NET 5 for Windows.

(new PR, same as #356, to try to clear out stuck build jobs).