### PR TITLE
Fix Binskim issues

### DIFF
--- a/build/yaml/steps/codeanalysis/postanalysis.yaml
+++ b/build/yaml/steps/codeanalysis/postanalysis.yaml
@@ -31,4 +31,6 @@ steps:
     GdnBreakOutputSuppressionSet: MySupp1
     GdnBreakBaselineFiles: $(Build.SourcesDirectory)\build\yaml\steps\codeanalysis\baseline
     GdnBreakBaselines: ApiScanBaseline
+    GdnBreakSuppressionFiles: $(Build.SourcesDirectory)\build\yaml\steps\codeanalysis\suppress
+    GdnBreakSuppressionSets: BinSkimSuppression
   condition: succeededOrFailed()

--- a/build/yaml/steps/codeanalysis/suppress.gdnsuppress
+++ b/build/yaml/steps/codeanalysis/suppress.gdnsuppress
@@ -1,0 +1,76 @@
+{
+  "version": "latest",
+  "suppressionSets": {
+    "BinSkimSuppression": {
+      "name": "BinSkimSuppression",
+      "createdDate": "2021-06-29 20:47:18Z",
+      "lastUpdatedDate": "2021-06-29 20:47:18Z"
+    }
+  },
+  "results": {
+    "67c5533291875bf56cdca19105b6b22411ecdd7c22e8abec4f1a22090580f80b": {
+      "signature": "67c5533291875bf56cdca19105b6b22411ecdd7c22e8abec4f1a22090580f80b",
+      "alternativeSignatures": [
+        "0be1212e84fab7e7fc54c95109c22ca392d5302d4baa265e94814ccdf2d7cd25"
+      ],
+      "target": "binaries-windows-Release/x64/CommonLibTests.exe",
+      "memberOf": [
+        "BinSkimSuppression"
+      ],
+      "tool": "binskim",
+      "ruleId": "BA2024",
+      "justification": "linking to gtest will give this warning, which we cannot change.",
+      "createdDate": "2021-06-29 20:47:18Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "9c0c38899ed52e119bfdd7008daa44537a70d0d0c818a9023130931c716172a5": {
+      "signature": "9c0c38899ed52e119bfdd7008daa44537a70d0d0c818a9023130931c716172a5",
+      "alternativeSignatures": [
+        "1700d381b7f1ed5e65c6dbcb66cea323df1bdc568f5cd53578e3a5c46cdb075d"
+      ],
+      "target": "binaries-windows-Release/x64/InstrumentationEngineLibTests.exe",
+      "memberOf": [
+        "BinSkimSuppression"
+      ],
+      "tool": "binskim",
+      "ruleId": "BA2024",
+      "justification": "linking to gtest will give this warning, which we cannot change.",
+      "createdDate": "2021-06-29 20:47:18Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "736849a4a3e9a3dadef236e1889e3f1733009721c6f49ef3526deec8712ed8b9": {
+      "signature": "736849a4a3e9a3dadef236e1889e3f1733009721c6f49ef3526deec8712ed8b9",
+      "alternativeSignatures": [
+        "e10babc8ad89fb88a86a14a15ca4c3d0b95fba7f734c034e7436fdfe04bb8b50"
+      ],
+      "target": "binaries-windows-Release/x86/CommonLibTests.exe",
+      "memberOf": [
+        "BinSkimSuppression"
+      ],
+      "tool": "binskim",
+      "ruleId": "BA2024",
+      "justification": "linking to gtest will give this warning, which we cannot change.",
+      "createdDate": "2021-06-29 20:47:18Z",
+      "expirationDate": null,
+      "type": null
+    },
+    "77cd5e20a402c668dbaf20ac67f358fd9da6faef00befaad0ce91f5f431a8f0f": {
+      "signature": "77cd5e20a402c668dbaf20ac67f358fd9da6faef00befaad0ce91f5f431a8f0f",
+      "alternativeSignatures": [
+        "3e2aa7602d9c152b7c093f87f07e622265bcc2fed5e396e5160a149ea979f0f9"
+      ],
+      "target": "binaries-windows-Release/x86/InstrumentationEngineLibTests.exe",
+      "memberOf": [
+        "BinSkimSuppression"
+      ],
+      "tool": "binskim",
+      "ruleId": "BA2024",
+      "justification": "linking to gtest will give this warning, which we cannot change.",
+      "createdDate": "2021-06-29 20:47:18Z",
+      "expirationDate": null,
+      "type": null
+    }
+  }
+}

--- a/src/Tests/CommonLibTests/CommonLibTests.vcxproj
+++ b/src/Tests/CommonLibTests/CommonLibTests.vcxproj
@@ -85,6 +85,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -100,6 +101,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -114,6 +116,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -130,6 +133,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/src/Tests/CommonLibTests/StringConversionTests.cpp
+++ b/src/Tests/CommonLibTests/StringConversionTests.cpp
@@ -8,14 +8,14 @@ using namespace std;
 using namespace CommonLib;
 TEST(StringConversionTests, u8u16test) {
     const char* ss = u8"①Ⅻㄨㄩ 啊阿鼾齄丂丄狚狛狜狝﨨﨩ˊˋ˙– ⿻〇㐀㐁䶴䶵";
-    tstring u16test = _WT("①Ⅻㄨㄩ 啊阿鼾齄丂丄狚狛狜狝﨨﨩ˊˋ˙– ⿻〇㐀㐁䶴䶵");
+    tstring u16test = _WS("①Ⅻㄨㄩ 啊阿鼾齄丂丄狚狛狜狝﨨﨩ˊˋ˙– ⿻〇㐀㐁䶴䶵");
     tstring tresult;
     EXPECT_OK(SystemString::Convert(ss, tresult));
     EXPECT_EQ(u16test, tresult);
 }
 
 TEST(StringConversionTests, u16u8test) {
-    const WCHAR* ss = _WT("①Ⅻㄨㄩ 啊阿鼾齄丂丄狚狛狜狝﨨﨩ˊˋ˙– ⿻〇㐀㐁䶴䶵");
+    const WCHAR* ss = _WS("①Ⅻㄨㄩ 啊阿鼾齄丂丄狚狛狜狝﨨﨩ˊˋ˙– ⿻〇㐀㐁䶴䶵");
     string u8test = u8"①Ⅻㄨㄩ 啊阿鼾齄丂丄狚狛狜狝﨨﨩ˊˋ˙– ⿻〇㐀㐁䶴䶵";
     string u8result;
     EXPECT_OK(SystemString::Convert(ss, u8result));

--- a/src/Tests/CommonLibTests/pch.h
+++ b/src/Tests/CommonLibTests/pch.h
@@ -25,11 +25,11 @@
 #include "Common.Lib/refcount.h"
 
 #if defined(PLATFORM_UNIX)
-#define _WT(X) u ## X
-#define _ST(X) u8 ## X
+#define _WS(X) u ## X
+#define _SS(X) u8 ## X
 #else
-#define _WT(X) L ## X
-#define _ST(X) L ## X
+#define _WS(X) L ## X
+#define _SS(X) L ## X
 #endif
 
 #define ASSERT_OK(X) ASSERT_EQ(S_OK, (X))

--- a/src/Tests/InstrumentationEngineLibTests/ConfigurationLoaderTests.cpp
+++ b/src/Tests/InstrumentationEngineLibTests/ConfigurationLoaderTests.cpp
@@ -57,7 +57,7 @@ TEST(ConfigurationTests, LoadConfigurationLoadsOneInstrumentationMethodCorrectly
 {
     // Initialze for COM, if needed.
     CoInit co;
-    auto fileName = fs::current_path() / _ST("ConfigLoads.xml");
+    auto fileName = fs::current_path() / _SS("ConfigLoads.xml");
     if (exists(fileName))
     {
         remove(fileName);
@@ -69,15 +69,15 @@ TEST(ConfigurationTests, LoadConfigurationLoadsOneInstrumentationMethodCorrectly
 
     ASSERT_TRUE(!output.fail() && !output.bad());
 
-    output << _ST("<InstrumentationEngineConfiguration>") << std::endl;
-    output << _ST("  <InstrumentationMethod>") << std::endl;
-    output << _ST("    <Name>Squid Instrumentation</Name>") << std::endl;
-    output << _ST("    <Description>Dynamically make squids swim</Description>") << std::endl;
-    output << _ST("    <Module>SeafoodInstrumentation.dll</Module>") << std::endl;
-    output << _ST("    <ClassGuid>{249E89A6-12D9-4E03-82FF-7FEAA41310E9}</ClassGuid>") << std::endl;
-    output << _ST("    <Priority>50</Priority>") << std::endl;
-    output << _ST("  </InstrumentationMethod>") << std::endl;
-    output << _ST("</InstrumentationEngineConfiguration>") << std::endl;
+    output << _SS("<InstrumentationEngineConfiguration>") << std::endl;
+    output << _SS("  <InstrumentationMethod>") << std::endl;
+    output << _SS("    <Name>Squid Instrumentation</Name>") << std::endl;
+    output << _SS("    <Description>Dynamically make squids swim</Description>") << std::endl;
+    output << _SS("    <Module>SeafoodInstrumentation.dll</Module>") << std::endl;
+    output << _SS("    <ClassGuid>{249E89A6-12D9-4E03-82FF-7FEAA41310E9}</ClassGuid>") << std::endl;
+    output << _SS("    <Priority>50</Priority>") << std::endl;
+    output << _SS("  </InstrumentationMethod>") << std::endl;
+    output << _SS("</InstrumentationEngineConfiguration>") << std::endl;
 
     output.close();
 
@@ -98,7 +98,7 @@ TEST(ConfigurationTests, LoadConfigurationLoadsOneInstrumentationMethodCorrectly
 TEST(ConfigurationTests, LoadConfigurationDoesNotCrashWhenDescriptionIsMissing)
 {
     CoInit co;
-    auto fileName = fs::current_path() / _ST("ConfigFails.xml");
+    auto fileName = fs::current_path() / _SS("ConfigFails.xml");
     if (exists(fileName))
     {
         remove(fileName);
@@ -108,14 +108,14 @@ TEST(ConfigurationTests, LoadConfigurationDoesNotCrashWhenDescriptionIsMissing)
     output.open(fileName, ios_base::app | ios_base::out);
     ASSERT_TRUE(!output.fail() && !output.bad());
 
-    output << _ST("<InstrumentationEngineConfiguration>") << std::endl;
-    output << _ST("<InstrumentationMethod>") << std::endl;
-    output << _ST("  <Name>Squid Instrumentation</Name>") << std::endl;
-    output << _ST("  <Module>SeafoodInstrumentation.dll</Module>") << std::endl;
-    output << _ST("  <ClassGuid>{249E89A6-12D9-4E03-82FF-7FEAA41310E9}</ClassGuid>") << std::endl;
-    output << _ST("  <Priority>50</Priority>") << std::endl;
-    output << _ST("</InstrumentationMethod>") << std::endl;
-    output << _ST("</InstrumentationEngineConfiguration>") << std::endl;
+    output << _SS("<InstrumentationEngineConfiguration>") << std::endl;
+    output << _SS("<InstrumentationMethod>") << std::endl;
+    output << _SS("  <Name>Squid Instrumentation</Name>") << std::endl;
+    output << _SS("  <Module>SeafoodInstrumentation.dll</Module>") << std::endl;
+    output << _SS("  <ClassGuid>{249E89A6-12D9-4E03-82FF-7FEAA41310E9}</ClassGuid>") << std::endl;
+    output << _SS("  <Priority>50</Priority>") << std::endl;
+    output << _SS("</InstrumentationMethod>") << std::endl;
+    output << _SS("</InstrumentationEngineConfiguration>") << std::endl;
 
     output.close();
 

--- a/src/Tests/InstrumentationEngineLibTests/InstrumentationEngineLibTests.vcxproj
+++ b/src/Tests/InstrumentationEngineLibTests/InstrumentationEngineLibTests.vcxproj
@@ -102,6 +102,7 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -116,6 +117,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -132,6 +134,7 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/src/Tests/InstrumentationEngineLibTests/pch.h
+++ b/src/Tests/InstrumentationEngineLibTests/pch.h
@@ -61,11 +61,11 @@
 
 
 #if defined(PLATFORM_UNIX)
-#define _WT(X) u ## X
-#define _ST(X) u8 ## X
+#define _WS(X) u ## X
+#define _SS(X) u8 ## X
 #else
-#define _WT(X) L ## X
-#define _ST(X) L ## X
+#define _WS(X) L ## X
+#define _SS(X) L ## X
 #endif
 
 


### PR DESCRIPTION
Security tools are complaining that our google tests don't have control flow guards and spectre mitigation enabled.  We are able to fix the error about control flow guard by just enabling it. However, BinSkim will always fail the spectre mitigation check because the libs supplied by the gtest nuget are not compiled with spectre mitigation. Therefore, we suppress that warning.