### PR TITLE
Scan environment for instrumentation methods on Unix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Please format the changes as follows:
 ## 1.0.43
 + BugFixes:
   + Fix XmlReader.Create to read from stream instead of filepath string
++ New:
+  + On Unix, environment is now scanned for instrumentation methods instead of looking for hardcoded ProductionBreakpoints.
 
 ## 1.0.42
 + BugFixes:

--- a/src/InstrumentationEngine.Lib/ConfigurationLocator.h
+++ b/src/InstrumentationEngine.Lib/ConfigurationLocator.h
@@ -13,22 +13,22 @@ namespace MicrosoftInstrumentationEngine
 
     private:
         static constexpr const WCHAR* s_wszConfigurationFilePattern = _T("*.config");
-#if defined(_WIN64) || defined(PLATFORM_UNIX)
+#ifdef PLATFORM_UNIX
+#ifdef X86
+        static constexpr const char* s_szConfigurationPathEnvironmentVariablePrefix = "MicrosoftInstrumentationEngine_ConfigPath32_";
+#else
+        static constexpr const char* s_szConfigurationPathEnvironmentVariablePrefix = "MicrosoftInstrumentationEngine_ConfigPath64_";
+#endif
+        static constexpr const char s_cEnvironmentVariableNameValueSeparator = '=';
+        static constexpr const char s_cEnvironmentVariablePathDelimiter = ':';
+#else  // PLATFORM_UNIX
+#if defined(_WIN64)
         static constexpr const WCHAR* s_wszConfigurationPathEnvironmentVariablePrefix = _T("MicrosoftInstrumentationEngine_ConfigPath64_");
 #else
         static constexpr const WCHAR* s_wszConfigurationPathEnvironmentVariablePrefix = _T("MicrosoftInstrumentationEngine_ConfigPath32_");
 #endif
         static constexpr const WCHAR* s_wszEnvironmentVariableNameValueSeparator = _T("=");
         static constexpr const WCHAR* s_wszEnvironmentVariablePathDelimiter = _T(";");
-
-#ifdef PLATFORM_UNIX
-#ifdef X86
-        static constexpr const WCHAR* s_wszProductionBreakpointsConfigName = _T("ProductionBreakpoints_x86.config");
-        static constexpr const WCHAR* s_wszProfilerPathVariableName = _T("CORECLR_PROFILER_PATH_32");
-#else
-        static constexpr const WCHAR* s_wszProductionBreakpointsConfigName = _T("ProductionBreakpoints_x64.config");
-        static constexpr const WCHAR* s_wszProfilerPathVariableName = _T("CORECLR_PROFILER_PATH_64");
-#endif
 #endif
 
     public:

--- a/src/Tests/InstrumentationEngineLibTests/CMakeLists.txt
+++ b/src/Tests/InstrumentationEngineLibTests/CMakeLists.txt
@@ -19,6 +19,7 @@ build_init(CPP InstrumentationEngine.LibTests)
 set(src_files
     ./pch.cpp
     ./ConfigurationLoaderTests.cpp
+    ./ConfigurationLocatorTests.cpp
     ../../InstrumentationEngine.Api/InstrumentationEngine_i.cpp
 )
 

--- a/src/Tests/InstrumentationEngineLibTests/ConfigurationLocatorTests.cpp
+++ b/src/Tests/InstrumentationEngineLibTests/ConfigurationLocatorTests.cpp
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+// This file only covers UNIX environment.
+// Similar test for windows is in tests/InstrumentationEngine.Lib.Tests
+#ifdef PLATFORM_UNIX
+
+#include "pch.h"
+#include <fstream>
+#include <cstdlib>
+
+#include "Common.Lib/refcount.h"
+#include "Common.Lib/systemstring.h"
+
+using namespace CommonLib;
+
+#include "InstrumentationEngine.Api/InstrumentationEngine.h"
+#include "InstrumentationEngine.Lib/InstrumentationMethod.h"
+#include "InstrumentationEngine.Lib/ConfigurationLocator.h"
+
+using namespace MicrosoftInstrumentationEngine;
+using namespace std;
+
+namespace fs = std::experimental::filesystem;
+
+namespace {
+    struct temp_file: fs::path {
+        temp_file(fs::path p): path(p)
+        {
+            ofstream{p};
+        }
+
+        ~temp_file()
+        {
+            remove(*this);
+        }
+    };
+}
+
+TEST(ConfigurationTests, GetConfigurationPathsExpandsPathCorrectly)
+{
+    constexpr const char szFeatureAVariable[] = "MicrosoftInstrumentationEngine_ConfigPath64_FeatureA";
+    constexpr const char szFeatureBVariable[] = "MicrosoftInstrumentationEngine_ConfigPath64_FeatureB";
+    constexpr const char szFeatureCVariable[] = "MicrosoftInstrumentationEngine_ConfigPath64_FeatureC";
+
+    // Create temporary files to use during test.
+    temp_file filePath1 = fs::temp_directory_path() / "config1.xml";
+    temp_file filePath2 = fs::temp_directory_path() / "config2.xml";
+
+    // This variable will be picked up, but should be excluded from results since the path does not exist.
+    setenv(szFeatureAVariable, "/non/existing/path", true);
+    // This variable will be picked up and included since the CWD exists.
+    setenv(szFeatureBVariable, ".", true);
+    // Some of the paths will be picked up from this variable, the first and third one.
+    string sPaths = string(filePath1) + ":/non/existing/path:" + string(filePath2);
+    setenv(szFeatureCVariable, sPaths.c_str(), true);
+
+    std::vector<ATL::CComPtr<CConfigurationSource>> sources;
+    ASSERT_OK(CConfigurationLocator::GetFromEnvironment(sources));
+
+    // Clear environment variables so that they do not interfere with other tests
+    unsetenv(szFeatureAVariable);
+    unsetenv(szFeatureBVariable);
+    unsetenv(szFeatureCVariable);
+
+    ASSERT_EQ(3, sources.size());
+
+    tstring expected;
+    CComBSTR actual;
+
+    ASSERT_OK(sources[0]->GetPath(&actual));
+    ASSERT_OK(SystemString::Convert(fs::current_path().c_str(), expected));
+    ASSERT_EQ(expected, tstring{actual});
+
+    ASSERT_OK(sources[1]->GetPath(&actual));
+    ASSERT_OK(SystemString::Convert(filePath1.c_str(), expected));
+    ASSERT_EQ(expected, tstring{actual});
+
+    ASSERT_OK(sources[2]->GetPath(&actual));
+    ASSERT_OK(SystemString::Convert(filePath2.c_str(), expected));
+    ASSERT_EQ(expected, tstring{actual});
+}
+
+#endif


### PR DESCRIPTION
On UNIX instead of scanning the environment like on Windows for
MicrosoftInstrumentationEngine_ConfigPath variables, hardcoded
ProductionBreakpoints config file used to be looked up.

This change brings parity with Windows (except environment
variable substitution in variable values, which would be
highly unusual in Unix).

Fixes #60.