### PR TITLE
Fix XmlReader.Create to read from stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.43
++ BugFixes:
+  + Fix XmlReader.Create to read from stream instead of filepath string
 
 ## 1.0.42
 + BugFixes:

--- a/src/InstrumentationEngine.Attach/CommandHandler/AttachCommandHandler.cs
+++ b/src/InstrumentationEngine.Attach/CommandHandler/AttachCommandHandler.cs
@@ -109,6 +109,7 @@ namespace Microsoft.InstrumentationEngine
                     readerSettings.ValidationType = ValidationType.Schema;
 
                     // Read configuration source file
+                    // XmlReader handles filepaths as URI and escapes widechars so we convert it to a stream first.
                     using (var stream = new StreamReader(sourceInfo.ConfigSourceFilePath))
                     using (XmlReader reader = XmlReader.Create(stream, readerSettings))
                     {

--- a/src/InstrumentationEngine.Attach/CommandHandler/AttachCommandHandler.cs
+++ b/src/InstrumentationEngine.Attach/CommandHandler/AttachCommandHandler.cs
@@ -109,7 +109,8 @@ namespace Microsoft.InstrumentationEngine
                     readerSettings.ValidationType = ValidationType.Schema;
 
                     // Read configuration source file
-                    using (XmlReader reader = XmlReader.Create(sourceInfo.ConfigSourceFilePath, readerSettings))
+                    using (var stream = new StreamReader(sourceInfo.ConfigSourceFilePath))
+                    using (XmlReader reader = XmlReader.Create(stream, readerSettings))
                     {
                         XmlSerializer serializer = new XmlSerializer(typeof(InstrumentationConfigurationSources));
                         try


### PR DESCRIPTION
Wide characters get URI escaped in XmlReader.Create call. The fix here is to pass to StreamReader (which does not escape the string) and pass the stream to XmlReader.