### PR TITLE
Fix roslyn static analysis

### DIFF
--- a/InstrumentationEngine.sln
+++ b/InstrumentationEngine.sln
@@ -527,7 +527,6 @@ Global
 		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|x64.ActiveCfg = Release|Any CPU
 		{9DFAD1B4-8F6D-483D-8932-00D2D8B87708}.Release|x86.ActiveCfg = Release|Any CPU
 		{DF259ED5-4041-4089-8A55-D0C7E695EE3C}.CodeAnalysis.Managed|Any CPU.ActiveCfg = Release|Win32
-		{DF259ED5-4041-4089-8A55-D0C7E695EE3C}.CodeAnalysis.Managed|Any CPU.Build.0 = Release|Win32
 		{DF259ED5-4041-4089-8A55-D0C7E695EE3C}.CodeAnalysis.Managed|x64.ActiveCfg = Release|x64
 		{DF259ED5-4041-4089-8A55-D0C7E695EE3C}.CodeAnalysis.Managed|x64.Build.0 = Release|x64
 		{DF259ED5-4041-4089-8A55-D0C7E695EE3C}.CodeAnalysis.Managed|x86.ActiveCfg = Release|Win32
@@ -548,7 +547,6 @@ Global
 		{DF259ED5-4041-4089-8A55-D0C7E695EE3C}.Release|x86.ActiveCfg = Release|Win32
 		{DF259ED5-4041-4089-8A55-D0C7E695EE3C}.Release|x86.Build.0 = Release|Win32
 		{B1FFBD51-80A9-41D6-BC54-07B7E0DE7CF6}.CodeAnalysis.Managed|Any CPU.ActiveCfg = Release|x64
-		{B1FFBD51-80A9-41D6-BC54-07B7E0DE7CF6}.CodeAnalysis.Managed|Any CPU.Build.0 = Release|x64
 		{B1FFBD51-80A9-41D6-BC54-07B7E0DE7CF6}.CodeAnalysis.Managed|x64.ActiveCfg = Release|x64
 		{B1FFBD51-80A9-41D6-BC54-07B7E0DE7CF6}.CodeAnalysis.Managed|x64.Build.0 = Release|x64
 		{B1FFBD51-80A9-41D6-BC54-07B7E0DE7CF6}.CodeAnalysis.Managed|x86.ActiveCfg = Release|Win32


### PR DESCRIPTION
We were accidentally building some C++ unit tests
during the managed static analysis builds. This
was confusing the static analysis and causing it
to fail.