### PR TITLE
Rename branches: main to release, develop to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,14 +22,14 @@ or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any addi
 
 ## Branches
 
-Active development is happening in `develop` branch.
+Active development is happening in `main` branch.
 
-Last released version is in `main` branch.
+Last released version is in `release` branch.
 
 ## Submitting your Pull Request:
 
 - Build solution in both `Release` and `Debug` configurations (see *Building locally* section)
-- Create a Pull Request against the `develop` branch and add clrieowners@microsoft.com as a reviewer
+- Create a Pull Request against the `main` branch and add clrieowners@microsoft.com as a reviewer
 
 ## Instrumentation Engine Api Changes
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ﻿# CLR Instrumentation Engine
 
-Develop Branch: [![Build Status](https://dev.azure.com/ms/CLRInstrumentationEngine/_apis/build/status/CI-Yaml?branchName=develop)](https://dev.azure.com/ms/CLRInstrumentationEngine/_build/latest?definitionId=275&branchName=develop)
+Main Branch: [![Build Status](https://dev.azure.com/ms/CLRInstrumentationEngine/_apis/build/status/CI-Yaml?branchName=main)](https://dev.azure.com/ms/CLRInstrumentationEngine/_build/latest?definitionId=275&branchName=main)
 
-Main Branch: [![Build Status](https://devdiv.visualstudio.com/DevDiv/_apis/build/status/ClrInstrumentationEngine/GitHub/ClrInstrumentationEngine-Signed-Yaml?branchName=main)](https://devdiv.visualstudio.com/DevDiv/_build/latest?definitionId=11311&branchName=main)
+Release Branch: [![Build Status](https://devdiv.visualstudio.com/DevDiv/_apis/build/status/ClrInstrumentationEngine/GitHub/ClrInstrumentationEngine-Signed-Yaml?branchName=release)](https://devdiv.visualstudio.com/DevDiv/_build/latest?definitionId=11311&branchName=release)
 
 ## Overview
 

--- a/build/yaml/pipelines/codeanalysis.yaml
+++ b/build/yaml/pipelines/codeanalysis.yaml
@@ -15,7 +15,7 @@ schedules:
   displayName: Weekly Static Analysis
   branches:
     include:
-    - main
+    - release
 
 variables:
   TeamName: ClrInstrumentationEngine

--- a/build/yaml/pipelines/codeanalysis.yaml
+++ b/build/yaml/pipelines/codeanalysis.yaml
@@ -8,15 +8,6 @@
 
 name: $(date:yyyyMMdd)$(rev:rr)
 
-# Trigger every Sunday at 8am UTC (Sunday at midnight PST)
-# See https://docs.microsoft.com/azure/devops/pipelines/build/triggers?tabs=yaml&view=azure-devops#scheduled-triggers
-schedules:
-- cron: "0 8 * * Sun"
-  displayName: Weekly Static Analysis
-  branches:
-    include:
-    - release
-
 variables:
   TeamName: ClrInstrumentationEngine
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,14 +1,14 @@
 # Releasing the CLR Instrumentation Engine
 
-Release occurs from the `main` branch. Please notify clrieowners@microsoft.com to initiate the release process.
+Release occurs from the `release` branch. Please notify clrieowners@microsoft.com to initiate the release process.
 
 ## Microsoft Internal Process
 
 ### Develop Phase
-1.  When changes are merged to develop branch, the
-[Develop-CI](https://devdiv.visualstudio.com/DevDiv/_build/index?context=allDefinitions&path=%5CClrInstrumentationEngine%5CGitHub&definitionId=10093&_a=completed)
+1.  When changes are merged to `main` branch, the
+[Main-CI](https://devdiv.visualstudio.com/DevDiv/_build/index?context=allDefinitions&path=%5CClrInstrumentationEngine%5CGitHub&definitionId=10093&_a=completed)
 build runs and creates artifacts (NuGet, zip, etc.)
-2.  Once the build completes, the [Develop-CI Release](https://devdiv.visualstudio.com/DevDiv/_releases2?view=all&definitionId=1116) pipeline
+2.  Once the build completes, the [Main-CI Release](https://devdiv.visualstudio.com/DevDiv/_releases2?view=all&definitionId=1116) pipeline
 automatically publishes artifacts to the internal NuGet feed with a preview version (eg. 1.0.15-build00001)
 3.  When a release occurs, a PR to version bump the Instrumentation Engine as well as updating the [CHANGELOG](../CHANGELOG.md) should occur.
 
@@ -16,7 +16,7 @@ automatically publishes artifacts to the internal NuGet feed with a preview vers
 Based on the changes and targeted platform releases, impacted scenarios and partner teams should be involved in testing for regressions.
 
 ### Release Phase
-1.  Once testing completes, PR to merge develop branch to main branch
+1.  Once testing completes, PR to merge `main` branch to `release` branch
 2.  Manually run the [Signed](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=11311) build to create release artifacts
 3.  Manually run the
 [CLR Instrumentation Engine Release](https://devdiv.visualstudio.com/DevDiv/_releases2?view=all&definitionId=901)


### PR DESCRIPTION
These changes rename the branches as described in #410. This change targets the current main branch so that when the new release branch is forked from it, the changes are already in the release branch.