### PR TITLE
Update docs for LogFilePath

### DIFF
--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -40,7 +40,7 @@ These are the environment variables and values that aid in troubleshooting the C
 | Variable | Value | Description |
 |-|-|-|
 MicrosoftInstrumentationEngine_DebugWait|1|Suspends the process until the debugger is attached.
-MicrosoftInstrumentationEngine_FileLogPath|"[FULL PATH TO LOGGING FILE]"|File to host the event logs. This requires LogLevel to be set.
+MicrosoftInstrumentationEngine_FileLogPath|"[FULL PATH TO LOGGING FILE]"|File to host the event logs. This requires LogLevel to be set. If multiple processes are profiled, then use a directory (end with slash) so that each process generates its own log file `ProfilerLog_[processId].txt`
 MicrosoftInstrumentationEngine_DisableCodeSignatureValidation|1|Disables signature validation
 MicrosoftInstrumentationEngine_IsPreinstalled|1|The preinstalled site extension for CLRIE sets this to help users know that the applicationHost.xdt file for the preinstalled extension was applied. The Application Insights private site extension won't set this.
 MicrosoftInstrumentationEngine_LatestPath|D:\Program Files (x86)\SiteExtensions\InstrumentationEngine\\[LATEST VERSION]|This environment variable is available in Azure App Service v91+ and allows private site extensions to reference the path to the latest preinstalled InstrumentationEngine.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -40,7 +40,7 @@ These are the environment variables and values that aid in troubleshooting the C
 | Variable | Value | Description |
 |-|-|-|
 MicrosoftInstrumentationEngine_DebugWait|1|Suspends the process until the debugger is attached.
-MicrosoftInstrumentationEngine_FileLogPath|"[FULL PATH TO LOGGING FILE]"|File to host the event logs. This requires LogLevel to be set. If multiple processes are profiled, then use a directory (end with slash) so that each process generates its own log file `ProfilerLog_[processId].txt`
+MicrosoftInstrumentationEngine_FileLogPath|"[FULL PATH TO LOGGING FILE]"|File to host the event logs. This requires LogLevel to be set. If multiple processes are profiled, then use a directory (`[path]\` or `[path]\.`) so that each process generates its own log file: `ProfilerLog_[processId].txt`
 MicrosoftInstrumentationEngine_DisableCodeSignatureValidation|1|Disables signature validation
 MicrosoftInstrumentationEngine_IsPreinstalled|1|The preinstalled site extension for CLRIE sets this to help users know that the applicationHost.xdt file for the preinstalled extension was applied. The Application Insights private site extension won't set this.
 MicrosoftInstrumentationEngine_LatestPath|D:\Program Files (x86)\SiteExtensions\InstrumentationEngine\\[LATEST VERSION]|This environment variable is available in Azure App Service v91+ and allows private site extensions to reference the path to the latest preinstalled InstrumentationEngine.


### PR DESCRIPTION
Setting a single log file when multiple processes are profiled causes only the first process to log correctly. This documents the ability to set LogFilePath to a directory path which allows each process to generate its own log file.