### PR TITLE
Override Compile targets for packaging projects instead of suppressing warnings.

### DIFF
--- a/src/Dependencies/LegacyDependencies.csproj
+++ b/src/Dependencies/LegacyDependencies.csproj
@@ -21,10 +21,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <!-- CS2008: Project is used for restoring NuGet packages only. -->
-    <NoWarn>CS2008</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept" Version="$(LegacyApplicationInsightsAgentInterceptVersion)">
@@ -34,4 +30,6 @@
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="$(EnlistmentRoot)\build\Common.targets" />
+  <!-- Project does not compile assembly; override to avoid CS2008. -->
+  <Target Name="Compile" />
 </Project>

--- a/src/Dependencies/NativeDependencies.csproj
+++ b/src/Dependencies/NativeDependencies.csproj
@@ -21,10 +21,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <!-- CS2008: Project is used for restoring NuGet packages only. -->
-    <NoWarn>CS2008</NoWarn>
   </PropertyGroup>
   <Choose>
     <When Condition="!$([MSBuild]::IsOsPlatform('Windows'))">
@@ -53,4 +49,6 @@
   </Choose>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="$(EnlistmentRoot)\build\Common.targets" />
+  <!-- Project does not compile assembly; override to avoid CS2008. -->
+  <Target Name="Compile" />
 </Project>

--- a/src/Dependencies/WixDependencies.csproj
+++ b/src/Dependencies/WixDependencies.csproj
@@ -21,10 +21,6 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
     <TargetFramework>net461</TargetFramework>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <!-- CS2008: Project is used for restoring NuGet packages only. -->
-    <NoWarn>CS2008</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Wix" Version="$(WixVersion)" />
@@ -34,4 +30,6 @@
   </ItemGroup>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="$(EnlistmentRoot)\build\Common.targets" />
+  <!-- Project does not compile assembly; override to avoid CS2008. -->
+  <Target Name="Compile" />
 </Project>

--- a/src/InstrumentationEngine.Installer.NuGet/Module/InstrumentationEngine.Module.NuGet.csproj
+++ b/src/InstrumentationEngine.Installer.NuGet/Module/InstrumentationEngine.Module.NuGet.csproj
@@ -14,8 +14,6 @@
   <Import Project="$(EnlistmentRoot)\build\Packaging.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -26,8 +24,6 @@
     <ProjectGuid>{59CC768D-2E07-4FD9-8013-2EBC3898FEED}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.InstrumentationEngine.Module</RootNamespace>
-    <!-- CS2008: Project is used for packaging only and does not produce its own assembly. -->
-    <NoWarn>CS2008</NoWarn>
     <Platforms>x64</Platforms>
   </PropertyGroup>
   <PropertyGroup>
@@ -46,4 +42,6 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="$(EnlistmentRoot)\build\Common.targets" />
   <Target Name="VerifyPackCompleteEngine" AfterTargets="Pack" />
+  <!-- Project does not compile assembly; override to avoid CS2008. -->
+  <Target Name="Compile" />
 </Project>

--- a/src/InstrumentationEngine.NuGet.Headers/InstrumentationEngine.Nuget.Headers.csproj
+++ b/src/InstrumentationEngine.NuGet.Headers/InstrumentationEngine.Nuget.Headers.csproj
@@ -14,19 +14,13 @@
   <Import Project="$(EnlistmentRoot)\build\Packaging.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <NuspecFile>InstrumentationEngine.Headers.nuspec</NuspecFile>
     <NuspecProperties>$(NuspecProperties);apidir=$(InstrumentationEngineApiInc)</NuspecProperties>
-    <PreserveCompilationContext>false</PreserveCompilationContext>
     <ProjectGuid>{3D3BA42C-4A1E-4135-B750-4D8CB0A7117F}</ProjectGuid>
     <OutputType>Library</OutputType>
-    <RootNamespace>Microsoft.Diagnostics.InstrumentationEngine.NuGet.Headers</RootNamespace>
-    <!-- CS2008: Project is used for packaging only and does not produce its own assembly. -->
-    <NoWarn>CS2008</NoWarn>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
   <PropertyGroup>
@@ -40,4 +34,6 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="$(EnlistmentRoot)\build\Common.targets" />
   <Target Name="VerifyPackCompleteHeaders" AfterTargets="Pack" />
+  <!-- Project does not compile assembly; override to avoid CS2008. -->
+  <Target Name="Compile" />
 </Project>

--- a/src/InstrumentationEngine.NuGet/InstrumentationEngine.Nuget.csproj
+++ b/src/InstrumentationEngine.NuGet/InstrumentationEngine.Nuget.csproj
@@ -16,8 +16,6 @@
   <Import Project="$(EnlistmentRoot)\build\Packaging.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <ResolveNuGetPackages>true</ResolveNuGetPackages>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
@@ -27,9 +25,8 @@
     <ProjectGuid>{0B12FD8F-83DE-4A80-9BC1-ABE67E0E808A}</ProjectGuid>
     <OutputType>Library</OutputType>
     <RootNamespace>Microsoft.Diagnostics.InstrumentationEngine.NuGet</RootNamespace>
-    <!-- CS2008: Project is used for packaging only and does not produce its own assembly. -->
     <!-- NU5100: Package is used as a means to acquire the engine and not to have its assets referenced directly. -->
-    <NoWarn>CS2008;NU5100</NoWarn>
+    <NoWarn>$(NoWarn);NU5100</NoWarn>
     <Platforms>AnyCPU;x64;x86</Platforms>
   </PropertyGroup>
   <PropertyGroup>
@@ -87,4 +84,6 @@
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
   <Import Project="$(EnlistmentRoot)\build\Common.targets" />
   <Target Name="VerifyPackCompleteEngine" AfterTargets="Pack" />
+  <!-- Project does not compile assembly; override to avoid CS2008. -->
+  <Target Name="Compile" />
 </Project>

--- a/src/InstrumentationEngine.SiteExtension/InstrumentationEngine.SiteExtension.csproj
+++ b/src/InstrumentationEngine.SiteExtension/InstrumentationEngine.SiteExtension.csproj
@@ -6,8 +6,6 @@
   <Import Project="$(EnlistmentRoot)\build\Packaging.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <TargetFramework>netstandard2.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Title>InstrumentationEngine</Title>
@@ -19,8 +17,6 @@
     <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
     <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <!-- CS2008: Project is used for packaging only and does not produce its own assembly. -->
-    <NoWarn>CS2008</NoWarn>
   </PropertyGroup>
   <PropertyGroup>
     <EnableDefaultItems>false</EnableDefaultItems>
@@ -78,4 +74,6 @@
     </SiteExtensionContents>
   </ItemGroup>
   <Import Project="$(EnlistmentRoot)\build\SiteExtensions.targets" />
+  <!-- Project does not compile assembly; override to avoid CS2008. -->
+  <Target Name="Compile" />
 </Project>


### PR DESCRIPTION
Since the packaging projects do not produce a usable assembly, just override the Compile target instead of compiling an empty assembly, which alleviates the need to suppress CS2008.