### PR TITLE
Rollback Microsoft.Web.Xdt to 1.4.0

### DIFF
--- a/src/InstrumentationEngine.SiteExtension/InstrumentationEngine.SiteExtension.csproj
+++ b/src/InstrumentationEngine.SiteExtension/InstrumentationEngine.SiteExtension.csproj
@@ -6,7 +6,7 @@
   <Import Project="$(EnlistmentRoot)\build\Packaging.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Title>InstrumentationEngine</Title>
     <Authors>$(PackageAuthors)</Authors>

--- a/src/InstrumentationEngine.XdtExtensions/XdtExtensions.csproj
+++ b/src/InstrumentationEngine.XdtExtensions/XdtExtensions.csproj
@@ -5,11 +5,11 @@
   <PropertyGroup>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <RootNamespace>Microsoft.InstrumentationEngine.XdtExtensions</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Web.Xdt" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Web.Xdt" Version="1.4.0" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="$(MicroBuildCoreVersion)">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Attach without restart is broken for the test InstrumentationEngine site extension. The reason is that the XdtExtensions assembly is requiring a version of Microsoft.Web.Xdt that is newer than what App Service uses, so the assembly fails to load, which then causes the custom transform usage to fail the entire transform process for the InstrumentationEngine site extension.

The 1.4.0 version of Microsoft.Web.Xdt does not have any .NET Core or .NET Standard support, so I had to change the target framework of the projects to .NET Framework (and chose a reasonable version that should be supported for a while). It's not important for the site extension project since its assembly is not actually used.

Overview of changes:
- Rollback Microsoft.Web.Xdt to 1.4.0
- Update projects to net462 to avoid target framework inconsistencies.