### PR TITLE
Flush log file before closing it via smart pointer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please format the changes as follows:
 ## 1.0.39
 + BugFixes:
   + Remove MethodInfo creation from JitComplete events. This fixes a race condition when accessing method info map.
+  + Fix CFileLoggerSink to flush writes before closing the file.
 
 ## 1.0.38
 + New:

--- a/src/InstrumentationEngine.Lib/FileLoggerSink.cpp
+++ b/src/InstrumentationEngine.Lib/FileLoggerSink.cpp
@@ -137,10 +137,10 @@ void CFileLoggerSink::CloseLogFile()
     FILE* pOutputFile = m_pOutputFile.get();
     if (pOutputFile)
     {
-        m_pOutputFile.reset(nullptr);
-
         fflush(pOutputFile);
-        fclose(pOutputFile);
+
+        // Pointer has deleter that will close the file.
+        m_pOutputFile.reset(nullptr);
     }
 }
 


### PR DESCRIPTION
The `m_pOutputFile` smart pointer has a deleter on it that closes the file. The CFileLoggerSink::CloseLogFile method used to clear the pointer (which would close the file), then try to flush the writes to the file, and close the file. On Windows, this is benign even though it is not the correct behavior; however, on Linux, this will generate a SIGSEGV and crash the process.

The fix is to flush the writes to the file and then clear the pointer (which will close the file).

closes: #382

cc: @jakubch1 