### PR TITLE
Protect method infos dictionary in ProfilerManager

### DIFF
--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -3706,12 +3706,14 @@ HRESULT CProfilerManager::AddMethodInfoToMap(_In_ FunctionID functionId, _In_ CM
         return E_FAIL;
     }
 
+    CCriticalSectionHolder holder(&m_cs);
     m_methodInfos.insert({ functionId, pMethodInfo });
     return S_OK;
 }
 
 HRESULT CProfilerManager::RemoveMethodInfoFromMap(_In_ FunctionID functionId)
 {
+    CCriticalSectionHolder holder(&m_cs);
     m_methodInfos.erase(functionId);
     return S_OK;
 }


### PR DESCRIPTION
Under bigger load CLR IE is crashing process on linux here:


```
Not Flagged		26724	0	Worker Thread		!__waitpid
 	 	 	 	 	 	libpthread.so.0!__waitpid(__pid_t pid, int * stat_loc, int options) Line 30
 	 	 	 	 	 	libcoreclr.so![Unknown/Just-In-Time compiled code]
 	 	 	 	 	 	libpthread.so.0!<signal handler called>
 	 	 	 	 	 	libInstrumentationEngine.so!std::_Hashtable<unsigned long, std::pair<unsigned long const, ATL::CComPtr<MicrosoftInstrumentationEngine::CMethodInfo> >, std::allocator<std::pair<unsigned long const, ATL::CComPtr<MicrosoftInstrumentationEngine::CMethodInfo> > >, std::__detail::_Select1st, std::equal_to<unsigned long>, std::hash<unsigned long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_rehash_aux(unsigned long, std::integral_constant<bool, true>)
 	 	 	 	 	 	libInstrumentationEngine.so!std::_Hashtable<unsigned long, std::pair<unsigned long const, ATL::CComPtr<MicrosoftInstrumentationEngine::CMethodInfo> >, std::allocator<std::pair<unsigned long const, ATL::CComPtr<MicrosoftInstrumentationEngine::CMethodInfo> > >, std::__detail::_Select1st, std::equal_to<unsigned long>, std::hash<unsigned long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_insert_unique_node(unsigned long, unsigned long, std::__detail::_Hash_node<std::pair<unsigned long const, ATL::CComPtr<MicrosoftInstrumentationEngine::CMethodInfo> >, false>*)
 	 	 	 	 	 	libInstrumentationEngine.so!std::pair<std::__detail::_Node_iterator<std::pair<unsigned long const, ATL::CComPtr<MicrosoftInstrumentationEngine::CMethodInfo> >, false, false>, bool> std::_Hashtable<unsigned long, std::pair<unsigned long const, ATL::CComPtr<MicrosoftInstrumentationEngine::CMethodInfo> >, std::allocator<std::pair<unsigned long const, ATL::CComPtr<MicrosoftInstrumentationEngine::CMethodInfo> > >, std::__detail::_Select1st, std::equal_to<unsigned long>, std::hash<unsigned long>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::_M_emplace<std::pair<unsigned long const, ATL::CComPtr<MicrosoftInstrumentationEngine::CMethodInfo> > >(std::integral_constant<bool, true>, std::pair<unsigned long const, ATL::CComPtr<MicrosoftInstrumentationEngine::CMethodInfo> >&&)
 	 	 	 	 	 	libInstrumentationEngine.so!MicrosoftInstrumentationEngine::CProfilerManager::AddMethodInfoToMap(unsigned long, MicrosoftInstrumentationEngine::CMethodInfo*)
 	 	 	 	 	 	[Unknown/Just-In-Time compiled code]
 	 	 	 	 	 	libInstrumentationEngine.so!MicrosoftInstrumentationEngine::CProfilerManager::CreateMethodInfo(unsigned long, MicrosoftInstrumentationEngine::CMethodInfo**)
 	 	 	 	 	 	libInstrumentationEngine.so!MicrosoftInstrumentationEngine::CProfilerManager::JITCompilationStarted(unsigned long, int)
 	 	 	 	 	 	libcoreclr.so![Unknown/Just-In-Time compiled code]
```


I've checked that those changes are fixing the issue. I believe on linux JITCompilationStarted/Finished can be coming in parallel and there is no protection on this dictionary. I see in JITCompilationStarted:

```
CCriticalSectionHolder holder(&m_csForJIT);
```

but there is no in JITCompilationFinished. Probably this is intentional.