### PR TITLE
Build fixes for OSX and recent Linux

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,42 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+name: build
+
+on: [push]
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        # Note OSX isn't officially supported yet, but might be in the future.
+        # The build here will help ensure no changes are introduced that
+        # would make it difficult.
+        os: [ ubuntu-latest, macos-latest ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/cache@v2
+      with:
+        path: out/packages
+        key: nuget
+
+    - run: src/build.sh x64 release
+
+    - name: archive so
+      if: matrix.os == 'ubuntu-latest'
+      uses: actions/upload-artifact@v2
+      with:
+        name: libInstrumentationEngine.so
+        path: out/Linux/bin/x64.Release/ClrInstrumentationEngine/libInstrumentationEngine.so
+
+    - name: archive dylib
+      if: matrix.os == 'macos-latest'
+      uses: actions/upload-artifact@v2
+      with:
+        name: libInstrumentationEngine.dylib
+        path: out/OSX/bin/x64.Release/ClrInstrumentationEngine/libInstrumentationEngine.dylib

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Please format the changes as follows:
   + Fix XmlReader.Create to read from stream instead of filepath string
   + Remove references to libunwind8 and libuuid; they're not used anymore
   + Fixes for compatibility with recent clang versions
+  + Fix bad memset argument order in AppDomainCollection::GetAppDomainIDs
 + Updates:
   + Use net50 platform for restoring native dependencies on Unix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.43
-+ BugFixes:
-  + Fix XmlReader.Create to read from stream instead of filepath string
 + New:
   + On Unix, environment is now scanned for instrumentation methods instead of looking for hardcoded ProductionBreakpoints.
++ BugFixes:
+  + Fix XmlReader.Create to read from stream instead of filepath string
++ Updates:
+  + Use net50 platform for restoring native dependencies on Unix
 
 ## 1.0.42
 + BugFixes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Please format the changes as follows:
   + On Unix, environment is now scanned for instrumentation methods instead of looking for hardcoded ProductionBreakpoints.
 + BugFixes:
   + Fix XmlReader.Create to read from stream instead of filepath string
+  + Remove references to libunwind8 and libuuid; they're not used anymore
 + Updates:
   + Use net50 platform for restoring native dependencies on Unix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Please format the changes as follows:
 + BugFixes:
   + Fix XmlReader.Create to read from stream instead of filepath string
   + Remove references to libunwind8 and libuuid; they're not used anymore
+  + Fixes for compatibility with recent clang versions
 + Updates:
   + Use net50 platform for restoring native dependencies on Unix
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Please format the changes as follows:
 ## 1.0.43
 + New:
   + On Unix, environment is now scanned for instrumentation methods instead of looking for hardcoded ProductionBreakpoints.
+  + Allow building on OSX. Note this is only experimental and not officially supported yet.
 + BugFixes:
   + Fix XmlReader.Create to read from stream instead of filepath string
   + Remove references to libunwind8 and libuuid; they're not used anymore

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -153,6 +153,8 @@ macro (build_init build_language build_type)
     add_compile_options(-Wno-new-returns-null)
     add_compile_options(-Wno-deprecated-declarations)
     add_compile_options(-Wno-delete-incomplete)
+    add_compile_options(-Wno-pragma-pack)
+    add_compile_options(-Wno-unknown-warning-option)
 
     # Turn all enabled warnings into errors
     add_compile_options(-Werror)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -274,8 +274,8 @@ endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    message(FATAL_ERROR "Darwin build not supported.")
-    return()
+    set(PLAT_DLL_EXT "dylib")
+    set(CLR_CMAKE_PLATFORM_UNIX 1)
 elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
     set(PLAT_DLL_EXT "so")
 else()
@@ -322,33 +322,39 @@ if (CMAKE_SYSTEM_NAME STREQUAL Linux)
     )
 
     add_custom_target(pal_redefines DEPENDS ${REDEFINES_FILE})
+elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    message(NOTICE "Building for Darwin is currently experimental.")
 
-    function(add_library_pal target_name do_redefinition lib_location)
-        get_filename_component(lib_file_name ${lib_location} NAME)
-        set(redefine_lib_location ${CMAKE_CURRENT_BINARY_DIR}/${lib_file_name})
-
-        if(${do_redefinition})
-            # Copy the PAL lib from it's original location and do the redefine
-            add_custom_command(
-                OUTPUT ${redefine_lib_location}
-                COMMAND ${OBJCOPY} --redefine-syms ${REDEFINES_FILE} ${lib_location} ${redefine_lib_location}
-                DEPENDS pal_redefines ${lib_location} ${REDEFINES_FILE}
-                COMMENT "Redefining exported PAL symbols in ${lib_location}"
-            )
-        else()
-            configure_file(${lib_location} ${redefine_lib_location} COPYONLY)
-        endif(${do_redefinition})
-
-        add_custom_target(${target_name}_redefines DEPENDS ${redefine_lib_location})
-
-        add_library(${target_name} STATIC IMPORTED)
-        set_property(TARGET ${target_name} PROPERTY IMPORTED_LOCATION ${redefine_lib_location})
-
-        add_dependencies(${target_name} ${target_name}_redefines)
-    endfunction()
+    # Dummy noop target to prevent warnings.
+    add_custom_target(pal_redefines_header)
 else()
-    message(FATAL_ERROR "Linux is only supported platform.")
+    message(FATAL_ERROR "CMake build not supported for system '${CMAKE_SYSTEM_NAME}'")
 endif()
+
+function(add_library_pal target_name do_redefinition lib_location)
+    get_filename_component(lib_file_name ${lib_location} NAME)
+    set(redefine_lib_location ${CMAKE_CURRENT_BINARY_DIR}/${lib_file_name})
+
+    if((CMAKE_SYSTEM_NAME STREQUAL Linux) AND ${do_redefinition})
+        # Copy the PAL lib from it's original location and do the redefine
+        add_custom_command(
+            OUTPUT ${redefine_lib_location}
+            COMMAND ${OBJCOPY} --redefine-syms ${REDEFINES_FILE} ${lib_location} ${redefine_lib_location}
+            DEPENDS pal_redefines ${lib_location} ${REDEFINES_FILE}
+            COMMENT "Redefining exported PAL symbols in ${lib_location}"
+        )
+    else()
+        configure_file(${lib_location} ${redefine_lib_location} COPYONLY)
+    endif()
+
+    add_custom_target(${target_name}_redefines DEPENDS ${redefine_lib_location})
+
+    add_library(${target_name} STATIC IMPORTED)
+    set_property(TARGET ${target_name} PROPERTY IMPORTED_LOCATION ${redefine_lib_location})
+
+    add_dependencies(${target_name} ${target_name}_redefines)
+endfunction()
+
 add_library_pal(coreclrpal true ${CORECLR_PAL_ROOT}/lib/${CMAKE_BUILD_TYPE}/libcoreclrpal.a)
 add_library_pal(palrt true ${CORECLR_PAL_ROOT}/lib/${CMAKE_BUILD_TYPE}/libpalrt.a)
 add_library_pal(corguids false ${CORECLR_PAL_ROOT}/lib/${CMAKE_BUILD_TYPE}/libcorguids.a)
@@ -363,4 +369,3 @@ add_subdirectory(InstrumentationEngine)
 enable_testing()
 add_subdirectory(Tests/CommonLibTests)
 add_subdirectory(Tests/InstrumentationEngineLibTests)
-

--- a/src/Common.Headers/tstring.h
+++ b/src/Common.Headers/tstring.h
@@ -15,9 +15,7 @@
 
 #ifdef PLATFORM_UNIX
 typedef std::basic_string<WCHAR, std::char_traits<WCHAR>, std::allocator<WCHAR>> tstring;
-typedef std::basic_stringstream<WCHAR> tstringstream;
 #else
 typedef std::wstring tstring;
-typedef std::wstringstream tstringstream;
 #endif
 typedef std::basic_ofstream<WCHAR, std::char_traits<WCHAR> > tofstream;

--- a/src/Dependencies/NativeDependencies.csproj
+++ b/src/Dependencies/NativeDependencies.csproj
@@ -19,11 +19,11 @@
   <!-- This must be a relative or absolute path, not computed, so that dotnet restore on Linux finds this correctly. -->
   <Import Project="$(MSBuildThisFileDirectory)..\..\build\Common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
-  <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
-  </PropertyGroup>
   <Choose>
     <When Condition="!$([MSBuild]::IsOsPlatform('Windows'))">
+      <PropertyGroup>
+        <TargetFramework>net50</TargetFramework>
+      </PropertyGroup>
       <ItemGroup>
         <PackageReference Include="Microsoft.VisualStudio.Debugger.CoreCLRPAL" Version="$(CoreClrPalVersion)">
           <ExcludeAssets>All</ExcludeAssets>
@@ -31,6 +31,9 @@
       </ItemGroup>
     </When>
     <Otherwise>
+      <PropertyGroup>
+        <TargetFramework>net461</TargetFramework>
+      </PropertyGroup>
       <ItemGroup>
         <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept" Version="$(ApplicationInsightsAgentInterceptVersion)">
           <ExcludeAssets>All</ExcludeAssets>

--- a/src/InstrumentationEngine.Lib/Logging.h
+++ b/src/InstrumentationEngine.Lib/Logging.h
@@ -41,7 +41,7 @@ namespace MicrosoftInstrumentationEngine
             tstring m_tag;
             tstring m_indent;
             tstring m_childrenIndent;
-            tstringstream m_result;
+            tstring m_result;
         public:
             XmlDumpHelper(const WCHAR* tag, const unsigned int indent);
             ~XmlDumpHelper();

--- a/src/InstrumentationEngine/AppDomainCollection.cpp
+++ b/src/InstrumentationEngine/AppDomainCollection.cpp
@@ -105,7 +105,7 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAppDomainIDs(_I
     IfNullRetPointer(pcActual);
     IfNullRetPointer(pAppDomainIDs);
 
-    memset(pAppDomainIDs, cAppDomains, 0);
+    memset(pAppDomainIDs, 0, cAppDomains);
 
     *pcActual = 0;
 

--- a/src/InstrumentationEngine/CMakeLists.txt
+++ b/src/InstrumentationEngine/CMakeLists.txt
@@ -91,8 +91,6 @@ target_link_libraries(${PROJECT_NAME}
     InstrumentationEngine.Api
     InstrumentationEngine.Lib
     corguids
-    :libuuid.so
-    :libunwind-x86_64.so
     )
 
 #ensure that the linux pal gets built before this

--- a/src/InstrumentationEngine/CMakeLists.txt
+++ b/src/InstrumentationEngine/CMakeLists.txt
@@ -62,21 +62,28 @@ add_lib(${PROJECT_NAME}
     ${src_files}
     )
 
-# Force every object to be included even if it's unused.
-SET (ATL -Wl,--whole-archive atl -Wl,--no-whole-archive)
-SET (CORECLRPAL -Wl,--whole-archive coreclrpal -Wl,--no-whole-archive)
-SET (LINUXPAL -Wl,--whole-archive linux_pal -Wl,--no-whole-archive)
-#SET (LINUXPALRT -Wl,--whole-archive palrt -Wl,--no-whole-archive)
+if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+    # Force every object to be included even if it's unused.
+    SET (ATL -Wl,--whole-archive atl -Wl,--no-whole-archive)
+    SET (CORECLRPAL -Wl,--whole-archive coreclrpal -Wl,--no-whole-archive)
+    SET (LINUXPAL -Wl,--whole-archive linux_pal -Wl,--no-whole-archive)
+else()
+    SET (ATL atl)
+    SET (CORECLRPAL coreclrpal)
+    SET (LINUXPAL linux_pal)
+endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 
 # For some reason linking against musl-libc we need libintl and on glibc we need libdl.
 # They have nothing to do with one another, each is just a quirk of the environment.
 if(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
     target_link_libraries(${PROJECT_NAME} :libintl.so)
-else()
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
     # NOTE: Explicitly link to the .so version of libdl.so to make sure we don't somehow accidentally
     # start statically linking to these, as these are LGPL components.
     target_link_libraries(${PROJECT_NAME} :libdl.so)
+else()
+    target_link_libraries(${PROJECT_NAME} dl)
 endif()
 
 target_link_libraries(${PROJECT_NAME}
@@ -92,6 +99,14 @@ target_link_libraries(${PROJECT_NAME}
     InstrumentationEngine.Lib
     corguids
     )
+
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    target_link_libraries(${PROJECT_NAME}
+        iconv
+        "-framework CoreFoundation"
+        "-framework Security"
+    )
+endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
 
 #ensure that the linux pal gets built before this
 add_dependencies(${PROJECT_NAME} atl)

--- a/src/InstrumentationEngine/MethodInfo.cpp
+++ b/src/InstrumentationEngine/MethodInfo.cpp
@@ -206,7 +206,7 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeFullName()
     }*/
 
     //Build fullName
-    tstringstream nameBuilder;
+    tstring name;
     if (m_pDeclaringType)
     {
         CComBSTR declaringTypeName;
@@ -214,13 +214,14 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeFullName()
             declaringTypeName != nullptr &&
             declaringTypeName.Length() > 0)
         {
-            nameBuilder << (LPWSTR)declaringTypeName << _T(".");
+            name += (LPWSTR)declaringTypeName;
+            name += _T(".");
         }
     }
 
-    nameBuilder << (LPWSTR)m_bstrMethodName;
+    name += (LPWSTR)m_bstrMethodName;
 
-    m_bstrMethodFullName = nameBuilder.str().c_str();
+    m_bstrMethodFullName = name.c_str();
     return S_OK;
 }
 
@@ -1124,9 +1125,10 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeName(_In_ mdToken
 
     if (!m_genericParameters.empty())
     {
-        tstringstream nameBuilder;
+        tstring name;
 
-        nameBuilder << (LPWSTR)m_bstrMethodName << _T("<");
+        name += (LPWSTR)m_bstrMethodName;
+        name += _T("<");
 
         ULONG cparams = static_cast<ULONG>(m_genericParameters.size());
         IfFalseRet(cparams == m_genericParameters.size(), E_BOUNDS);
@@ -1134,18 +1136,17 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeName(_In_ mdToken
         {
             WCHAR szIndex[11] = { 0 }; // ULONG probably can contain 4,294,967,295 so make space for 10 digits + \0.
             _ultow_s(i, szIndex, 11, 10);
-            nameBuilder << _T("!!") << szIndex;
+            name += _T("!!");
+            name += szIndex;
 
             if (i < cparams - 1)
             {
-                nameBuilder << _T(",");
+                name += _T(",");
             }
         }
-        nameBuilder << _T(">");
+        name += _T(">");
 
-        tstring value = nameBuilder.str();
-
-        m_bstrMethodName = value.c_str();
+        m_bstrMethodName = name.c_str();
     }
 
     return S_OK;

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -2627,14 +2627,14 @@ HRESULT CProfilerManager::ExceptionSearchCatcherFound(
 }
 
 HRESULT CProfilerManager::ExceptionOSHandlerEnter(
-    _In_ UINT_PTR __unused
+    _In_ UINT_PTR unused
     )
 {
     HRESULT hr = S_OK;
 
     PROF_CALLBACK_BEGIN
 
-    IfFailRet(SendEventToRawProfilerCallback(&ICorProfilerCallback::ExceptionOSHandlerEnter, __unused));
+    IfFailRet(SendEventToRawProfilerCallback(&ICorProfilerCallback::ExceptionOSHandlerEnter, unused));
 
     PROF_CALLBACK_END
 
@@ -2642,14 +2642,14 @@ HRESULT CProfilerManager::ExceptionOSHandlerEnter(
 }
 
 HRESULT CProfilerManager::ExceptionOSHandlerLeave(
-    _In_ UINT_PTR __unused
+    _In_ UINT_PTR unused
     )
 {
     HRESULT hr = S_OK;
 
     PROF_CALLBACK_BEGIN
 
-    IfFailRet(SendEventToRawProfilerCallback(&ICorProfilerCallback::ExceptionOSHandlerLeave, __unused));
+    IfFailRet(SendEventToRawProfilerCallback(&ICorProfilerCallback::ExceptionOSHandlerLeave, unused));
 
     PROF_CALLBACK_END
 

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -50,7 +50,7 @@ CProfilerManager::CProfilerManager() :
     GetEnvironmentVariable(_T("MicrosoftInstrumentationEngine_MessageboxAtAttach"), wszEnvVar, MAX_PATH);
     if (wcscmp(wszEnvVar, _T("1")) == 0)
     {
-        tstringstream mboxStream;
+        std::wstringstream mboxStream;
         DWORD pid = GetCurrentProcessId();
         mboxStream << _T("MicrosoftInstrumentationEngine ProfilerAttach. PID: ") << pid;
         MessageBoxW(NULL, mboxStream.str().c_str(), L"", MB_OK);

--- a/src/Tests/CommonLibTests/CMakeLists.txt
+++ b/src/Tests/CommonLibTests/CMakeLists.txt
@@ -34,5 +34,11 @@ target_link_libraries(
     gtest_main
 )
 
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    target_link_libraries(${PROJECT_NAME}
+        iconv
+    )
+endif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+
 include(GoogleTest)
 gtest_discover_tests(${PROJECT_NAME})

--- a/src/Tests/InstrumentationEngineLibTests/CMakeLists.txt
+++ b/src/Tests/InstrumentationEngineLibTests/CMakeLists.txt
@@ -59,8 +59,6 @@ target_link_libraries(
     Common.Lib
     palrt
     corguids
-    :libuuid.so
-    :libunwind-x86_64.so
     stdc++fs
     gtest_main
 )

--- a/src/Tests/InstrumentationEngineLibTests/CMakeLists.txt
+++ b/src/Tests/InstrumentationEngineLibTests/CMakeLists.txt
@@ -29,21 +29,28 @@ add_exe(
     ${src_files}
     )
 
-# Force every object to be included even if it's unused.
-SET (ATL -Wl,--whole-archive atl -Wl,--no-whole-archive)
-SET (CORECLRPAL -Wl,--whole-archive coreclrpal -Wl,--no-whole-archive)
-SET (LINUXPAL -Wl,--whole-archive linux_pal -Wl,--no-whole-archive)
-#SET (LINUXPALRT -Wl,--whole-archive palrt -Wl,--no-whole-archive)
+if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+    # Force every object to be included even if it's unused.
+    SET (ATL -Wl,--whole-archive atl -Wl,--no-whole-archive)
+    SET (CORECLRPAL -Wl,--whole-archive coreclrpal -Wl,--no-whole-archive)
+    SET (LINUXPAL -Wl,--whole-archive linux_pal -Wl,--no-whole-archive)
+else()
+    SET (ATL atl)
+    SET (CORECLRPAL coreclrpal)
+    SET (LINUXPAL linux_pal)
+endif(CMAKE_SYSTEM_NAME STREQUAL Linux)
 
 
 # For some reason linking against musl-libc we need libintl and on glibc we need libdl.
 # They have nothing to do with one another, each is just a quirk of the environment.
 if(CLR_CMAKE_PLATFORM_ALPINE_LINUX)
     target_link_libraries(${PROJECT_NAME} :libintl.so)
-else()
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
     # NOTE: Explicitly link to the .so version of libdl.so to make sure we don't somehow accidentally
     # start statically linking to these, as these are LGPL components.
     target_link_libraries(${PROJECT_NAME} :libdl.so)
+else()
+    target_link_libraries(${PROJECT_NAME} dl)
 endif()
 
 target_link_libraries(
@@ -59,9 +66,18 @@ target_link_libraries(
     Common.Lib
     palrt
     corguids
-    stdc++fs
     gtest_main
 )
+
+if (CMAKE_SYSTEM_NAME STREQUAL Linux)
+    target_link_libraries(${PROJECT_NAME} stdc++fs)
+elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
+    target_link_libraries(${PROJECT_NAME}
+        iconv
+        "-framework CoreFoundation"
+        "-framework Security"
+    )
+endif()
 
 add_dependencies(${PROJECT_NAME} atl)
 add_dependencies(${PROJECT_NAME} linux_pal)

--- a/src/build.sh
+++ b/src/build.sh
@@ -125,7 +125,7 @@ get_cmake()
     hash cmake 2>/dev/null || {
          $cmakeLocation=download_cmake
          echo cmakeLocation
-         return; 
+         return;
     }
 
     # get the current version of cmake, and see if it is high enough
@@ -183,11 +183,9 @@ locate_build_tools()
 
     if [[ $__BuildOS == "Linux" ]]; then
         linux_id_file="/etc/os-release"
-    else
-        echo "Build only supports Linux."
     fi
 
-    if [[ -e $linux_id_file ]]; then
+    if [[ -e "$linux_id_file" ]]; then
         source $linux_id_file
         cmake_extra_defines="$cmake_extra_defines -DCLR_CMAKE_LINUX_ID=$ID"
     fi
@@ -220,7 +218,8 @@ invoke_build()
       "-DGOOGLE_TEST_URL=$__GoogleTestUrl" \
       "-DGOOGLE_TEST_TAG=$__GoogleTestTag" \
       $cmake_extra_defines \
-      "$EnlistmentRoot/src"
+      -S "$EnlistmentRoot/src" \
+      -B "$__IntermediatesDir"
 
     # Check that the makefiles were created.
     if [ ! -f "$__IntermediatesDir/Makefile" ]; then
@@ -580,7 +579,7 @@ write_commit_file
 
 #copy binaries to output
 
-find $__IntermediatesDir -name "*.so" -exec cp {} $__ClrInstrumentationEngineDir ";"
+find $__IntermediatesDir \( -name "*.so" -o -name "*.dylib" \) -exec cp {} $__ClrInstrumentationEngineDir ";"
 
 # Build complete
 

--- a/src/build.sh
+++ b/src/build.sh
@@ -381,7 +381,7 @@ set_clang_path_and_version()
                 print_install_instructions
                 exit 1
             fi
-            ClangVersion=$(clang --version | head -n 1 | grep -o -E "[[:digit:]].[[:digit:]].[[:digit:]]" | uniq)
+            ClangVersion=$(clang --version | head -n 1 | grep -o -E "[[:digit:]]+.[[:digit:]].[[:digit:]]" | uniq | head -n1)
         fi
 
         local ClangVersionArray=(${ClangVersion//./ })

--- a/src/build.sh
+++ b/src/build.sh
@@ -13,7 +13,7 @@ print_install_instructions()
         echo "  Follow the instructions here: https://docs.microsoft.com/dotnet/core/linux-prerequisites?tabs=netcore2x"
         echo ""
         echo "  # Install required packages"
-        echo "  sudo apt-get install cmake clang-4.0 libunwind8 libunwind8-dev uuid-dev"
+        echo "  sudo apt-get install cmake clang-4.0"
         echo ""
     elif [ "$OSName" == "Darwin" ]; then
         echo ""

--- a/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
+++ b/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
@@ -37,8 +37,6 @@ RUN apt-get update \
         clang-3.9 \
         cmake \
         git \
-        libunwind8-dev \
         libxml2-dev \
         make \
-        uuid-dev \
         jq

--- a/src/unix/inc/palrt2.h
+++ b/src/unix/inc/palrt2.h
@@ -44,6 +44,8 @@ inline void * _recalloc(void *memblock, size_t num, size_t size)
 #define ULLONG_MAX    0xffffffffffffffffu       /* maximum unsigned long long int value */
 EXTERN_C PALAPI errno_t _ultow_s( unsigned long inValue, WCHAR* outBuffer, size_t inDestBufferSize, int inRadix );
 
+// newer CLang with -fms-extensions has these built-in
+#if !(defined(__clang__) && __has_builtin(_InterlockedIncrement))
 inline LONG _InterlockedIncrement(LONG volatile * _Addend)
 {
     return InterlockedIncrement(_Addend);
@@ -68,6 +70,7 @@ inline LONG _InterlockedExchange(LONG volatile * Target, LONG Value)
 {
     return InterlockedExchange(Target, Value);
 }
+#endif
 
 // --- guid ---
 __inline int InlineIsEqualGUID(REFGUID rguid1, REFGUID rguid2)


### PR DESCRIPTION
Hi, for https://github.com/applandinc/appmap-dotnet I needed CLRIE builds for Linux and OSX and found it a bit difficult to obtain them. I've discovered a couple of small issues (including a bug) that prevented those builds from proceeding on recent tools; each fix is in a separate commit for review convenience and the commit messages should make it pretty clear what the changes are. There's also a commit enabling build on OSX to proceed and, as a bonus, a github actions build job.

For the record, I am the sole author of these changes and I consider them trivial enough to not be copyrightable, and in any case, I disclaim any eventual copyrights for them.