### PR TITLE
Use latest Ubuntu build pool.

### DIFF
--- a/build/yaml/jobs/linux/binaries.yaml
+++ b/build/yaml/jobs/linux/binaries.yaml
@@ -23,7 +23,7 @@ jobs:
       - docker
       - sh
     ${{ if not(eq('true', parameters.IsMicroBuildInternal)) }}:
-      vmImage: ubuntu-16.04
+      vmImage: ubuntu-latest
 
   workspace:
     clean: outputs


### PR DESCRIPTION
The 16.04 pool is being removed in the next two weeks. Use the latest LTS pool for the build machine. This should not affect the binary build since those are run in containers.