### PR TITLE
Mark target tokens as volatile when importing assembly

### DIFF
--- a/tests/InstrEngineTests/Baselines/InjectToMscorlibTest.xml
+++ b/tests/InstrEngineTests/Baselines/InjectToMscorlibTest.xml
@@ -1,287 +1,526 @@
 <?xml version="1.0"?>
 <ImportModule>
-    <ImportAssemblyRef>
-        <token>0x23000001</token>
-        <UseTarget>true</UseTarget>
-        <targetToken>0x20000001</targetToken>
-    </ImportAssemblyRef>
+    <ImportAssemblyRef>
 
-    <ImportTypeDef>
-        <token>0x01000005</token>
-        <Name>System.Attribute</Name>
-        <targetToken>0x020000ad</targetToken>
-    </ImportTypeDef>
+        <token>0x23000001</token>
 
-    <ImportParam>
-        <token>0x08000001</token>
-        <Name>value</Name>
-    </ImportParam>
+        <UseTarget>true</UseTarget>
 
-    <ImportTypeDef>
-        <token>0x01000006</token>
-        <Name>System.Object</Name>
-        <targetToken>0x0200003d</targetToken>
-    </ImportTypeDef>
+        <targetToken Volatile="True">0x20000001</targetToken>
 
-    <ImportTypeDef>
-        <token>0x01000007</token>
-        <Name>System.Collections.Generic.List`1</Name>
-        <targetToken>0x020004af</targetToken>
-    </ImportTypeDef>
+    </ImportAssemblyRef>
 
-    <ImportFieldDef>
-        <token>0x04000001</token>
-        <Name>values</Name>
-        <Class>0x02000003</Class>
-        <targetToken>0x04003896</targetToken>
-    </ImportFieldDef>
 
-    <ImportParam>
-        <token>0x08000002</token>
-        <Name>value</Name>
-    </ImportParam>
+    <ImportTypeDef>
 
-    <ImportTypeSpec>
-        <token>0x1b000002</token>
-        <targetToken>0x1b0004d2</targetToken>
-    </ImportTypeSpec>
+        <token>0x01000005</token>
 
-    <ImportMemberRef>
-        <token>0x0a000008</token>
-        <Name>values</Name>
-        <DeclaringType>0x1b000002</DeclaringType>
-        <targetToken>0x0a000cf1</targetToken>
-    </ImportMemberRef>
+        <Name>System.Attribute</Name>
 
-    <ImportTypeSpec>
-        <token>0x1b000003</token>
-        <targetToken>0x1b0001da</targetToken>
-    </ImportTypeSpec>
+        <targetToken Volatile="True">0x020000ad</targetToken>
 
-    <ImportMemberRef>
-        <token>0x0a000009</token>
-        <Name>Add</Name>
-        <DeclaringType>0x1b000003</DeclaringType>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x0a000448</targetToken>
-    </ImportMemberRef>
+    </ImportTypeDef>
 
-    <ImportMethodDef>
-        <token>0x06000004</token>
-        <Name>Add</Name>
-        <Class>0x02000003</Class>
-        <targetToken>0x0600711a</targetToken>
-    </ImportMethodDef>
 
-    <ImportTypeDef>
-        <token>0x01000008</token>
-        <Name>Enumerator</Name>
-        <targetToken>0x02000bae</targetToken>
-    </ImportTypeDef>
+    <ImportParam>
 
-    <ImportLocalVarSig>
-        <token>0x11000002</token>
-        <targetToken>0x11000ed8</targetToken>
-    </ImportLocalVarSig>
+        <token>0x08000001</token>
 
-    <ImportMemberRef>
-        <token>0x0a00000a</token>
-        <Name>GetEnumerator</Name>
-        <DeclaringType>0x1b000003</DeclaringType>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x0a00062b</targetToken>
-    </ImportMemberRef>
+        <Name Volatile="True">value</Name>
 
-    <ImportTypeSpec>
-        <token>0x1b000004</token>
-        <targetToken>0x1b0002d3</targetToken>
-    </ImportTypeSpec>
+    </ImportParam>
 
-    <ImportMemberRef>
-        <token>0x0a00000b</token>
-        <Name>get_Current</Name>
-        <DeclaringType>0x1b000004</DeclaringType>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x0a00062c</targetToken>
-    </ImportMemberRef>
 
-    <ImportMemberRef>
-        <token>0x0a00000c</token>
-        <Name>MoveNext</Name>
-        <DeclaringType>0x1b000004</DeclaringType>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x0a00062e</targetToken>
-    </ImportMemberRef>
+    <ImportTypeDef>
 
-    <ImportTypeDef>
-        <token>0x01000009</token>
-        <Name>System.IDisposable</Name>
-        <targetToken>0x020000ee</targetToken>
-    </ImportTypeDef>
+        <token>0x01000006</token>
 
-    <ImportMemberRef>
-        <token>0x0a00000d</token>
-        <Name>Dispose</Name>
-        <DeclaringType>0x01000009</DeclaringType>
-        <targetToken>0x0a000cf2</targetToken>
-    </ImportMemberRef>
+        <Name>System.Object</Name>
 
-    <ImportMethodDef>
-        <token>0x06000005</token>
-        <Name>GetSumValue</Name>
-        <Class>0x02000003</Class>
-        <targetToken>0x0600711b</targetToken>
-    </ImportMethodDef>
+        <targetToken Volatile="True">0x0200003d</targetToken>
 
-    <ImportMemberRef>
-        <token>0x0a00000e</token>
-        <Name>.ctor</Name>
-        <DeclaringType>0x01000006</DeclaringType>
-        <targetToken>0x0a000cf3</targetToken>
-    </ImportMemberRef>
+    </ImportTypeDef>
 
-    <ImportMethodDef>
-        <token>0x06000006</token>
-        <Name>.ctor</Name>
-        <Class>0x02000003</Class>
-        <targetToken>0x0600711c</targetToken>
-    </ImportMethodDef>
 
-    <ImportMemberRef>
-        <token>0x0a00000f</token>
-        <Name>.ctor</Name>
-        <DeclaringType>0x1b000003</DeclaringType>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x0a00039a</targetToken>
-    </ImportMemberRef>
+    <ImportTypeDef>
 
-    <ImportMethodDef>
-        <token>0x06000007</token>
-        <Name>.cctor</Name>
-        <Class>0x02000003</Class>
-        <targetToken>0x0600711d</targetToken>
-    </ImportMethodDef>
+        <token>0x01000007</token>
 
-    <ImportGenericParam>
-        <token>0x2a000001</token>
-        <Name>T</Name>
-        <targetToken>0x2a0006ed</targetToken>
-    </ImportGenericParam>
+        <Name>System.Collections.Generic.List`1</Name>
 
-    <ImportTypeDef>
-        <token>0x02000003</token>
-        <Name>System.Diagnostics.Instrumentation.A`1</Name>
-        <targetToken>0x02000ce4</targetToken>
-    </ImportTypeDef>
+        <targetToken Volatile="True">0x020004af</targetToken>
 
-    <ImportLocalVarSig>
-        <token>0x11000001</token>
-        <targetToken>0x11000ed9</targetToken>
-    </ImportLocalVarSig>
+    </ImportTypeDef>
 
-    <ImportTypeSpec>
-        <token>0x1b000001</token>
-        <targetToken>0x1b0004d3</targetToken>
-    </ImportTypeSpec>
 
-    <ImportMemberRef>
-        <token>0x0a000004</token>
-        <Name>.ctor</Name>
-        <DeclaringType>0x1b000001</DeclaringType>
-        <targetToken>0x0a000cf4</targetToken>
-    </ImportMemberRef>
+    <ImportFieldDef>
 
-    <ImportMemberRef>
-        <token>0x0a000005</token>
-        <Name>Add</Name>
-        <DeclaringType>0x1b000001</DeclaringType>
-        <targetToken>0x0a000cf5</targetToken>
-    </ImportMemberRef>
+        <token>0x04000001</token>
 
-    <ImportMemberRef>
-        <token>0x0a000006</token>
-        <Name>GetSumValue</Name>
-        <DeclaringType>0x1b000001</DeclaringType>
-        <targetToken>0x0a000cf6</targetToken>
-    </ImportMemberRef>
+        <Name>values</Name>
 
-    <ImportMethodDef>
-        <token>0x06000001</token>
-        <Name>MethodToCallInstead</Name>
-        <Class>0x02000002</Class>
-        <targetToken>0x06007119</targetToken>
-    </ImportMethodDef>
+        <Class>0x02000003</Class>
 
-    <ImportMethodDef>
-        <token>0x06000002</token>
-        <Name>NoLocalVariablesMethod</Name>
-        <Class>0x02000002</Class>
-        <targetToken>0x0600711e</targetToken>
-    </ImportMethodDef>
+        <targetToken Volatile="True">0x04003896</targetToken>
 
-    <ImportMemberRef>
-        <token>0x0a000007</token>
-        <Name>.ctor</Name>
-        <DeclaringType>0x01000005</DeclaringType>
-        <targetToken>0x0a000cf7</targetToken>
-    </ImportMemberRef>
+    </ImportFieldDef>
 
-    <ImportMethodDef>
-        <token>0x06000003</token>
-        <Name>.ctor</Name>
-        <Class>0x02000002</Class>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x060031e8</targetToken>
-    </ImportMethodDef>
 
-    <ImportTypeDef>
-        <token>0x02000002</token>
-        <Name>_System.Diagnostics.DebuggerHiddenAttribute</Name>
-        <MergedToType>System.Diagnostics.DebuggerHiddenAttribute</MergedToType>
-        <targetToken>0x020003bc</targetToken>
-    </ImportTypeDef>
+    <ImportParam>
 
-    <ImportParam>
-        <token>0x08000003</token>
-        <Name>args</Name>
-    </ImportParam>
+        <token>0x08000002</token>
 
-    <ImportString>
-        <token>0x70000001</token>
-        <targetToken>0x70006294</targetToken>
-    </ImportString>
+        <Name>value</Name>
 
-    <ImportParam>
-        <token>0x08000004</token>
-        <Name>value</Name>
-    </ImportParam>
+    </ImportParam>
 
-    <ImportMethodDef>
-        <token>0x06000009</token>
-        <Name>InjectToMscorlib</Name>
-        <Class>0x02000004</Class>
-        <targetToken>0x06007120</targetToken>
-    </ImportMethodDef>
 
-    <ImportMethodDef>
-        <token>0x06000008</token>
-        <Name>Main</Name>
-        <Class>0x02000004</Class>
-        <targetToken>0x0600711f</targetToken>
-    </ImportMethodDef>
+    <ImportTypeSpec>
 
-    <ImportMethodDef>
-        <token>0x0600000a</token>
-        <Name>.ctor</Name>
-        <Class>0x02000004</Class>
-        <targetToken>0x06007121</targetToken>
-    </ImportMethodDef>
+        <token>0x1b000002</token>
 
-    <ImportTypeDef>
-        <token>0x02000004</token>
-        <Name>InstruOperationsTests.Program</Name>
-        <targetToken>0x02000ce5</targetToken>
-    </ImportTypeDef>
+        <targetToken Volatile="True">0x1b0004d2</targetToken>
+
+    </ImportTypeSpec>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000008</token>
+
+        <Name>values</Name>
+
+        <DeclaringType>0x1b000002</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf1</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportTypeSpec>
+
+        <token>0x1b000003</token>
+
+        <targetToken Volatile="True">0x1b0001da</targetToken>
+
+    </ImportTypeSpec>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000009</token>
+
+        <Name>Add</Name>
+
+        <DeclaringType>0x1b000003</DeclaringType>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x0a000448</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000004</token>
+
+        <Name>Add</Name>
+
+        <Class>0x02000003</Class>
+
+        <targetToken Volatile="True">0x0600711a</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportTypeDef>
+
+        <token>0x01000008</token>
+
+        <Name>Enumerator</Name>
+
+        <targetToken Volatile="True">0x02000bae</targetToken>
+
+    </ImportTypeDef>
+
+
+    <ImportLocalVarSig>
+
+        <token>0x11000002</token>
+
+        <targetToken Volatile="True">0x11000ed8</targetToken>
+
+    </ImportLocalVarSig>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000a</token>
+
+        <Name>GetEnumerator</Name>
+
+        <DeclaringType>0x1b000003</DeclaringType>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x0a00062b</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportTypeSpec>
+
+        <token>0x1b000004</token>
+
+        <targetToken Volatile="True">0x1b0002d3</targetToken>
+
+    </ImportTypeSpec>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000b</token>
+
+        <Name>get_Current</Name>
+
+        <DeclaringType>0x1b000004</DeclaringType>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x0a00062c</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000c</token>
+
+        <Name>MoveNext</Name>
+
+        <DeclaringType>0x1b000004</DeclaringType>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x0a00062e</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportTypeDef>
+
+        <token>0x01000009</token>
+
+        <Name>System.IDisposable</Name>
+
+        <targetToken Volatile="True">0x020000ee</targetToken>
+
+    </ImportTypeDef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000d</token>
+
+        <Name>Dispose</Name>
+
+        <DeclaringType>0x01000009</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf2</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000005</token>
+
+        <Name>GetSumValue</Name>
+
+        <Class>0x02000003</Class>
+
+        <targetToken Volatile="True">0x0600711b</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000e</token>
+
+        <Name>.ctor</Name>
+
+        <DeclaringType>0x01000006</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf3</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000006</token>
+
+        <Name>.ctor</Name>
+
+        <Class>0x02000003</Class>
+
+        <targetToken Volatile="True">0x0600711c</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000f</token>
+
+        <Name>.ctor</Name>
+
+        <DeclaringType>0x1b000003</DeclaringType>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x0a00039a</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000007</token>
+
+        <Name>.cctor</Name>
+
+        <Class>0x02000003</Class>
+
+        <targetToken Volatile="True">0x0600711d</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportGenericParam>
+
+        <token>0x2a000001</token>
+
+        <Name>T</Name>
+
+        <targetToken Volatile="True">0x2a0006ed</targetToken>
+
+    </ImportGenericParam>
+
+
+    <ImportTypeDef>
+
+        <token>0x02000003</token>
+
+        <Name>System.Diagnostics.Instrumentation.A`1</Name>
+
+        <targetToken Volatile="True">0x02000ce4</targetToken>
+
+    </ImportTypeDef>
+
+
+    <ImportLocalVarSig>
+
+        <token>0x11000001</token>
+
+        <targetToken Volatile="True">0x11000ed9</targetToken>
+
+    </ImportLocalVarSig>
+
+
+    <ImportTypeSpec>
+
+        <token>0x1b000001</token>
+
+        <targetToken Volatile="True">0x1b0004d3</targetToken>
+
+    </ImportTypeSpec>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000004</token>
+
+        <Name>.ctor</Name>
+
+        <DeclaringType>0x1b000001</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf4</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000005</token>
+
+        <Name>Add</Name>
+
+        <DeclaringType>0x1b000001</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf5</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000006</token>
+
+        <Name>GetSumValue</Name>
+
+        <DeclaringType>0x1b000001</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf6</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000001</token>
+
+        <Name>MethodToCallInstead</Name>
+
+        <Class>0x02000002</Class>
+
+        <targetToken Volatile="True">0x06007119</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000002</token>
+
+        <Name>NoLocalVariablesMethod</Name>
+
+        <Class>0x02000002</Class>
+
+        <targetToken Volatile="True">0x0600711e</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000007</token>
+
+        <Name>.ctor</Name>
+
+        <DeclaringType>0x01000005</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf7</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000003</token>
+
+        <Name>.ctor</Name>
+
+        <Class>0x02000002</Class>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x060031e8</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportTypeDef>
+
+        <token>0x02000002</token>
+
+        <Name>_System.Diagnostics.DebuggerHiddenAttribute</Name>
+
+        <MergedToType>System.Diagnostics.DebuggerHiddenAttribute</MergedToType>
+
+        <targetToken Volatile="True">0x020003bc</targetToken>
+
+    </ImportTypeDef>
+
+
+    <ImportParam>
+
+        <token>0x08000003</token>
+
+        <Name>args</Name>
+
+    </ImportParam>
+
+
+    <ImportString>
+
+        <token>0x70000001</token>
+
+        <targetToken Volatile="True">0x70006294</targetToken>
+
+    </ImportString>
+
+
+    <ImportParam>
+
+        <token>0x08000004</token>
+
+        <Name>value</Name>
+
+    </ImportParam>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000009</token>
+
+        <Name>InjectToMscorlib</Name>
+
+        <Class>0x02000004</Class>
+
+        <targetToken Volatile="True">0x06007120</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000008</token>
+
+        <Name>Main</Name>
+
+        <Class>0x02000004</Class>
+
+        <targetToken Volatile="True">0x0600711f</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMethodDef>
+
+        <token>0x0600000a</token>
+
+        <Name>.ctor</Name>
+
+        <Class>0x02000004</Class>
+
+        <targetToken Volatile="True">0x06007121</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportTypeDef>
+
+        <token>0x02000004</token>
+
+        <Name>InstruOperationsTests.Program</Name>
+
+        <targetToken Volatile="True">0x02000ce5</targetToken>
+
+    </ImportTypeDef>
+
 
 </ImportModule>
 <?xml version="1.0"?>

--- a/tests/InstrEngineTests/Baselines/InjectToMscorlibTest32.xml
+++ b/tests/InstrEngineTests/Baselines/InjectToMscorlibTest32.xml
@@ -1,287 +1,526 @@
 <?xml version="1.0"?>
 <ImportModule>
-    <ImportAssemblyRef>
-        <token>0x23000001</token>
-        <UseTarget>true</UseTarget>
-        <targetToken>0x20000001</targetToken>
-    </ImportAssemblyRef>
+    <ImportAssemblyRef>
 
-    <ImportTypeDef>
-        <token>0x01000005</token>
-        <Name>System.Attribute</Name>
-        <targetToken>0x020000ad</targetToken>
-    </ImportTypeDef>
+        <token>0x23000001</token>
 
-    <ImportParam>
-        <token>0x08000001</token>
-        <Name>value</Name>
-    </ImportParam>
+        <UseTarget>true</UseTarget>
 
-    <ImportTypeDef>
-        <token>0x01000006</token>
-        <Name>System.Object</Name>
-        <targetToken>0x0200003d</targetToken>
-    </ImportTypeDef>
+        <targetToken Volatile="True">0x20000001</targetToken>
 
-    <ImportTypeDef>
-        <token>0x01000007</token>
-        <Name>System.Collections.Generic.List`1</Name>
-        <targetToken>0x020004af</targetToken>
-    </ImportTypeDef>
+    </ImportAssemblyRef>
 
-    <ImportFieldDef>
-        <token>0x04000001</token>
-        <Name>values</Name>
-        <Class>0x02000003</Class>
-        <targetToken>0x0400389d</targetToken>
-    </ImportFieldDef>
 
-    <ImportParam>
-        <token>0x08000002</token>
-        <Name>value</Name>
-    </ImportParam>
+    <ImportTypeDef>
 
-    <ImportTypeSpec>
-        <token>0x1b000002</token>
-        <targetToken>0x1b0004d2</targetToken>
-    </ImportTypeSpec>
+        <token>0x01000005</token>
 
-    <ImportMemberRef>
-        <token>0x0a000008</token>
-        <Name>values</Name>
-        <DeclaringType>0x1b000002</DeclaringType>
-        <targetToken>0x0a000cf1</targetToken>
-    </ImportMemberRef>
+        <Name>System.Attribute</Name>
 
-    <ImportTypeSpec>
-        <token>0x1b000003</token>
-        <targetToken>0x1b0001da</targetToken>
-    </ImportTypeSpec>
+        <targetToken Volatile="True">0x020000ad</targetToken>
 
-    <ImportMemberRef>
-        <token>0x0a000009</token>
-        <Name>Add</Name>
-        <DeclaringType>0x1b000003</DeclaringType>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x0a000448</targetToken>
-    </ImportMemberRef>
+    </ImportTypeDef>
 
-    <ImportMethodDef>
-        <token>0x06000004</token>
-        <Name>Add</Name>
-        <Class>0x02000003</Class>
-        <targetToken>0x0600711d</targetToken>
-    </ImportMethodDef>
 
-    <ImportTypeDef>
-        <token>0x01000008</token>
-        <Name>Enumerator</Name>
-        <targetToken>0x02000bb0</targetToken>
-    </ImportTypeDef>
+    <ImportParam>
 
-    <ImportLocalVarSig>
-        <token>0x11000002</token>
-        <targetToken>0x11000ed4</targetToken>
-    </ImportLocalVarSig>
+        <token>0x08000001</token>
 
-    <ImportMemberRef>
-        <token>0x0a00000a</token>
-        <Name>GetEnumerator</Name>
-        <DeclaringType>0x1b000003</DeclaringType>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x0a00062b</targetToken>
-    </ImportMemberRef>
+        <Name>value</Name>
 
-    <ImportTypeSpec>
-        <token>0x1b000004</token>
-        <targetToken>0x1b0002d3</targetToken>
-    </ImportTypeSpec>
+    </ImportParam>
 
-    <ImportMemberRef>
-        <token>0x0a00000b</token>
-        <Name>get_Current</Name>
-        <DeclaringType>0x1b000004</DeclaringType>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x0a00062c</targetToken>
-    </ImportMemberRef>
 
-    <ImportMemberRef>
-        <token>0x0a00000c</token>
-        <Name>MoveNext</Name>
-        <DeclaringType>0x1b000004</DeclaringType>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x0a00062e</targetToken>
-    </ImportMemberRef>
+    <ImportTypeDef>
 
-    <ImportTypeDef>
-        <token>0x01000009</token>
-        <Name>System.IDisposable</Name>
-        <targetToken>0x020000ee</targetToken>
-    </ImportTypeDef>
+        <token>0x01000006</token>
 
-    <ImportMemberRef>
-        <token>0x0a00000d</token>
-        <Name>Dispose</Name>
-        <DeclaringType>0x01000009</DeclaringType>
-        <targetToken>0x0a000cf2</targetToken>
-    </ImportMemberRef>
+        <Name>System.Object</Name>
 
-    <ImportMethodDef>
-        <token>0x06000005</token>
-        <Name>GetSumValue</Name>
-        <Class>0x02000003</Class>
-        <targetToken>0x0600711e</targetToken>
-    </ImportMethodDef>
+        <targetToken Volatile="True">0x0200003d</targetToken>
 
-    <ImportMemberRef>
-        <token>0x0a00000e</token>
-        <Name>.ctor</Name>
-        <DeclaringType>0x01000006</DeclaringType>
-        <targetToken>0x0a000cf3</targetToken>
-    </ImportMemberRef>
+    </ImportTypeDef>
 
-    <ImportMethodDef>
-        <token>0x06000006</token>
-        <Name>.ctor</Name>
-        <Class>0x02000003</Class>
-        <targetToken>0x0600711f</targetToken>
-    </ImportMethodDef>
 
-    <ImportMemberRef>
-        <token>0x0a00000f</token>
-        <Name>.ctor</Name>
-        <DeclaringType>0x1b000003</DeclaringType>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x0a00039a</targetToken>
-    </ImportMemberRef>
+    <ImportTypeDef>
 
-    <ImportMethodDef>
-        <token>0x06000007</token>
-        <Name>.cctor</Name>
-        <Class>0x02000003</Class>
-        <targetToken>0x06007120</targetToken>
-    </ImportMethodDef>
+        <token>0x01000007</token>
 
-    <ImportGenericParam>
-        <token>0x2a000001</token>
-        <Name>T</Name>
-        <targetToken>0x2a0006ed</targetToken>
-    </ImportGenericParam>
+        <Name>System.Collections.Generic.List`1</Name>
 
-    <ImportTypeDef>
-        <token>0x02000003</token>
-        <Name>System.Diagnostics.Instrumentation.A`1</Name>
-        <targetToken>0x02000ce6</targetToken>
-    </ImportTypeDef>
+        <targetToken Volatile="True">0x020004af</targetToken>
 
-    <ImportLocalVarSig>
-        <token>0x11000001</token>
-        <targetToken>0x11000ed5</targetToken>
-    </ImportLocalVarSig>
+    </ImportTypeDef>
 
-    <ImportTypeSpec>
-        <token>0x1b000001</token>
-        <targetToken>0x1b0004d3</targetToken>
-    </ImportTypeSpec>
 
-    <ImportMemberRef>
-        <token>0x0a000004</token>
-        <Name>.ctor</Name>
-        <DeclaringType>0x1b000001</DeclaringType>
-        <targetToken>0x0a000cf4</targetToken>
-    </ImportMemberRef>
+    <ImportFieldDef>
 
-    <ImportMemberRef>
-        <token>0x0a000005</token>
-        <Name>Add</Name>
-        <DeclaringType>0x1b000001</DeclaringType>
-        <targetToken>0x0a000cf5</targetToken>
-    </ImportMemberRef>
+        <token>0x04000001</token>
 
-    <ImportMemberRef>
-        <token>0x0a000006</token>
-        <Name>GetSumValue</Name>
-        <DeclaringType>0x1b000001</DeclaringType>
-        <targetToken>0x0a000cf6</targetToken>
-    </ImportMemberRef>
+        <Name>values</Name>
 
-    <ImportMethodDef>
-        <token>0x06000001</token>
-        <Name>MethodToCallInstead</Name>
-        <Class>0x02000002</Class>
-        <targetToken>0x0600711c</targetToken>
-    </ImportMethodDef>
+        <Class>0x02000003</Class>
 
-    <ImportMethodDef>
-        <token>0x06000002</token>
-        <Name>NoLocalVariablesMethod</Name>
-        <Class>0x02000002</Class>
-        <targetToken>0x06007121</targetToken>
-    </ImportMethodDef>
+        <targetToken Volatile="True">0x0400389d</targetToken>
 
-    <ImportMemberRef>
-        <token>0x0a000007</token>
-        <Name>.ctor</Name>
-        <DeclaringType>0x01000005</DeclaringType>
-        <targetToken>0x0a000cf7</targetToken>
-    </ImportMemberRef>
+    </ImportFieldDef>
 
-    <ImportMethodDef>
-        <token>0x06000003</token>
-        <Name>.ctor</Name>
-        <Class>0x02000002</Class>
-        <UseExisting>true</UseExisting>
-        <targetToken>0x060031e8</targetToken>
-    </ImportMethodDef>
 
-    <ImportTypeDef>
-        <token>0x02000002</token>
-        <Name>_System.Diagnostics.DebuggerHiddenAttribute</Name>
-        <MergedToType>System.Diagnostics.DebuggerHiddenAttribute</MergedToType>
-        <targetToken>0x020003bc</targetToken>
-    </ImportTypeDef>
+    <ImportParam>
 
-    <ImportParam>
-        <token>0x08000003</token>
-        <Name>args</Name>
-    </ImportParam>
+        <token>0x08000002</token>
 
-    <ImportString>
-        <token>0x70000001</token>
-        <targetToken>0x70006294</targetToken>
-    </ImportString>
+        <Name>value</Name>
 
-    <ImportParam>
-        <token>0x08000004</token>
-        <Name>value</Name>
-    </ImportParam>
+    </ImportParam>
 
-    <ImportMethodDef>
-        <token>0x06000009</token>
-        <Name>InjectToMscorlib</Name>
-        <Class>0x02000004</Class>
-        <targetToken>0x06007123</targetToken>
-    </ImportMethodDef>
 
-    <ImportMethodDef>
-        <token>0x06000008</token>
-        <Name>Main</Name>
-        <Class>0x02000004</Class>
-        <targetToken>0x06007122</targetToken>
-    </ImportMethodDef>
+    <ImportTypeSpec>
 
-    <ImportMethodDef>
-        <token>0x0600000a</token>
-        <Name>.ctor</Name>
-        <Class>0x02000004</Class>
-        <targetToken>0x06007124</targetToken>
-    </ImportMethodDef>
+        <token>0x1b000002</token>
 
-    <ImportTypeDef>
-        <token>0x02000004</token>
-        <Name>InstruOperationsTests.Program</Name>
-        <targetToken>0x02000ce7</targetToken>
-    </ImportTypeDef>
+        <targetToken Volatile="True">0x1b0004d2</targetToken>
+
+    </ImportTypeSpec>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000008</token>
+
+        <Name>values</Name>
+
+        <DeclaringType>0x1b000002</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf1</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportTypeSpec>
+
+        <token>0x1b000003</token>
+
+        <targetToken Volatile="True">0x1b0001da</targetToken>
+
+    </ImportTypeSpec>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000009</token>
+
+        <Name>Add</Name>
+
+        <DeclaringType>0x1b000003</DeclaringType>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x0a000448</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000004</token>
+
+        <Name>Add</Name>
+
+        <Class>0x02000003</Class>
+
+        <targetToken Volatile="True">0x0600711d</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportTypeDef>
+
+        <token>0x01000008</token>
+
+        <Name>Enumerator</Name>
+
+        <targetToken Volatile="True">0x02000bb0</targetToken>
+
+    </ImportTypeDef>
+
+
+    <ImportLocalVarSig>
+
+        <token>0x11000002</token>
+
+        <targetToken Volatile="True">0x11000ed4</targetToken>
+
+    </ImportLocalVarSig>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000a</token>
+
+        <Name>GetEnumerator</Name>
+
+        <DeclaringType>0x1b000003</DeclaringType>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x0a00062b</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportTypeSpec>
+
+        <token>0x1b000004</token>
+
+        <targetToken Volatile="True">0x1b0002d3</targetToken>
+
+    </ImportTypeSpec>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000b</token>
+
+        <Name>get_Current</Name>
+
+        <DeclaringType>0x1b000004</DeclaringType>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x0a00062c</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000c</token>
+
+        <Name>MoveNext</Name>
+
+        <DeclaringType>0x1b000004</DeclaringType>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x0a00062e</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportTypeDef>
+
+        <token>0x01000009</token>
+
+        <Name>System.IDisposable</Name>
+
+        <targetToken Volatile="True">0x020000ee</targetToken>
+
+    </ImportTypeDef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000d</token>
+
+        <Name>Dispose</Name>
+
+        <DeclaringType>0x01000009</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf2</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000005</token>
+
+        <Name>GetSumValue</Name>
+
+        <Class>0x02000003</Class>
+
+        <targetToken Volatile="True">0x0600711e</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000e</token>
+
+        <Name>.ctor</Name>
+
+        <DeclaringType>0x01000006</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf3</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000006</token>
+
+        <Name>.ctor</Name>
+
+        <Class>0x02000003</Class>
+
+        <targetToken Volatile="True">0x0600711f</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a00000f</token>
+
+        <Name>.ctor</Name>
+
+        <DeclaringType>0x1b000003</DeclaringType>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x0a00039a</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000007</token>
+
+        <Name>.cctor</Name>
+
+        <Class>0x02000003</Class>
+
+        <targetToken Volatile="True">0x06007120</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportGenericParam>
+
+        <token>0x2a000001</token>
+
+        <Name>T</Name>
+
+        <targetToken Volatile="True">0x2a0006ed</targetToken>
+
+    </ImportGenericParam>
+
+
+    <ImportTypeDef>
+
+        <token>0x02000003</token>
+
+        <Name>System.Diagnostics.Instrumentation.A`1</Name>
+
+        <targetToken Volatile="True">0x02000ce6</targetToken>
+
+    </ImportTypeDef>
+
+
+    <ImportLocalVarSig>
+
+        <token>0x11000001</token>
+
+        <targetToken Volatile="True">0x11000ed5</targetToken>
+
+    </ImportLocalVarSig>
+
+
+    <ImportTypeSpec>
+
+        <token>0x1b000001</token>
+
+        <targetToken Volatile="True">0x1b0004d3</targetToken>
+
+    </ImportTypeSpec>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000004</token>
+
+        <Name>.ctor</Name>
+
+        <DeclaringType>0x1b000001</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf4</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000005</token>
+
+        <Name>Add</Name>
+
+        <DeclaringType>0x1b000001</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf5</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000006</token>
+
+        <Name>GetSumValue</Name>
+
+        <DeclaringType>0x1b000001</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf6</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000001</token>
+
+        <Name>MethodToCallInstead</Name>
+
+        <Class>0x02000002</Class>
+
+        <targetToken Volatile="True">0x0600711c</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000002</token>
+
+        <Name>NoLocalVariablesMethod</Name>
+
+        <Class>0x02000002</Class>
+
+        <targetToken Volatile="True">0x06007121</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMemberRef>
+
+        <token>0x0a000007</token>
+
+        <Name>.ctor</Name>
+
+        <DeclaringType>0x01000005</DeclaringType>
+
+        <targetToken Volatile="True">0x0a000cf7</targetToken>
+
+    </ImportMemberRef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000003</token>
+
+        <Name>.ctor</Name>
+
+        <Class>0x02000002</Class>
+
+        <UseExisting>true</UseExisting>
+
+        <targetToken Volatile="True">0x060031e8</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportTypeDef>
+
+        <token>0x02000002</token>
+
+        <Name>_System.Diagnostics.DebuggerHiddenAttribute</Name>
+
+        <MergedToType>System.Diagnostics.DebuggerHiddenAttribute</MergedToType>
+
+        <targetToken Volatile="True">0x020003bc</targetToken>
+
+    </ImportTypeDef>
+
+
+    <ImportParam>
+
+        <token>0x08000003</token>
+
+        <Name>args</Name>
+
+    </ImportParam>
+
+
+    <ImportString>
+
+        <token>0x70000001</token>
+
+        <targetToken Volatile="True">0x70006294</targetToken>
+
+    </ImportString>
+
+
+    <ImportParam>
+
+        <token>0x08000004</token>
+
+        <Name>value</Name>
+
+    </ImportParam>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000009</token>
+
+        <Name>InjectToMscorlib</Name>
+
+        <Class>0x02000004</Class>
+
+        <targetToken Volatile="True">0x06007123</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMethodDef>
+
+        <token>0x06000008</token>
+
+        <Name>Main</Name>
+
+        <Class>0x02000004</Class>
+
+        <targetToken Volatile="True">0x06007122</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportMethodDef>
+
+        <token>0x0600000a</token>
+
+        <Name>.ctor</Name>
+
+        <Class>0x02000004</Class>
+
+        <targetToken Volatile="True">0x06007124</targetToken>
+
+    </ImportMethodDef>
+
+
+    <ImportTypeDef>
+
+        <token>0x02000004</token>
+
+        <Name>InstruOperationsTests.Program</Name>
+
+        <targetToken Volatile="True">0x02000ce7</targetToken>
+
+    </ImportTypeDef>
+
 
 </ImportModule>
 <?xml version="1.0"?>

--- a/tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
@@ -68,7 +68,7 @@ namespace InstrEngineTests
         {
             // Usually we use the same file name for test script, baseline and test result
             ProfilerHelpers.LaunchAppUnderProfiler(parameters, testApp, fileName, fileName, false, args, timeoutMs);
-            ProfilerHelpers.DiffResultToBaseline(fileName, fileName, regexCompare);
+            ProfilerHelpers.DiffResultToBaseline(parameters.TestContext, fileName, fileName, regexCompare);
         }
 
         public static void LaunchAppUnderProfiler(TestParameters parameters, string testApp, string testScript, string output, bool isRejit = true, string args = null, int timeoutMs = TestAppTimeoutMs)
@@ -250,7 +250,7 @@ namespace InstrEngineTests
             return docs.ToArray();
         }
 
-        public static void DiffResultToBaseline(string output, string baseline, bool regexCompare = false)
+        public static void DiffResultToBaseline(TestContext testContext, string output, string baseline, bool regexCompare = false)
         {
             string outputPath = Path.Combine(PathUtils.GetTestResultsPath(), output);
             string baselinePath = Path.Combine(PathUtils.GetBaselinesPath(), baseline);
@@ -331,6 +331,7 @@ namespace InstrEngineTests
             }
             catch (AssertFailedException)
             {
+                testContext.AddResultFile(outputPath);
                 Console.WriteLine($"Baseline FilePath: {baselinePath}");
                 Console.WriteLine();
                 Console.WriteLine($"Output FilePath: {outputPath}");

--- a/tests/InstrEngineTests/InstrEngineTests/RuntimeExceptionCallbacks.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/RuntimeExceptionCallbacks.cs
@@ -42,7 +42,7 @@ namespace InstrEngineTests
                 output: "RuntimeExceptionCallbacks.xml",
                 isRejit: false);
 
-            ProfilerHelpers.DiffResultToBaseline(output: "RuntimeExceptionCallbacks.xml", baseline: "RuntimeExceptionCallbacks.xml");
+            ProfilerHelpers.DiffResultToBaseline(Context, output: "RuntimeExceptionCallbacks.xml", baseline: "RuntimeExceptionCallbacks.xml");
         }
     }
 }

--- a/tests/InstrEngineTests/InstrEngineTests/TestRejit.cs
+++ b/tests/InstrEngineTests/InstrEngineTests/TestRejit.cs
@@ -45,7 +45,7 @@ namespace InstrEngineTests
                 testScript: "RoundTrip_IfTest.xml",
                 output: "Rejit_RoundTrip_IfTest.xml");
 
-            ProfilerHelpers.DiffResultToBaseline(output: "Rejit_RoundTrip_IfTest.xml", baseline: "RoundTrip_IfTest.xml");
+            ProfilerHelpers.DiffResultToBaseline(Context, output: "Rejit_RoundTrip_IfTest.xml", baseline: "RoundTrip_IfTest.xml");
         }
 
         [TestMethod]
@@ -58,7 +58,7 @@ namespace InstrEngineTests
                 testScript: "RoundTrip_SwitchTest.xml",
                 output: "Rejit_RoundTrip_SwitchTest.xml");
 
-            ProfilerHelpers.DiffResultToBaseline(output: "Rejit_RoundTrip_SwitchTest.xml", baseline: "RoundTrip_SwitchTest.xml");
+            ProfilerHelpers.DiffResultToBaseline(Context, output: "Rejit_RoundTrip_SwitchTest.xml", baseline: "RoundTrip_SwitchTest.xml");
         }
 
         [TestMethod]
@@ -71,7 +71,7 @@ namespace InstrEngineTests
                 testScript: "RoundTrip_ForTest.xml",
                 output: "Rejit_RoundTrip_ForTest.xml");
 
-            ProfilerHelpers.DiffResultToBaseline(output: "Rejit_RoundTrip_ForTest.xml", baseline: "RoundTrip_ForTest.xml");
+            ProfilerHelpers.DiffResultToBaseline(Context, output: "Rejit_RoundTrip_ForTest.xml", baseline: "RoundTrip_ForTest.xml");
         }
 
         [TestMethod]
@@ -84,7 +84,7 @@ namespace InstrEngineTests
                 testScript: "AddNop_SwitchTest2.xml",
                 output: "Rejit_AddNop_SwitchTest2.xml");
 
-            ProfilerHelpers.DiffResultToBaseline(output: "Rejit_AddNop_SwitchTest2.xml", baseline: "AddNop_SwitchTest2.xml");
+            ProfilerHelpers.DiffResultToBaseline(Context, output: "Rejit_AddNop_SwitchTest2.xml", baseline: "AddNop_SwitchTest2.xml");
         }
 
         [TestMethod]
@@ -97,7 +97,7 @@ namespace InstrEngineTests
                 testScript: "ExceptionFinallyTest.xml",
                 output: "Rejit_ExceptionFinallyTest.xml");
 
-            ProfilerHelpers.DiffResultToBaseline(output: "Rejit_ExceptionFinallyTest.xml", baseline: "ExceptionFinallyTest.xml");
+            ProfilerHelpers.DiffResultToBaseline(Context, output: "Rejit_ExceptionFinallyTest.xml", baseline: "ExceptionFinallyTest.xml");
         }
 
         [TestMethod]
@@ -110,7 +110,7 @@ namespace InstrEngineTests
                 testScript: "ExceptionMultiTryCatchTest.xml",
                 output: "Rejit_ExceptionMultiTryCatchTest.xml");
 
-            ProfilerHelpers.DiffResultToBaseline(output: "Rejit_ExceptionMultiTryCatchTest.xml", baseline: "ExceptionMultiTryCatchTest.xml");
+            ProfilerHelpers.DiffResultToBaseline(Context, output: "Rejit_ExceptionMultiTryCatchTest.xml", baseline: "ExceptionMultiTryCatchTest.xml");
         }
 
         [TestMethod]
@@ -124,7 +124,7 @@ namespace InstrEngineTests
                 output: "Rejit_Instru_RemoveAllTest.xml",
                 args: "Instru_CreateErrorTest");
 
-            ProfilerHelpers.DiffResultToBaseline(output: "Rejit_Instru_RemoveAllTest.xml", baseline: "Instru_RemoveAllTest.xml");
+            ProfilerHelpers.DiffResultToBaseline(Context, output: "Rejit_Instru_RemoveAllTest.xml", baseline: "Instru_RemoveAllTest.xml");
         }
 
         [TestMethod]
@@ -138,7 +138,7 @@ namespace InstrEngineTests
                 output: "Rejit_Instru_ReplaceTest.xml",
                 args: "Instru_ReplaceTest");
 
-            ProfilerHelpers.DiffResultToBaseline(output: "Rejit_Instru_ReplaceTest.xml", baseline: "Instru_ReplaceTest.xml");
+            ProfilerHelpers.DiffResultToBaseline(Context, output: "Rejit_Instru_ReplaceTest.xml", baseline: "Instru_ReplaceTest.xml");
         }
     }
 }


### PR DESCRIPTION
The InjectToMscorlib tests are failing on the CI machines whereas they are not failing on a local machine. This issue is that the target tokens (when importing an assembly into mscorlib) are different from the baseline. My theory is that the mscorlib on the CI machines is different (it has more or less TypeDefs, FieldDefs, etc compared to local machine) which causes the imported tokens to have values different from the baseline. I think its best to mark these as volatile so that we don't have to account for variations in mscorlib versions.

Additional changes were made to attach the output xml file when the tests fail to make it easier to determine the full difference between the output and the baseline.