### PR TITLE
Remove Start/End messages from methods

### DIFF
--- a/src/InstrumentationEngine/AppDomainCollection.cpp
+++ b/src/InstrumentationEngine/AppDomainCollection.cpp
@@ -52,7 +52,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAppDomainCount(
 HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAppDomainById(_In_ AppDomainID appDomainId, _Out_ IAppDomainInfo** ppAppDomainInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetAppDomainById"));
     IfNullRetPointer(ppAppDomainInfo);
     *ppAppDomainInfo = nullptr;
 
@@ -69,15 +68,12 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAppDomainById(_
     *ppAppDomainInfo = (iter->second);
     (*ppAppDomainInfo)->AddRef();
 
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetAppDomainById"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::RemoveAppDomainInfo(_In_ AppDomainID appDomainId)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::RemoveAppDomainInfo"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -91,8 +87,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::RemoveAppDomainInf
 
     m_appDomains.erase(iter);
 
-    CLogging::LogMessage(_T("End CAppDomainCollection::RemoveAppDomainInfo"));
-
     return hr;
 }
 
@@ -100,7 +94,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::RemoveAppDomainInf
 HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAppDomainIDs(_In_ DWORD cAppDomains, _Out_ DWORD* pcActual, _Out_writes_(cAppDomains) AppDomainID* pAppDomainIDs)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetAppDomainIDs"));
 
     IfNullRetPointer(pcActual);
     IfNullRetPointer(pAppDomainIDs);
@@ -126,15 +119,12 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAppDomainIDs(_I
 
     *pcActual = i;
 
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetAppDomainIDs"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAppDomains(_Out_ IEnumAppDomainInfo** ppEnumAppDomains)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetAppDomains"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -156,15 +146,12 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAppDomains(_Out
     *ppEnumAppDomains = (IEnumAppDomainInfo*)pEnumerator;
     (*ppEnumAppDomains)->AddRef();
 
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetAppDomains"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAssemblyInfoById(_In_ AssemblyID assemblyID, _Out_ IAssemblyInfo** ppAssemblyInfo)
 {
     HRESULT hr = S_OK;
-
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetAssemblyInfoById"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -173,21 +160,17 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetAssemblyInfoByI
         hr = p.second->GetAssemblyInfoById(assemblyID, ppAssemblyInfo);
         if (SUCCEEDED(hr))
         {
-            CLogging::LogMessage(_T("End CAppDomainCollection::GetAssemblyInfoById - found assembly"));
             return S_OK;
         }
     }
 
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetAssemblyInfoById - no assembly found"));
-
+    CLogging::LogMessage(_T("CAppDomainCollection::GetAssemblyInfoById - no assembly found"));
     return E_FAIL;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetModuleInfoById(_In_ ModuleID moduleID, _Out_ IModuleInfo** ppModuleInfo)
 {
     HRESULT hr = S_OK;
-
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetModuleInfoById"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -196,13 +179,11 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetModuleInfoById(
         hr = p.second->GetModuleInfoById(moduleID, ppModuleInfo);
         if (SUCCEEDED(hr))
         {
-            CLogging::LogMessage(_T("End CAppDomainCollection::GetModuleInfoById - found module"));
             return S_OK;
         }
     }
 
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetModuleInfoById - no module found"));
-
+    CLogging::LogMessage(_T("CAppDomainCollection::GetModuleInfoById - no module found"));
     return E_FAIL;
 }
 
@@ -212,7 +193,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetModuleInfosByMv
     HRESULT hr = S_OK;
     IfNullRetPointer(ppEnum);
 
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetModuleInfosByMvid"));
     CCriticalSectionHolder lock(&m_cs);
     *ppEnum = nullptr;
 
@@ -250,8 +230,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainCollection::GetModuleInfosByMv
 
     *ppEnum = (IEnumModuleInfo*)pEnumerator;
     (*ppEnum)->AddRef();
-
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetModuleInfosByMvid"));
 
     return S_OK;
 }

--- a/src/InstrumentationEngine/AppDomainInfo.cpp
+++ b/src/InstrumentationEngine/AppDomainInfo.cpp
@@ -25,8 +25,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::FinishInitialization(_In
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Begin CAppDomainInfo::FinishInitialization"));
-
     // Get name regardless of whether previously initialized, since appdomains can be renamed.
     ULONG cchName = 0;
     ULONG cchNameLength = 0;
@@ -101,25 +99,17 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::FinishInitialization(_In
         CLogging::LogMessage(_T("Renamed appdomain in CAppDomainInfo::FinishInitialization"));
     }
 
-    CLogging::LogMessage(_T("End CAppDomainInfo::FinishInitialization"));
-
     return S_OK;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::AddAssemblyInfo(_In_ CAssemblyInfo* pAssemblyInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CAppDomainInfo::AddAssemblyInfo"));
-
     CCriticalSectionHolder lock(&m_cs);
 
     AssemblyID assemblyId;
-
     IfFailRet(pAssemblyInfo->GetID(&assemblyId));
-
     m_assemblyInfos[assemblyId] = pAssemblyInfo;
-
-    CLogging::LogMessage(_T("End CAppDomainInfo::AddAssemblyInfo"));
 
     return hr;
 }
@@ -127,17 +117,11 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::AddAssemblyInfo(_In_ CAs
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::AssemblyInfoUnloaded(_In_ CAssemblyInfo* pAssemblyInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CAppDomainInfo::AssemblyInfoUnloaded"));
-
     CCriticalSectionHolder lock(&m_cs);
 
     AssemblyID assemblyId;
-
     IfFailRet(pAssemblyInfo->GetID(&assemblyId));
-
     m_assemblyInfos.erase(assemblyId);
-
-    CLogging::LogMessage(_T("End CAppDomainInfo::AssemblyInfoUnloaded"));
 
     return hr;
 }
@@ -145,16 +129,11 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::AssemblyInfoUnloaded(_In
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::AddModuleInfo(_In_ CModuleInfo* pModuleInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CAppDomainInfo::AddModuleInfo"));
-
     CCriticalSectionHolder lock(&m_cs);
 
     ModuleID moduleId;
     IfFailRet(pModuleInfo->GetModuleID(&moduleId));
-
     m_moduleInfos[moduleId] = pModuleInfo;
-
-    CLogging::LogMessage(_T("end CAppDomainInfo::AddModuleInfo"));
 
     return hr;
 }
@@ -162,17 +141,11 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::AddModuleInfo(_In_ CModu
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::ModuleInfoUnloaded(_In_ CModuleInfo* pModuleInfo)
 {
     HRESULT hr = S_OK;
-
-    CLogging::LogMessage(_T("Begin CAppDomainInfo::ModuleInfoUnloaded"));
-
     CCriticalSectionHolder lock(&m_cs);
 
     ModuleID moduleId;
     IfFailRet(pModuleInfo->GetModuleID(&moduleId));
-
     m_moduleInfos.erase(moduleId);
-
-    CLogging::LogMessage(_T("End CAppDomainInfo::ModuleInfoUnloaded"));
 
     return hr;
 }
@@ -182,7 +155,6 @@ shared_ptr<list<AssemblyID>> MicrosoftInstrumentationEngine::CAppDomainInfo::Get
     CCriticalSectionHolder lock(&m_cs);
 
     shared_ptr<list<AssemblyID>> pAssemblyIds = make_shared<list<AssemblyID>>();
-
     for (std::pair<AssemblyID, CComPtr<CAssemblyInfo>> assemblyInfoPair : m_assemblyInfos)
     {
         pAssemblyIds->emplace_back(assemblyInfoPair.first);
@@ -196,7 +168,6 @@ shared_ptr<list<ModuleID>> MicrosoftInstrumentationEngine::CAppDomainInfo::GetMo
     CCriticalSectionHolder lock(&m_cs);
 
     shared_ptr<list<ModuleID>> pModuleIds = make_shared<list<ModuleID>>();
-
     for (std::pair<ModuleID, CComPtr<CModuleInfo>> moduleInfoPair : m_moduleInfos)
     {
         pModuleIds->emplace_back(moduleInfoPair.first);
@@ -218,49 +189,42 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetAppDomainId(_Out_ App
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetIsSystemDomain(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CAppDomainInfo::GetIsSystemDomain"));
 
     IfNullRetPointer(pbValue);
     IfFalseRet(m_bIsInitialized, E_FAIL);
 
     *pbValue = m_bIsSystemDomain;
 
-    CLogging::LogMessage(_T("End CAppDomainInfo::GetIsSystemDomain"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetIsSharedDomain(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CAppDomainInfo::GetIsSharedDomain"));
 
     IfNullRetPointer(pbValue);
     IfFalseRet(m_bIsInitialized, E_FAIL);
 
     *pbValue = m_bIsSharedDomain;
 
-    CLogging::LogMessage(_T("End CAppDomainInfo::GetIsSharedDomain"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetIsDefaultDomain(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CAppDomainInfo::GetIsDefaultDomain"));
 
     IfNullRetPointer(pbValue);
     IfFalseRet(m_bIsInitialized, E_FAIL);
 
     *pbValue = m_bIsDefaultDomain;
 
-    CLogging::LogMessage(_T("End CAppDomainInfo::GetIsDefaultDomain"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetName(_Out_ BSTR* pbstrName)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CAppDomainInfo::GetName"));
 
     IfNullRetPointer(pbstrName);
     IfFalseRet(m_bIsInitialized, E_FAIL);
@@ -268,14 +232,12 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetName(_Out_ BSTR* pbst
     CComBSTR bstrName = m_bstrAppDomainName;
     *pbstrName = bstrName.Detach();
 
-    CLogging::LogMessage(_T("End CAppDomainInfo::GetName"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetAssemblies(_Out_ IEnumAssemblyInfo** ppAssemblyInfos)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetAssemblies"));
     IfNullRetPointer(ppAssemblyInfos);
     *ppAssemblyInfos = NULL;
 
@@ -299,15 +261,12 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetAssemblies(_Out_ IEnu
     *ppAssemblyInfos = (IEnumAssemblyInfo*)pEnumerator;
     (*ppAssemblyInfos)->AddRef();
 
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetAssemblies"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetModules(_Out_ IEnumModuleInfo** ppModuleInfos)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetModules"));
 
     IfNullRetPointer(ppModuleInfos);
     *ppModuleInfos = NULL;
@@ -332,15 +291,12 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetModules(_Out_ IEnumMo
     *ppModuleInfos = (IEnumModuleInfo*)pEnumerator;
     (*ppModuleInfos)->AddRef();
 
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetModules"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetAssemblyInfoById(_In_ AssemblyID assemblyID, _Out_ IAssemblyInfo** ppAssemblyInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetAssemblyInfoById"));
 
     IfNullRetPointer(ppAssemblyInfo);
     *ppAssemblyInfo = NULL;
@@ -348,17 +304,14 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetAssemblyInfoById(_In_
     CCriticalSectionHolder lock(&m_cs);
 
     std::unordered_map<AppDomainID, CComPtr<CAssemblyInfo>>::iterator iter = m_assemblyInfos.find(assemblyID);
-
     if (iter == m_assemblyInfos.end())
     {
-        CLogging::LogMessage(_T("CAppDomainCollection::GetAssemblyById - Failed to find specified assembly %08" PRIxPTR),assemblyID);
+        CLogging::LogMessage(_T("CAppDomainCollection::GetAssemblyInfoById - Failed to find specified assembly %08" PRIxPTR), assemblyID);
         return E_FAIL;
     }
 
     *ppAssemblyInfo = iter->second;
     (*ppAssemblyInfo)->AddRef();
-
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetAssemblyInfoById"));
 
     return hr;
 }
@@ -368,8 +321,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetAssemblyInfosByName(_
     HRESULT hr = S_OK;
     IfNullRetPointer(ppAssemblyInfos);
     *ppAssemblyInfos = NULL;
-
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetAssemblyInfoByName"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -401,22 +352,17 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetAssemblyInfosByName(_
     IfFailRet(pEnumerator->Initialize(vecAssemblies));
     *ppAssemblyInfos = pEnumerator.Detach();
 
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetAssemblyInfoByName"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetModuleCount(_Out_ ULONG* pcModuleInfos)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CAppDomainInfo::GetModuleCount"));
     IfNullRetPointer(pcModuleInfos);
 
     CCriticalSectionHolder lock(&m_cs);
 
     *pcModuleInfos = ((ULONG)m_moduleInfos.size());
-
-    CLogging::LogMessage(_T("End CAppDomainInfo::GetModuleCount"));
 
     return hr;
 }
@@ -427,22 +373,17 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetModuleInfoById(_In_ M
     IfNullRetPointer(ppModuleInfo);
     *ppModuleInfo = NULL;
 
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetModuleInfoById"));
-
     CCriticalSectionHolder lock(&m_cs);
 
     std::unordered_map<ModuleID, CComPtr<CModuleInfo>>::iterator iter = m_moduleInfos.find(moduleId);
-
     if (iter == m_moduleInfos.end())
     {
-        CLogging::LogMessage(_T("CAppDomainCollection::GetModuleById - Failed to find specified assembly %08" PRIxPTR), moduleId);
+        CLogging::LogMessage(_T("CAppDomainCollection::GetModuleInfoById - Failed to find specified assembly %08" PRIxPTR), moduleId);
         return E_FAIL;
     }
 
     *ppModuleInfo = iter->second;
     (*ppModuleInfo)->AddRef();
-
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetModuleInfoById"));
 
     return hr;
 }
@@ -452,8 +393,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetModuleInfosByMvid(GUI
     HRESULT hr = S_OK;
     IfNullRetPointer(ppModuleInfo);
     *ppModuleInfo = NULL;
-
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetModuleInfosByMvid"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -482,8 +421,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetModuleInfosByMvid(GUI
     *ppModuleInfo = (IEnumModuleInfo*)pEnumerator;
     (*ppModuleInfo)->AddRef();
 
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetModuleInfosByMvid"));
-
     return hr;
 }
 
@@ -492,8 +429,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetModuleInfosByName(_In
     HRESULT hr = S_OK;
     IfNullRetPointer(ppEnumModuleInfo);
     *ppEnumModuleInfo = NULL;
-
-    CLogging::LogMessage(_T("Starting CAppDomainCollection::GetModuleInfosByName"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -525,8 +460,6 @@ HRESULT MicrosoftInstrumentationEngine::CAppDomainInfo::GetModuleInfosByName(_In
     IfFailRet(pEnumerator->Initialize(vecModules));
 
     *ppEnumModuleInfo = pEnumerator.Detach();
-
-    CLogging::LogMessage(_T("End CAppDomainCollection::GetModuleInfosByName"));
 
     return hr;
 }

--- a/src/InstrumentationEngine/AssemblyInfo.cpp
+++ b/src/InstrumentationEngine/AssemblyInfo.cpp
@@ -28,7 +28,6 @@ MicrosoftInstrumentationEngine::CAssemblyInfo::~CAssemblyInfo()
     DeleteCriticalSection(&m_cs);
 }
 
-
 HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::Initialize(
     _In_ AssemblyID assemblyId,
     _In_ const WCHAR* wszAssemblyName,
@@ -37,11 +36,8 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::Initialize(
     )
 {
     m_assemblyId = assemblyId;
-
     m_bstrAssemblyName = wszAssemblyName;
-
     m_pAppDomainInfo = pAppDomainInfo;
-
     m_manifestModuleID = manifestModuleID;
 
     return S_OK;
@@ -60,7 +56,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetAppDomainInfo(_Out_ IA
 HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::AddModuleInfo(_In_ CModuleInfo* pModuleInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CAssemblyInfo::AddModuleInfo"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -75,16 +70,12 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::AddModuleInfo(_In_ CModul
         IfFailRet(HandleManifestModuleLoad());
     }
 
-    CLogging::LogMessage(_T("end CAssemblyInfo::AddModuleInfo"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::HandleManifestModuleLoad()
 {
     HRESULT hr = S_OK;
-
-    CLogging::LogMessage(_T("Begin CAssemblyInfo::HandleManifestModuleLoad"));
 
     if (m_pManifestModule == NULL)
     {
@@ -105,16 +96,12 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::HandleManifestModuleLoad(
         IfFailRet(InitializePublicKeyToken());
     }
 
-    CLogging::LogMessage(_T("End CAssemblyInfo::HandleManifestModuleLoad"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::ModuleInfoUnloaded(_In_ CModuleInfo* pModuleInfo)
 {
     HRESULT hr = S_OK;
-
-    CLogging::LogMessage(_T("Begin CAssemblyInfo::ModuleInfoUnloaded"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -123,22 +110,17 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::ModuleInfoUnloaded(_In_ C
 
     m_moduleInfos.erase(moduleId);
 
-    CLogging::LogMessage(_T("End CAssemblyInfo::ModuleInfoUnloaded"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModuleCount(_Out_ ULONG* pcModuleInfos)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CAssemblyInfo::GetModuleCount"));
     IfNullRetPointer(pcModuleInfos);
 
     CCriticalSectionHolder lock(&m_cs);
 
     *pcModuleInfos = ((ULONG)m_moduleInfos.size());
-
-    CLogging::LogMessage(_T("End CAssemblyInfo::GetModuleCount"));
 
     return hr;
 }
@@ -146,7 +128,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModuleCount(_Out_ ULON
 HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModules(_In_ ULONG cModuleInfos, _Out_ IEnumModuleInfo** ppModuleInfos)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetModules"));
 
     IfNullRetPointer(ppModuleInfos);
     *ppModuleInfos = NULL;
@@ -171,8 +152,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModules(_In_ ULONG cMo
     *ppModuleInfos = (IEnumModuleInfo*)pEnumerator;
     (*ppModuleInfos)->AddRef();
 
-    CLogging::LogMessage(_T("End CAssemblyInfo::GetModules"));
-
     return hr;
 }
 
@@ -181,8 +160,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModuleById(_In_ Module
     HRESULT hr = S_OK;
     IfNullRetPointer(ppModuleInfo);
     *ppModuleInfo = NULL;
-
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetModuleById"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -197,8 +174,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModuleById(_In_ Module
     *ppModuleInfo = iter->second;
     (*ppModuleInfo)->AddRef();
 
-    CLogging::LogMessage(_T("End CAssemblyInfo::GetModuleById"));
-
     return hr;
 }
 
@@ -207,8 +182,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModuleByMvid(_In_ GUID
     HRESULT hr = S_OK;
     IfNullRetPointer(ppModuleInfo);
     *ppModuleInfo = NULL;
-
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetModuleByMvid"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -235,8 +208,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModuleByMvid(_In_ GUID
 
     IfFailRet(pEnumerator->Initialize(vecModules));
 
-    CLogging::LogMessage(_T("End CAssemblyInfo::GetModuleByMvid"));
-
     return hr;
 }
 
@@ -245,8 +216,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModulesByName(_In_ BST
     HRESULT hr = S_OK;
     IfNullRetPointer(ppEnumModuleInfo);
     *ppEnumModuleInfo = NULL;
-
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetModulesByName"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -277,8 +246,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModulesByName(_In_ BST
 
     IfFailRet(pEnumerator->Initialize(vecModules));
 
-    CLogging::LogMessage(_T("End CAssemblyInfo::GetModulesByName"));
-
     return hr;
 }
 
@@ -302,8 +269,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetModuleForType(_In_ BST
 HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetManifestModule(_Out_ IModuleInfo** ppModuleInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetManifestModule"));
-
     IfNullRetPointer(ppModuleInfo);
     *ppModuleInfo = NULL;
 
@@ -315,16 +280,12 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetManifestModule(_Out_ I
 
 	IfFailRet(m_pManifestModule.CopyTo(ppModuleInfo));
 
-    CLogging::LogMessage(_T("end CAssemblyInfo::GetManifestModule"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetPublicKey(_In_ ULONG cbBytes, _Out_writes_(cbBytes) BYTE* pbBytes)
 {
     HRESULT hr = S_OK;
-
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetPublicKey"));
 
     IfNullRetPointer(pbBytes);
     if (cbBytes != m_cbPublicKey)
@@ -334,21 +295,15 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetPublicKey(_In_ ULONG c
 
     memcpy_s(pbBytes, cbBytes, m_pPublicKey, m_cbPublicKey);
 
-    CLogging::LogMessage(_T("end CAssemblyInfo::GetPublicKey"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetPublicKeySize(_Out_ ULONG* pcbBytes)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetPublicKeySize"));
-
     IfNullRetPointer(pcbBytes);
 
     *pcbBytes = m_cbPublicKey;
-
-    CLogging::LogMessage(_T("end CAssemblyInfo::GetPublicKeySize"));
 
     return hr;
 }
@@ -356,9 +311,8 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetPublicKeySize(_Out_ UL
 HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetPublicKeyToken(_Out_ BSTR* pbstrPublicKeyToken)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetPublicKeyToken"));
-    IfNullRetPointer(pbstrPublicKeyToken);
 
+    IfNullRetPointer(pbstrPublicKeyToken);
     if (!m_publicKeyTokenInitialized)
     {
         CLogging::LogError(_T("Starting CAssemblyInfo::GetPublicKeyToken - public key token not initiliazed"));
@@ -367,8 +321,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetPublicKeyToken(_Out_ B
 
     IfFailRet(m_bstrPublicKeyToken.CopyTo(pbstrPublicKeyToken));
 
-    CLogging::LogMessage(_T("end CAssemblyInfo::GetPublicKeyToken"));
-
     return hr;
 }
 
@@ -376,11 +328,7 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetID(_Out_ AssemblyID* p
 {
     HRESULT hr = S_OK;
     IfNullRetPointer(pAssemblyId);
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetID"));
-
     *pAssemblyId = m_assemblyId;
-
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetID"));
 
     return hr;
 }
@@ -389,11 +337,7 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetName(_Out_ BSTR* pbstr
 {
     HRESULT hr = S_OK;
     IfNullRetPointer(pbstrName);
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetName"));
-
-	IfFailRet(m_bstrAssemblyName.CopyTo(pbstrName));
-
-    CLogging::LogMessage(_T("End CAssemblyInfo::GetName"));
+    IfFailRet(m_bstrAssemblyName.CopyTo(pbstrName));
 
     return hr;
 }
@@ -402,8 +346,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetMetaDataToken(_Out_ DW
 {
     HRESULT hr = S_OK;
     IfNullRetPointer(pdwToken);
-    CLogging::LogMessage(_T("Starting CAssemblyInfo::GetMetaDataToken"));
-
     if (m_tkAssembly == mdTokenNil)
     {
         CLogging::LogMessage(_T("CAssemblyInfo::GetMetaDataToken - token is mdTokenNil."));
@@ -411,8 +353,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::GetMetaDataToken(_Out_ DW
     }
 
     *pdwToken = m_tkAssembly;
-
-    CLogging::LogMessage(_T("End CAssemblyInfo::GetMetaDataToken"));
 
     return hr;
 }
@@ -428,7 +368,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::InitializePublicKeyToken(
     {
         return S_OK;
     }
-    CLogging::LogMessage(_T("Begin CAssemblyInfo::InitializePublicKeyToken"));
 
     m_publicKeyTokenInitialized = true;
 
@@ -474,8 +413,6 @@ HRESULT MicrosoftInstrumentationEngine::CAssemblyInfo::InitializePublicKeyToken(
     StrongNameFreeBufferPtr(pPublicKeyToken);
 
     m_bstrPublicKeyToken = wszPublicKeyToken;
-
-    CLogging::LogMessage(_T("End CAssemblyInfo::InitializePublicKeyToken"));
 
 #endif
 

--- a/src/InstrumentationEngine/CorProfilerFunctionControlWrapper.cpp
+++ b/src/InstrumentationEngine/CorProfilerFunctionControlWrapper.cpp
@@ -9,23 +9,16 @@ MicrosoftInstrumentationEngine::CCorProfilerFunctionInfoWrapper::CCorProfilerFun
     _In_ CMethodInfo* pMethodInfo
     ) : m_pProfilerManager(pProfilerManager), m_pMethodInfo(pMethodInfo)
 {
-
 }
-
 
 HRESULT MicrosoftInstrumentationEngine::CCorProfilerFunctionInfoWrapper::SetCodegenFlags(
     _In_ DWORD flags)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CCorProfilerFunctionInfoWrapper::SetCodegenFlags"));
-
     DWORD originalFlags = 0;
 
     IfFailRet(m_pMethodInfo->GetRejitCodeGenFlags(&originalFlags));
-
     IfFailRet(m_pMethodInfo->SetRejitCodeGenFlags(originalFlags | flags));
-
-    CLogging::LogMessage(_T("End CCorProfilerFunctionInfoWrapper::SetCodegenFlags"));
 
     return S_OK;
 }
@@ -35,11 +28,8 @@ HRESULT MicrosoftInstrumentationEngine::CCorProfilerFunctionInfoWrapper::SetILFu
     _In_reads_(cbNewILMethodHeader) LPCBYTE pbNewILMethodHeader)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CCorProfilerFunctionInfoWrapper::SetILFunctionBody"));
 
     IfFailRet(m_pMethodInfo->SetFinalRenderedFunctionBody(pbNewILMethodHeader, cbNewILMethodHeader));
-
-    CLogging::LogMessage(_T("End CCorProfilerFunctionInfoWrapper::SetILFunctionBody"));
 
     return S_OK;
 }
@@ -50,11 +40,7 @@ HRESULT MicrosoftInstrumentationEngine::CCorProfilerFunctionInfoWrapper::SetILIn
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CCorProfilerFunctionInfoWrapper::SetILFunctionBody"));
-
     IfFailRet(m_pMethodInfo->MergeILInstrumentedCodeMap(cILMapEntries, rgILMapEntries));
-
-    CLogging::LogMessage(_T("End CCorProfilerFunctionInfoWrapper::SetILFunctionBody"));
 
     return S_OK;
 }

--- a/src/InstrumentationEngine/ExceptionClause.cpp
+++ b/src/InstrumentationEngine/ExceptionClause.cpp
@@ -18,8 +18,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::InitializeFromSmall(
     )
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::InitializeFromSmall"));
-
 #ifndef _WIN64
     m_flags = pSmallClause->Flags;
 #else
@@ -44,8 +42,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::InitializeFromSmall(
         IfFailRet(pInstructionGraph->GetInstructionAtOffsetInternal(pSmallClause->FilterOffset, &m_pFilterFirstInstruction));
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::InitializeFromSmall"));
-
     return hr;
 }
 
@@ -55,7 +51,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::InitializeFromFat(
     )
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::InitializeFromFat"));
 
     m_flags = pFatClause->Flags;
 
@@ -77,15 +72,12 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::InitializeFromFat(
         IfFailRet(pInstructionGraph->GetInstructionAtOffsetInternal(pFatClause->FilterOffset, &m_pFilterFirstInstruction));
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::InitializeFromSmall"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::RenderExceptionClause(_In_ IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT* pEHClause)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::RenderExceptionClause"));
     IfNullRetPointer(pEHClause);
 
     IfNullRet(m_pTryFirstInstruction);
@@ -127,8 +119,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::RenderExceptionClause(
         IfFailRet(m_pFilterFirstInstruction->GetOffset(&pEHClause->FilterOffset));
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::RenderExceptionClause"));
-
     return hr;
 }
 
@@ -137,7 +127,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::UpdateInstruction(_In_
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CExceptionClause::UpdateInstruction"));
     IfNullRetPointer(pInstructionOld);
 
     // This function is to update the exception clause range for InsertBefore, Remove and Replace instructions.
@@ -180,27 +169,22 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::UpdateInstruction(_In_
         m_pFilterFirstInstruction = pInstructionNew;
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::UpdateInstruction"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetFlags(_Out_ DWORD* pFlags)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::GetFlags"));
     IfNullRetPointer(pFlags);
 
     *pFlags = m_flags;
 
-    CLogging::LogMessage(_T("End CExceptionClause::GetFlags"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetTryFirstInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::GetTryFirstInstruction"));
     IfNullRetPointer(ppInstruction);
     *ppInstruction = NULL;
 
@@ -210,14 +194,12 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetTryFirstInstruction
         (*ppInstruction)->AddRef();
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::GetTryFirstInstruction"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetTryLastInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::GetTryLastInstruction"));
     IfNullRetPointer(ppInstruction);
     *ppInstruction = NULL;
 
@@ -227,14 +209,12 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetTryLastInstruction(
         (*ppInstruction)->AddRef();
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::GetTryLastInstruction"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetHandlerFirstInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::GetHandlerFirstInstruction"));
     IfNullRetPointer(ppInstruction);
     *ppInstruction = NULL;
 
@@ -244,14 +224,12 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetHandlerFirstInstruc
         (*ppInstruction)->AddRef();
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::GetHandlerFirstInstruction"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetHandlerLastInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::GetHandlerLastInstruction"));
     IfNullRetPointer(ppInstruction);
     *ppInstruction = NULL;
 
@@ -261,14 +239,12 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetHandlerLastInstruct
         (*ppInstruction)->AddRef();
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::GetHandlerLastInstruction"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetFilterFirstInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::GetFilterFirstInstruction"));
     IfNullRetPointer(ppInstruction);
     *ppInstruction = NULL;
 
@@ -278,7 +254,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetFilterFirstInstruct
         (*ppInstruction)->AddRef();
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::GetFilterFirstInstruction"));
     return hr;
 }
 
@@ -286,12 +261,10 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetFilterFirstInstruct
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetExceptionHandlerType(_Out_ mdToken* pToken)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::GetExceptionHandlerType"));
     IfNullRetPointer(pToken);
 
     *pToken = m_ExceptionHandlerType;
 
-    CLogging::LogMessage(_T("End CExceptionClause::GetExceptionHandlerType"));
     return hr;
 }
 
@@ -300,18 +273,15 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::GetExceptionHandlerTyp
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetFlags(_In_ DWORD flags)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::SetFlags"));
 
     m_flags = (CorExceptionFlag)flags;
 
-    CLogging::LogMessage(_T("End CExceptionClause::SetFlags"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetTryFirstInstruction(_In_ IInstruction* pInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::SetTryFirstInstruction"));
 
     if (pInstruction != nullptr)
     {
@@ -322,14 +292,12 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetTryFirstInstruction
         m_pTryFirstInstruction = nullptr;
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::SetTryFirstInstruction"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetTryLastInstruction(_In_ IInstruction* pInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::SetTryLastInstruction"));
 
     if (pInstruction != nullptr)
     {
@@ -340,14 +308,12 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetTryLastInstruction(
         m_pTryLastInstruction = nullptr;
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::SetTryLastInstruction"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetHandlerFirstInstruction(_In_ IInstruction* pInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::SetHandlerFirstInstruction"));
 
     if (pInstruction != nullptr)
     {
@@ -358,14 +324,12 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetHandlerFirstInstruc
         m_pHandlerFirstInstruction = nullptr;
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::SetHandlerFirstInstruction"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetHandlerLastInstruction(_In_ IInstruction* pInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::SetHandlerLastInstruction"));
 
     if (pInstruction != nullptr)
     {
@@ -376,14 +340,12 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetHandlerLastInstruct
         m_pHandlerLastInstruction = nullptr;
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::SetHandlerLastInstruction"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetFilterFirstInstruction(_In_ IInstruction* pInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::SetFilterFirstInstruction"));
 
     if (pInstruction != nullptr)
     {
@@ -394,7 +356,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetFilterFirstInstruct
         m_pFilterFirstInstruction = nullptr;
     }
 
-    CLogging::LogMessage(_T("End CExceptionClause::SetFilterFirstInstruction"));
     return hr;
 }
 
@@ -402,10 +363,8 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetFilterFirstInstruct
 HRESULT MicrosoftInstrumentationEngine::CExceptionClause::SetExceptionHandlerType(_In_ mdToken token)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionClause::SetExceptionHandlerType"));
 
     m_ExceptionHandlerType = token;
 
-    CLogging::LogMessage(_T("End CExceptionClause::SetExceptionHandlerType"));
     return hr;
 }

--- a/src/InstrumentationEngine/ExceptionSection.cpp
+++ b/src/InstrumentationEngine/ExceptionSection.cpp
@@ -25,7 +25,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::Initialize(
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CExceptionSection::Initialize"));
     IfNullRetPointer(pMethodHeader);
 
     if(((COR_ILMETHOD_TINY*)pMethodHeader)->IsTiny() || IsFlagClear(pMethodHeader->Fat.Flags, CorILMethod_MoreSects))
@@ -34,22 +33,22 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::Initialize(
         return S_OK;;
     }
 
-	const COR_ILMETHOD* pMethod = (COR_ILMETHOD*)pMethodHeader;
+    const COR_ILMETHOD* pMethod = (COR_ILMETHOD*)pMethodHeader;
     const BYTE* pSectsBegin = (BYTE*)(pMethod->Fat.GetSect());
 
-	COR_ILMETHOD_DECODER method(&(pMethod->Fat));
+    COR_ILMETHOD_DECODER method(&(pMethod->Fat));
 
     const COR_ILMETHOD_SECT_EH* pCurEHSect = method.EH;
 
     while (pCurEHSect)
-	{
+    {
         DWORD nCount = pCurEHSect->EHCount();
 
         if (pCurEHSect->IsFat())
-		{
+        {
             const IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_FAT* pFatEHClause = pCurEHSect->Fat.Clauses;
             for(DWORD nIndex = 0; nIndex < nCount; ++nIndex)
-			{
+            {
                 CComPtr<CExceptionClause> pClause;
                 pClause.Attach(new CExceptionClause(m_pMethodInfo));
 
@@ -59,10 +58,10 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::Initialize(
             }
         }
         else
-		{
+        {
             const IMAGE_COR_ILMETHOD_SECT_EH_CLAUSE_SMALL* pSmallEHClause = pCurEHSect->Small.Clauses;
             for  (DWORD nIndex = 0; nIndex < nCount; ++nIndex)
-			{
+            {
                 CComPtr<CExceptionClause> pClause;
                 pClause.Attach(new CExceptionClause(m_pMethodInfo));
 
@@ -74,13 +73,11 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::Initialize(
 
         // Find the next EH section
         do
-		{
+        {
             pCurEHSect = (COR_ILMETHOD_SECT_EH*)pCurEHSect->Next();
         } while  (pCurEHSect && (pCurEHSect->Kind() & CorILMethod_Sect_KindMask) != CorILMethod_Sect_EHTable);
 
     }
-
-    CLogging::LogMessage(_T("End CExceptionSection::Initialize"));
 
     return hr;
 }
@@ -88,7 +85,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::Initialize(
 HRESULT MicrosoftInstrumentationEngine::CExceptionSection::CreateExceptionHeader(_Out_ BYTE** ppExceptionHeader, _Out_ DWORD* pcbExceptionHeader)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionSection::CreateExceptionHeader"));
     IfNullRetPointer(ppExceptionHeader);
     IfNullRetPointer(pcbExceptionHeader);
     *ppExceptionHeader = NULL;
@@ -125,7 +121,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::CreateExceptionHeader
     *ppExceptionHeader = pBuffer.Detach();
     *pcbExceptionHeader = dwBufferSize;
 
-    CLogging::LogMessage(_T("End CExceptionSection::CreateExceptionHeader"));
     return hr;
 }
 
@@ -133,20 +128,17 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::CreateExceptionHeader
 HRESULT MicrosoftInstrumentationEngine::CExceptionSection::GetMethodInfo(_Out_ IMethodInfo** ppMethodInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionSection::GetMethodInfo"));
     IfNullRetPointer(ppMethodInfo);
 
     *ppMethodInfo = m_pMethodInfo;
     (*ppMethodInfo)->AddRef();
 
-    CLogging::LogMessage(_T("End CExceptionSection::GetMethodInfo"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionSection::GetExceptionClauses(_Out_ IEnumExceptionClauses** ppEnumExceptionClauses)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionSection::GetExceptionClauses"));
 
     IfNullRetPointer(ppEnumExceptionClauses);
     *ppEnumExceptionClauses = NULL;
@@ -164,7 +156,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::GetExceptionClauses(_
 
     *ppEnumExceptionClauses = pEnumerator.Detach();
 
-    CLogging::LogMessage(_T("End CExceptionSection::GetExceptionClauses"));
 
     return hr;
 }
@@ -172,7 +163,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::GetExceptionClauses(_
 HRESULT MicrosoftInstrumentationEngine::CExceptionSection::AddExceptionClause(_In_ IExceptionClause* pExceptionClause)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionSection::AddExceptionClause"));
 
     IfNullRetPointer(pExceptionClause);
 
@@ -182,15 +172,12 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::AddExceptionClause(_I
 
     m_exceptionClauses.push_back(pExceptionClause);
 
-    CLogging::LogMessage(_T("End CExceptionSection::AddExceptionClause"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionSection::RemoveExceptionClause(_In_ IExceptionClause* pExceptionClause)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionSection::RemoveExceptionClause"));
     IfNullRetPointer(pExceptionClause);
 
     CCriticalSectionHolder lock(&m_cs);
@@ -204,20 +191,15 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::RemoveExceptionClause
         }
     }
 
-    CLogging::LogMessage(_T("End CExceptionSection::RemoveExceptionClause"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CExceptionSection::RemoveAllExceptionClauses()
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionSection::RemoveAllExceptionClauses"));
     CCriticalSectionHolder lock(&m_cs);
 
     m_exceptionClauses.clear();
-
-    CLogging::LogMessage(_T("End CExceptionSection::RemoveAllExceptionClauses"));
 
     return hr;
 }
@@ -226,7 +208,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::RemoveAllExceptionCla
 HRESULT MicrosoftInstrumentationEngine::CExceptionSection::UpdateInstruction(_In_ CInstruction* pInstructionOld, _In_ CInstruction* pInstructionNew)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionSection::UpdateInstruction"));
     IfNullRetPointer(pInstructionOld);
 
     CCriticalSectionHolder lock(&m_cs);
@@ -236,8 +217,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::UpdateInstruction(_In
         CExceptionClause* pClause = (CExceptionClause*)((*iter).p);
         pClause->UpdateInstruction(pInstructionOld, pInstructionNew);
     }
-
-    CLogging::LogMessage(_T("End CExceptionSection::UpdateInstruction"));
 
     return hr;
 }
@@ -254,7 +233,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::AddNewExceptionClause
     )
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CExceptionSection::CreateExceptionClause"));
     IfNullRetPointer(ppExceptionClause);
     *ppExceptionClause = NULL;
 
@@ -276,8 +254,6 @@ HRESULT MicrosoftInstrumentationEngine::CExceptionSection::AddNewExceptionClause
     m_exceptionClauses.insert(iter, (IExceptionClause*)pExceptionClause);
 
     *ppExceptionClause = pExceptionClause.Detach();
-
-    CLogging::LogMessage(_T("End CExceptionSection::CreateExceptionClause"));
 
     return hr;
 }

--- a/src/InstrumentationEngine/Instruction.cpp
+++ b/src/InstrumentationEngine/Instruction.cpp
@@ -1195,7 +1195,6 @@ IInstruction* MicrosoftInstrumentationEngine::CSwitchInstruction::GetBranchTarge
 HRESULT MicrosoftInstrumentationEngine::CSwitchInstruction::SetBranchTarget(_In_ DWORD index, _In_ IInstruction* pTarget)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CSwitchInstruction::SetBranchTarget"));
 
     CComPtr<CInstruction> oldTarget = m_branchTargets[index];
     CComPtr<CInstruction> pNewTarget;

--- a/src/InstrumentationEngine/InstructionFactory.cpp
+++ b/src/InstrumentationEngine/InstructionFactory.cpp
@@ -14,7 +14,6 @@ MicrosoftInstrumentationEngine::CInstructionFactory::CInstructionFactory()
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateInstruction(_In_ enum ILOrdinalOpcode opcode, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<CInstruction> pInstruction;
@@ -27,7 +26,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateInstruction(_
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateInstruction"));
     return S_OK;
 }
 
@@ -35,7 +33,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateInstruction(_
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateByteOperandInstruction(_In_ enum ILOrdinalOpcode opcode, _In_ BYTE operand, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateByteOperandInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<COperandInstruction> pInstruction;
@@ -48,8 +45,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateByteOperandIn
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateByteOperandInstruction"));
-
     return S_OK;
 }
 
@@ -57,7 +52,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateByteOperandIn
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateUShortOperandInstruction(_In_ enum ILOrdinalOpcode opcode, _In_ USHORT operand, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateUShortOperandInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<COperandInstruction> pInstruction;
@@ -70,7 +64,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateUShortOperand
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateUShortOperandInstruction"));
     return S_OK;
 }
 
@@ -78,7 +71,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateUShortOperand
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateIntOperandInstruction(_In_ enum ILOrdinalOpcode opcode, _In_ INT32 operand, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateULongOperandInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<COperandInstruction> pInstruction;
@@ -91,7 +83,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateIntOperandIns
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateULongOperandInstruction"));
     return S_OK;
 }
 
@@ -99,7 +90,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateIntOperandIns
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLongOperandInstruction(_In_ enum ILOrdinalOpcode opcode, _In_ INT64 operand, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateLongOperandInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<COperandInstruction> pInstruction;
@@ -112,7 +102,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLongOperandIn
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateLongOperandInstruction"));
     return S_OK;
 }
 
@@ -121,7 +110,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLongOperandIn
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateFloatOperandInstruction(_In_ enum ILOrdinalOpcode opcode, _In_ float operand, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateLongOperandInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<COperandInstruction> pInstruction;
@@ -134,7 +122,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateFloatOperandI
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateLongOperandInstruction"));
     return S_OK;
 }
 
@@ -142,7 +129,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateFloatOperandI
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateDoubleOperandInstruction(_In_ enum ILOrdinalOpcode opcode, _In_ double operand, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateDoubleOperandInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<COperandInstruction> pInstruction;
@@ -155,7 +141,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateDoubleOperand
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateDoubleOperandInstruction"));
     return S_OK;
 }
 
@@ -163,7 +148,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateDoubleOperand
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateTokenOperandInstruction(_In_ enum ILOrdinalOpcode opcode, _In_ mdToken operand, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateDoubleOperandInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<COperandInstruction> pInstruction;
@@ -176,7 +160,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateTokenOperandI
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateDoubleOperandInstruction"));
     return S_OK;
 }
 
@@ -184,7 +167,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateTokenOperandI
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateBranchInstruction(_In_ enum ILOrdinalOpcode opcode, _In_ IInstruction* pBranchTarget, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateBranchInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<CBranchInstruction> pInstruction;
@@ -203,7 +185,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateBranchInstruc
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateBranchInstruction"));
     return S_OK;
 }
 
@@ -215,7 +196,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateSwitchInstruc
     _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateSwitchInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<CSwitchInstruction> pInstruction;
@@ -235,7 +215,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateSwitchInstruc
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateSwitchInstruction"));
     return S_OK;
 }
 
@@ -246,7 +225,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateSwitchInstruc
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadConstInstruction(_In_ int value, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateLoadConstInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<CLoadConstInstruction> pInstruction;
@@ -259,8 +237,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadConstInst
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateLoadConstInstruction"));
-
     return S_OK;
 }
 
@@ -268,7 +244,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadConstInst
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadLocalInstruction(_In_ USHORT index, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateLoadLocalInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<CLoadLocalInstruction> pInstruction;
@@ -281,8 +256,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadLocalInst
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateLoadLocalInstruction"));
-
     return S_OK;
 }
 
@@ -290,7 +263,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadLocalInst
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadLocalAddressInstruction(_In_ USHORT index, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateLoadLocalAddressInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<CLoadLocalAddrInstruction> pInstruction;
@@ -303,8 +275,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadLocalAddr
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateLoadLocalAddressInstruction"));
-
     return S_OK;
 }
 
@@ -312,7 +282,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadLocalAddr
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateStoreLocalInstruction(_In_ USHORT index, _Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateStoreLocalInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<CStoreLocalInstruction> pInstruction;
@@ -325,8 +294,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateStoreLocalIns
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateStoreLocalInstruction"));
-
     return S_OK;
 }
 
@@ -335,7 +302,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadArgInstru
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateLoadArgInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<CLoadArgInstruction> pInstruction;
@@ -348,8 +314,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadArgInstru
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateLoadArgInstruction"));
-
     return S_OK;
 }
 
@@ -358,7 +322,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadArgAddres
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CInstructionFactory::CreateLoadArgAddressInstruction"));
     IfNullRetPointer(ppInstruction);
 
     CComPtr<CLoadArgAddrInstruction> pInstruction;
@@ -371,15 +334,12 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::CreateLoadArgAddres
     *ppInstruction = (IInstruction*)(pInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionFactory::CreateLoadArgAddressInstruction"));
-
     return S_OK;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::DecodeInstructionByteStream(_In_ DWORD cbMethod, _In_reads_bytes_(cbMethod) LPCBYTE instructionBytes, _Out_ IInstructionGraph** ppInstructionGraph)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionFactory::DecodeInstructionByteStream"));
     IfNullRetPointer(instructionBytes);
     IfNullRetPointer(ppInstructionGraph);
     *ppInstructionGraph = NULL;
@@ -406,6 +366,5 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionFactory::DecodeInstructionBy
 
     *ppInstructionGraph = (IInstructionGraph*)(pInstructionGraph.Detach());
 
-    CLogging::LogMessage(_T("End CInstructionFactory::DecodeInstructionByteStream"));
     return hr;
 }

--- a/src/InstrumentationEngine/InstructionGraph.cpp
+++ b/src/InstrumentationEngine/InstructionGraph.cpp
@@ -69,11 +69,7 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::Initialize(_In_ CMeth
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CInstructionGraph::Initialize"));
-
     m_pMethodInfo = pMethodInfo;
-
-    CLogging::LogMessage(_T("End CInstructionGraph::Initialize"));
 
     return hr;
 }
@@ -224,7 +220,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetInstructionAtUnins
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::DecodeInstructions(_In_ LPCBYTE pCodeBase, _In_ LPCBYTE pEndOfCode)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::Decode"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -517,7 +512,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetInstructionAtEndOf
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::CalculateInstructionOffsets()
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::CalculateInstructionOffsets"));
     CCriticalSectionHolder lock(&m_cs);
 
     ULONG pos = 0;
@@ -539,14 +533,12 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::CalculateInstructionO
         pCurrent = pCurrent->NextInstructionInternal();
     }
 
-    CLogging::LogMessage(_T("End CInstructionGraph::CalculateInstructionOffsets"));
     return S_OK;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::ExpandBranches()
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::ExpandBranches"));
     CCriticalSectionHolder lock(&m_cs);
 
     ULONG pos = 0;
@@ -564,7 +556,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::ExpandBranches()
     }
 
     MarkInstructionsStale();
-    CLogging::LogMessage(_T("End CInstructionGraph::ExpandBranches"));
 
     return S_OK;
 }
@@ -573,7 +564,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetMethodInfo(_Out_ I
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CInstructionGraph::Initialize"));
     IfNullRetPointer(ppMethodInfo);
 
     if (!m_pMethodInfo)
@@ -584,8 +574,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetMethodInfo(_Out_ I
     *ppMethodInfo = m_pMethodInfo;
     (*ppMethodInfo)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionGraph::Initialize"));
-
     return hr;
 }
 
@@ -593,7 +581,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetMethodInfo(_Out_ I
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetFirstInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::GetFirstInstruction"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(ppInstruction);
@@ -604,15 +591,12 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetFirstInstruction(_
         (*ppInstruction)->AddRef();
     }
 
-    CLogging::LogMessage(_T("End CInstructionGraph::GetFirstInstruction"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetLastInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::GetLastInstruction"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(ppInstruction);
@@ -623,15 +607,12 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetLastInstruction(_O
         (*ppInstruction)->AddRef();
     }
 
-    CLogging::LogMessage(_T("End CInstructionGraph::GetLastInstruction"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetOriginalFirstInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::GetOriginalFirstInstruction"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(ppInstruction);
@@ -639,15 +620,12 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetOriginalFirstInstr
     *ppInstruction = (IInstruction*)(m_pOrigFirstInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionGraph::GetOriginalFirstInstruction"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetOriginalLastInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::GetOriginalLastInstruction"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(ppInstruction);
@@ -655,15 +633,12 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetOriginalLastInstru
     *ppInstruction = (IInstruction*)(m_pOrigLastInstruction.p);
     (*ppInstruction)->AddRef();
 
-    CLogging::LogMessage(_T("End CInstructionGraph::GetOriginalLastInstruction"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetUninstrumentedFirstInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::GetUninstrumentedFirstInstruction"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(ppInstruction);
@@ -676,15 +651,12 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetUninstrumentedFirs
 
     hr = m_pUninstrumentedFirstInstruction.QueryInterface(ppInstruction);
 
-    CLogging::LogMessage(_T("End CInstructionGraph::GetUninstrumentedFirstInstruction"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetUninstrumentedLastInstruction(_Out_ IInstruction** ppInstruction)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::GetUninstrumentedFirstInstruction"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(ppInstruction);
@@ -695,8 +667,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetUninstrumentedLast
         return S_FALSE;
     }
     hr = m_pUninstrumentedLastInstruction.QueryInterface(ppInstruction);
-
-    CLogging::LogMessage(_T("End CInstructionGraph::GetUninstrumentedFirstInstruction"));
 
     return hr;
 }
@@ -717,9 +687,7 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetInstructionAtOffse
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(ppInstruction);
-
     CInstruction* pCurrInstruction = m_pFirstInstruction;
-
     while (pCurrInstruction != NULL)
     {
         DWORD currOffset = 0;
@@ -788,7 +756,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::GetInstructionAtOrigi
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::InsertBefore(_In_ IInstruction* pInstructionOrig, _In_ IInstruction* pInstructionNew)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::InsertBefore"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(pInstructionOrig);
@@ -822,12 +789,9 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::InsertBefore(_In_ IIn
         m_pFirstInstruction = pInstrNew;
     }
 
-    
     // NOTE: Unlike intellitrace's engine, the offsets of instructions are updated after each change.
     // This is necessary since this is an API to be consumed by multiple instermentation methods.
     MarkInstructionsStale();
-
-    CLogging::LogMessage(_T("End CInstructionGraph::InsertBefore"));
 
     return hr;
 }
@@ -837,7 +801,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::InsertBefore(_In_ IIn
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::InsertAfter(_In_opt_ IInstruction* pInstructionOrig, _In_ IInstruction* pInstructionNew)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::InsertAfter"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(pInstructionNew);
@@ -885,8 +848,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::InsertAfter(_In_opt_ 
     // This is necessary since this is an API to be consumed by multiple instermentation methods.
     MarkInstructionsStale();
 
-    CLogging::LogMessage(_T("End CInstructionGraph::InsertAfter"));
-
     return hr;
 }
 
@@ -896,7 +857,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::InsertBeforeAndRetarg
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CInstructionGraph::InsertBeforeAndRetargetOffsets"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(pInstructionOrig);
@@ -949,8 +909,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::InsertBeforeAndRetarg
         }
     }
 
-    CLogging::LogMessage(_T("End CInstructionGraph::InsertBeforeAndRetargetOffsets"));
-
     return hr;
 }
 
@@ -959,7 +917,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::InsertBeforeAndRetarg
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::Replace(_In_ IInstruction* pInstructionOrig, _In_ IInstruction *pInstructionNew)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::Replace"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(pInstructionOrig);
@@ -1017,8 +974,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::Replace(_In_ IInstruc
         }
     }
 
-    CLogging::LogMessage(_T("End CInstructionGraph::Replace"));
-
     return hr;
 }
 
@@ -1027,7 +982,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::Remove(_In_ IInstruct
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CInstructionGraph::Remove"));
     CCriticalSectionHolder lock(&m_cs);
 
     IfNullRetPointer(pInstruction);
@@ -1092,8 +1046,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::Remove(_In_ IInstruct
         }
     }
 
-    CLogging::LogMessage(_T("End CInstructionGraph::Remove"));
-
     return hr;
 }
 
@@ -1102,7 +1054,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::Remove(_In_ IInstruct
 HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::RemoveAll()
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CInstructionGraph::RemoveAll"));
     CCriticalSectionHolder lock(&m_cs);
 
     CInstruction* pInstr = m_pFirstInstruction.p;
@@ -1126,8 +1077,6 @@ HRESULT MicrosoftInstrumentationEngine::CInstructionGraph::RemoveAll()
         IfFailRet(m_pMethodInfo->GetExceptionSection((IExceptionSection**)&pExceptionSection));
         IfFailRet(pExceptionSection->RemoveAllExceptionClauses());
     }
-
-    CLogging::LogMessage(_T("End CInstructionGraph::Remove"));
 
     return hr;
 }

--- a/src/InstrumentationEngine/LocalVariableCollection.cpp
+++ b/src/InstrumentationEngine/LocalVariableCollection.cpp
@@ -39,8 +39,6 @@ HRESULT MicrosoftInstrumentationEngine::CLocalVariableCollection::ReplaceSignatu
 {
     //TODO Should we allow complete signature removal?
 
-    CLogging::LogMessage(_T("Begin CLocalVariableCollection::ReplaceSignature"));
-
     if (m_bReadOnly)
     {
         CLogging::LogError(_T("Local variable collection is read-only"));
@@ -70,8 +68,6 @@ HRESULT MicrosoftInstrumentationEngine::CLocalVariableCollection::ReplaceSignatu
     }
 
     IfFailRet(Initialize());
-
-    CLogging::LogMessage(_T("End CLocalVariableCollection::ReplaceSignature"));
 
     return S_OK;
 }

--- a/src/InstrumentationEngine/MethodInfo.cpp
+++ b/src/InstrumentationEngine/MethodInfo.cpp
@@ -75,7 +75,6 @@ MicrosoftInstrumentationEngine::CMethodInfo::~CMethodInfo()
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::Initialize(_In_ bool bAddToMethodInfoMap, _In_ bool isRejit)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::Initialize"));
 
     // Do the minimum required amount of initialization.
     // The rest is deferred until needed
@@ -105,7 +104,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::Initialize(_In_ bool bAddTo
         m_bIsStandaloneMethodInfo = true;
     }
 
-    CLogging::LogMessage(_T("End CMethodInfo::Initialize"));
     return S_OK;
 }
 
@@ -126,42 +124,36 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::Cleanup()
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetModuleInfo(_Out_ IModuleInfo** ppModuleInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetModuleInfo"));
     IfNullRetPointer(ppModuleInfo);
     *ppModuleInfo = nullptr;
 
     *ppModuleInfo = (IModuleInfo*)m_pModuleInfo;
     (*ppModuleInfo)->AddRef();
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetModuleInfo"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetName(_Out_ BSTR* pbstrName)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetName"));
     IfNullRetPointer(pbstrName);
 
     IfFailRet(InitializeName(m_tkFunction));
 
     hr = m_bstrMethodName.CopyTo(pbstrName);
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetName"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetFullName(_Out_ BSTR* pbstrFullName)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetFullName"));
     IfNullRetPointer(pbstrFullName);
 
     IfFailRet(InitializeFullName());
 
     hr = m_bstrMethodFullName.CopyTo(pbstrFullName);
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetFullName"));
     return hr;
 }
 
@@ -338,7 +330,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::InitializeCorAttributes(_In
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::ApplyIntermediateMethodInstrumentation()
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::ApplyIntermediateMethodInstrumentation"));
 
     if (m_pInstructionGraph == NULL)
     {
@@ -360,7 +351,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::ApplyIntermediateMethodInst
 
     m_bIsInstrumented = true;
 
-    CLogging::LogMessage(_T("End CMethodInfo::ApplyIntermediateMethodInstrumentation"));
     return hr;
 }
 
@@ -443,7 +433,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::CreateILFunctionBody()
         IfFailRetErrno(memcpy_s((BYTE*)pNewMethod + FAT_HEADER_SIZE + cbNewMethodSizeWithoutHeader + nNewDelta, cbSehExtra, pSectEh, cbSehExtra));
     }
 
-
     return S_OK;
 }
 
@@ -452,8 +441,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::CreateILFunctionBody()
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetInstructions(_Out_ IInstructionGraph** ppInstructionGraph)
 {
     HRESULT hr = S_OK;
-
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetInstructions"));
 
     if (m_bIsStandaloneMethodInfo)
     {
@@ -471,8 +458,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetInstructions(_Out_ IInst
 
     *ppInstructionGraph = m_pInstructionGraph;
     (*ppInstructionGraph)->AddRef();
-
-    CLogging::LogMessage(_T("End CMethodInfo::GetInstructions"));
 
     return hr;
 }
@@ -636,7 +621,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetOriginalLocalVariables(_
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetClassId(_Out_ ClassID* pClassId)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetClassId"));
     IfNullRetPointer(pClassId);
 
     if (m_classId == 0)
@@ -647,14 +631,12 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetClassId(_Out_ ClassID* p
 
     *pClassId = m_classId;
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetClassId"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetFunctionId(_Out_ FunctionID* pFunctionID)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetFunctionId"));
     IfNullRetPointer(pFunctionID);
 
     if (m_functionId == 0)
@@ -665,26 +647,22 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetFunctionId(_Out_ Functio
 
     *pFunctionID = m_functionId;
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetFunctionId"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetMethodToken(_Out_ mdToken* pToken)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetMethodDefToken"));
     IfNullRetPointer(pToken);
 
     *pToken = m_tkFunction;
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetMethodDefToken"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetGenericParameterCount(_Out_ DWORD* pCount)
 {
     HRESULT hr = S_OK;
-
     IfFailRet(InitializeGenericParameters(m_tkFunction));
 
     *pCount = (DWORD)m_genericParameters.size();
@@ -694,7 +672,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetGenericParameterCount(_O
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsStatic(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetIsStatic"));
 
     IfNullRetPointer(pbValue);
 
@@ -702,15 +679,12 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsStatic(_Out_ BOOL* pbV
 
     *pbValue = IsFlagSet(m_methodAttr, mdStatic);
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetIsStatic %04x"), *pbValue);
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsPublic(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetIsPublic"));
 
     IfNullRetPointer(pbValue);
 
@@ -718,15 +692,12 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsPublic(_Out_ BOOL* pbV
 
     *pbValue = IsFlagSet(m_methodAttr, mdPublic);
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetIsPublic %04x"), *pbValue);
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsPrivate(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetIsPrivate"));
 
     IfNullRetPointer(pbValue);
 
@@ -734,15 +705,12 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsPrivate(_Out_ BOOL* pb
 
     *pbValue = IsFlagSet(m_methodAttr, mdPrivate);
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetIsPrivate %04x"), *pbValue);
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsPropertyGetter(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetIsPropertyGetter"));
 
     IfNullRetPointer(pbValue);
 
@@ -760,8 +728,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsPropertyGetter(_Out_ B
     {
         *pbValue = FALSE;
     }
-
-    CLogging::LogMessage(_T("End CMethodInfo::GetIsPropertyGetter %04x"), *pbValue);
 
     return hr;
 }
@@ -769,7 +735,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsPropertyGetter(_Out_ B
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsPropertySetter(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetIsPropertySetter"));
 
     IfNullRetPointer(pbValue);
 
@@ -788,15 +753,12 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsPropertySetter(_Out_ B
         *pbValue = FALSE;
     }
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetIsPropertySetter %04x"), *pbValue);
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsFinalizer(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetIsFinalizer"));
 
     IfNullRetPointer(pbValue);
 
@@ -815,15 +777,12 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsFinalizer(_Out_ BOOL* 
         *pbValue = FALSE;
     }
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetIsFinalizer %04x"), *pbValue);
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsConstructor(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetIsConstructor"));
 
     IfNullRetPointer(pbValue);
 
@@ -842,15 +801,12 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsConstructor(_Out_ BOOL
         *pbValue = FALSE;
     }
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetIsConstructor %04x"), *pbValue);
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsStaticConstructor(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetIsStaticConstructor"));
 
     IfNullRetPointer(pbValue);
 
@@ -868,8 +824,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIsStaticConstructor(_Out
     {
         *pbValue = FALSE;
     }
-
-    CLogging::LogMessage(_T("End CMethodInfo::GetIsStaticConstructor %04x"), *pbValue);
 
     return hr;
 }
@@ -899,7 +853,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetParameters(_Out_ IEnumMe
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetDeclaringType(_Out_ IType** ppType)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetDeclaringType"));
 
     InitializeFullName();
 
@@ -907,23 +860,18 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetDeclaringType(_Out_ ITyp
 
     hr = m_pDeclaringType.CopyTo(ppType);
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetDeclaringType"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetReturnType(_Out_ IType** ppType)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetReturnType"));
 
     IfNullRetPointer(ppType);
 
     IfFailRet(InitializeMethodSignature(m_tkFunction));
 
     hr = m_pReturnType.CopyTo(ppType);
-
-    CLogging::LogMessage(_T("End CMethodInfo::GetReturnType"));
 
     return hr;
 }
@@ -932,7 +880,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetReturnType(_Out_ IType**
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetCorSignature(_In_ DWORD cbBuffer, _Out_opt_ BYTE* pCorSignature, _Out_ DWORD* pcbSignature)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetCorSignature"));
     IfNullRetPointer(pcbSignature);
 
     IfFailRet(InitializeMethodSignature(m_tkFunction));
@@ -953,22 +900,17 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetCorSignature(_In_ DWORD 
         }
     }
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetCorSignature"));
-
     return S_FALSE;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetLocalVarSigToken(_Out_ mdToken* pToken)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetLocalVarSigToken"));
     IfNullRetPointer(pToken);
 
     IfFailRet(InitializeHeader());
 
     *pToken = m_newCorHeader.LocalVarSigTok;
-
-    CLogging::LogMessage(_T("End CMethodInfo::GetLocalVarSigToken"));
 
     return hr;
 }
@@ -976,13 +918,10 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetLocalVarSigToken(_Out_ m
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::SetLocalVarSigToken(_In_ mdToken token)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::SetLocalVarSigToken"));
 
     IfFailRet(InitializeHeader());
 
     m_newCorHeader.LocalVarSigTok = token;
-
-    CLogging::LogMessage(_T("End CMethodInfo::SetLocalVarSigToken"));
 
     return S_OK;
 }
@@ -990,14 +929,11 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::SetLocalVarSigToken(_In_ md
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetAttributes(_Out_ /*CorMethodAttr*/ DWORD* pCorMethodAttr)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetAttributes"));
     IfNullRetPointer(pCorMethodAttr);
 
     IfFailRet(InitializeCorAttributes(m_tkFunction));
 
     *pCorMethodAttr = m_methodAttr;
-
-    CLogging::LogMessage(_T("End CMethodInfo::GetAttributes"));
 
     return S_OK;
 }
@@ -1009,11 +945,7 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetRejitCodeGenFlags(_Out_ 
 
     *pRefitFlags = 0;
 
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetRejitCodeGenFlags"));
-
     *pRefitFlags = m_dwRejitCodeGenFlags;
-
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetRejitCodeGenFlags"));
 
     return hr;
 }
@@ -1021,28 +953,24 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetRejitCodeGenFlags(_Out_ 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetCodeRva(_Out_ DWORD* pRva)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetCodeRva"));
     IfNullRetPointer(pRva);
 
     IfFailRet(InitializeCorAttributes(m_tkFunction));
 
     *pRva = m_rva;
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetCodeRva"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::MethodImplFlags(_Out_ /*CorMethodImpl*/ UINT* pCorMethodImpl)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::MethodImplFlags"));
     IfNullRetPointer(pCorMethodImpl);
 
     IfFailRet(InitializeCorAttributes(m_tkFunction));
 
     *pCorMethodImpl = m_implFlags;
 
-    CLogging::LogMessage(_T("End CMethodInfo::MethodImplFlags"));
     return hr;
 }
 
@@ -1052,11 +980,7 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::SetRejitCodeGenFlags(_In_ D
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CMethodInfo::SetRejitCodeGenFlags"));
-
     m_dwRejitCodeGenFlags = dwFlags;
-
-    CLogging::LogMessage(_T("Starting CMethodInfo::SetRejitCodeGenFlags"));
 
     return hr;
 }
@@ -1064,7 +988,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::SetRejitCodeGenFlags(_In_ D
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetExceptionSection(_Out_ IExceptionSection** ppExceptionSection)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetExceptionSection"));
     IfNullRetPointer(ppExceptionSection);
     *ppExceptionSection = NULL;
 
@@ -1084,8 +1007,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetExceptionSection(_Out_ I
     *ppExceptionSection = (IExceptionSection*)(m_pExceptionSection.p);
     (*ppExceptionSection)->AddRef();
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetExceptionSection"));
-
     return S_OK;
 }
 
@@ -1093,7 +1014,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetExceptionSection(_Out_ I
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetInstructionFactory(_Out_ IInstructionFactory** ppInstructionFactory)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CMethodInfo::GetInstructionFactory"));
     IfNullRetPointer(ppInstructionFactory);
     *ppInstructionFactory = NULL;
 
@@ -1104,8 +1024,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetInstructionFactory(_Out_
 
     *ppInstructionFactory = (IInstructionFactory*)(m_pInstructionFactory.p);
     (*ppInstructionFactory)->AddRef();
-
-    CLogging::LogMessage(_T("End CMethodInfo::GetInstructionFactory"));
 
     return S_OK;
 }
@@ -1262,8 +1180,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIntermediateRenderedFunc
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Start CMethodInfo::GetIntermediateRenderedFunctionBody"));
-
     if (!this->IsInstrumented() || m_pIntermediateRenderedMethod.empty())
     {
         CLogging::LogError(_T("CMethodInfo::GetIntermediateRenderedFunctionBody should only be called if a method body has been set for this function"));
@@ -1280,8 +1196,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::GetIntermediateRenderedFunc
         *pcbMethodSize = static_cast<ULONG>(m_pIntermediateRenderedMethod.size());
     }
 
-    CLogging::LogMessage(_T("End CMethodInfo::GetIntermediateRenderedFunctionBody"));
-
     return hr;
 }
 
@@ -1293,7 +1207,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::SetFinalRenderedFunctionBod
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Start CMethodInfo::SetFinalRenderedFunctionBody"));
     IfNullRetPointer(pMethodHeader);
 
     m_bIsInstrumented = true;
@@ -1308,16 +1221,12 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::SetFinalRenderedFunctionBod
     m_pFinalRenderedMethod.reserve(cbMethodSize);
     m_pFinalRenderedMethod.insert(m_pFinalRenderedMethod.begin(), pMethodHeader, pMethodHeader + cbMethodSize);
 
-    CLogging::LogMessage(_T("End CMethodInfo::SetFinalRenderedFunctionBody"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CMethodInfo::ApplyFinalInstrumentation()
 {
     HRESULT hr = S_OK;
-
-    CLogging::LogMessage(_T("Start CMethodInfo::ApplyFinalInstrumentation"));
 
     if (!this->IsInstrumented())
     {
@@ -1409,8 +1318,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::ApplyFinalInstrumentation()
             m_pFunctionControl->SetILInstrumentedCodeMap((ULONG)m_pCorILMap.Count(), m_pCorILMap.Get());
         }
     }
-
-    CLogging::LogMessage(_T("End CMethodInfo::ApplyFinalInstrumentation"));
 
     return hr;
 }
@@ -1906,8 +1813,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::MergeILInstrumentedCodeMap(
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Start CMethodInfo::MergeILInstrumentedCodeMap"));
-
     if (!m_pCorILMap.IsEmpty())
     {
         // No need to merge if we are just setting to the exact same pointer.
@@ -1970,7 +1875,6 @@ HRESULT MicrosoftInstrumentationEngine::CMethodInfo::MergeILInstrumentedCodeMap(
 
     // Save the map with the module info so that it can be retrieved later by the JIT callbacks.
     m_pModuleInfo->SetILInstrumentationMap(this, m_pCorILMap);
-    CLogging::LogMessage(_T("End CMethodInfo::MergeILInstrumentedCodeMap"));
 
     return S_OK;
 }

--- a/src/InstrumentationEngine/ModuleInfo.cpp
+++ b/src/InstrumentationEngine/ModuleInfo.cpp
@@ -109,7 +109,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::Dispose()
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMethodInfoById(_In_ FunctionID functionId, CMethodInfo** ppMethodInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CModuleInfo::GetMethodInfoById"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -127,15 +126,12 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMethodInfoById(_In_ Func
     *ppMethodInfo = (iter->second);
     (*ppMethodInfo)->AddRef();
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetMethodInfoById"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMethodInfoByToken(_In_ mdToken methodToken, CMethodInfo** ppMethodInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CModuleInfo::GetMethodInfoByToken"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -153,15 +149,12 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMethodInfoByToken(_In_ m
     *ppMethodInfo = (iter->second);
     (*ppMethodInfo)->AddRef();
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetMethodInfoByToken"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::AddMethodInfo(_In_ FunctionID functionId, CMethodInfo* pMethodInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CModuleInfo::AddMethodInfo"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -171,15 +164,12 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::AddMethodInfo(_In_ Function
     m_methodInfos[functionId] = pMethodInfo;
     m_methodInfosByToken[methodToken] = pMethodInfo;
 
-    CLogging::LogMessage(_T("End CModuleInfo::AddMethodInfo"));
-
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::ReleaseMethodInfo(_In_ FunctionID functionId)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Starting CModuleInfo::ReleaseMethodInfo"));
 
     CCriticalSectionHolder lock(&m_cs);
 
@@ -197,8 +187,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::ReleaseMethodInfo(_In_ Func
     m_methodInfos.erase(functionId);
     m_methodInfosByToken.erase(methodToken);
 
-    CLogging::LogMessage(_T("End CModuleInfo::ReleaseMethodInfo"));
-
     return hr;
 }
 
@@ -206,12 +194,8 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetModuleName(_Out_ BSTR* p
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetModuleName"));
-
     IfNullRetPointer(pbstrModuleName);
     hr = m_bstrModuleName.CopyTo(pbstrModuleName);
-
-    CLogging::LogMessage(_T("End CModuleInfo::GetModuleName"));
 
     return hr;
 }
@@ -219,13 +203,10 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetModuleName(_Out_ BSTR* p
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetFullPath(_Out_ BSTR* pbstrFullPath)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetFullPath"));
 
     IfNullRetPointer(pbstrFullPath);
 
     hr = m_bstrModulePath.CopyTo(pbstrFullPath);
-
-    CLogging::LogMessage(_T("End CModuleInfo::GetFullPath"));
 
     return hr;
 }
@@ -234,12 +215,9 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetFullPath(_Out_ BSTR* pbs
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetAssemblyInfo(_Out_ IAssemblyInfo** ppAssemblyInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetAssemblyInfo"));
 
     IfNullRetPointer(ppAssemblyInfo);
     hr = m_pAssemblyInfo.CopyTo(ppAssemblyInfo);
-
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetAssemblyInfo"));
 
     return hr;
 }
@@ -247,12 +225,9 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetAssemblyInfo(_Out_ IAsse
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetAppDomainInfo(_Out_ IAppDomainInfo** ppAppDomainInfo)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetAppDomainInfo"));
 
     IfNullRetPointer(ppAppDomainInfo);
     hr = m_pAppDomainInfo.CopyTo(ppAppDomainInfo);
-
-    CLogging::LogMessage(_T("End CModuleInfo::GetAppDomainInfo"));
 
     return hr;
 }
@@ -260,13 +235,10 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetAppDomainInfo(_Out_ IApp
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMetaDataImport(_Out_ IUnknown** ppMetaDataImport)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetMetaDataImport"));
 
     IfNullRetPointer(ppMetaDataImport);
 
     hr = m_pMetadataImport.CopyTo((IMetaDataImport2**)ppMetaDataImport);
-
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetMetaDataImport"));
 
     return hr;
 }
@@ -274,13 +246,10 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMetaDataImport(_Out_ IUn
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMetaDataAssemblyImport(_Out_ IUnknown** ppMetadataAssemblyImport)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetMetadataAssemblyImport"));
 
     IfNullRetPointer(ppMetadataAssemblyImport);
 
     hr = m_pMetadataAssemblyImport.CopyTo((IMetaDataAssemblyImport**)ppMetadataAssemblyImport);
-
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetMetadataAssemblyImport"));
 
     return hr;
 }
@@ -289,20 +258,17 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMetaDataAssemblyImport(_
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMetaDataEmit(_Out_ IUnknown** ppMetaDataEmit)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetMetadataEmit"));
     IfNullRetPointer(ppMetaDataEmit);
     *ppMetaDataEmit = NULL;
 
     if (m_pMetaDataEmit2 != NULL)
     {
         hr = m_pMetaDataEmit2.CopyTo((IMetaDataEmit2**)ppMetaDataEmit);
-
-        CLogging::LogMessage(_T("End CModuleInfo::GetMetadataEmit"));
         return hr;
     }
     else
     {
-        CLogging::LogMessage(_T("End CModuleInfo::GetMetadataEmit = returning E_FAIL as no IMetaDataEmit exists"));
+        CLogging::LogMessage(_T("CModuleInfo::GetMetadataEmit - no IMetaDataEmit exists"));
         return E_FAIL;
     }
 }
@@ -310,20 +276,17 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMetaDataEmit(_Out_ IUnkn
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMetaDataAssemblyEmit(_Out_ IUnknown** ppMetaDataAssemblyEmit)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetMetaDataAssemblyEmit"));
     IfNullRetPointer(ppMetaDataAssemblyEmit);
     *ppMetaDataAssemblyEmit = NULL;
 
     if (m_pMetaDataAssemblyEmit != NULL)
     {
         hr = m_pMetaDataAssemblyEmit.CopyTo((IMetaDataAssemblyEmit**)ppMetaDataAssemblyEmit);
-
-        CLogging::LogMessage(_T("End CModuleInfo::GetMetaDataAssemblyEmit"));
         return hr;
     }
     else
     {
-        CLogging::LogMessage(_T("End CModuleInfo::GetMetaDataAssemblyEmit = returning E_FAIL as no IMetaDataAssemblyEmit exists"));
+        CLogging::LogMessage(_T("CModuleInfo::GetMetaDataAssemblyEmit - no IMetaDataAssemblyEmit exists"));
         return E_FAIL;
     }
 }
@@ -331,12 +294,10 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMetaDataAssemblyEmit(_Ou
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetModuleID(_Out_ ModuleID* pModuleId)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetModuleID"));
 
     IfNullRetPointer(pModuleId);
 
     *pModuleId = m_moduleID;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetModuleID"));
 
     return hr;
 }
@@ -345,51 +306,43 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetModuleID(_Out_ ModuleID*
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMVID(_Out_ GUID* pguidMvid)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetMVID"));
 
     IfNullRetPointer(pguidMvid);
     *pguidMvid = m_mvid;
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetMVID"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetIsILOnly(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetIsILOnly"));
 
     IfNullRetPointer(pbValue);
 
     *pbValue = m_bIsIlOnly;
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetIsILOnly"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetIsMscorlib(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetIsMscorlib"));
 
     IfNullRetPointer(pbValue);
 
     *pbValue = m_bIsMscorlib;
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetIsMscorlib"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetIsDynamic(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetIsDynamic"));
 
     IfNullRetPointer(pbValue);
 
     *pbValue = m_bIsDynamic;
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetIsDynamic"));
     return hr;
 }
 
@@ -397,52 +350,42 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetIsLoadedFromDisk(_Out_ B
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetIsLoadedFromDisk"));
-
     IfNullRetPointer(pbValue);
 
     *pbValue = m_bIsLoadedFromDisk;
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetIsLoadedFromDisk"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetIsNgen(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetIsNgen"));
 
     IfNullRetPointer(pbValue);
 
     *pbValue = m_bIsNgen;
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetIsNgen"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetIsWinRT(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetIsWinRT"));
 
     IfNullRetPointer(pbValue);
 
     *pbValue = m_bIsWinRT;
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetIsWinRT"));
     return hr;
 }
 
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetIs64bit(_Out_ BOOL* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetIs64bit"));
 
     IfNullRetPointer(pbValue);
 
     *pbValue = m_bIs64bit;
-
-    CLogging::LogMessage(_T("End CModuleInfo::GetIs64bit"));
 
     return hr;
 }
@@ -450,13 +393,10 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetIs64bit(_Out_ BOOL* pbVa
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetImageBase(_Out_ LPCBYTE* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetImageBase"));
 
     IfNullRetPointer(pbValue);
 
     *pbValue = m_pModuleBaseLoadAddress;
-
-    CLogging::LogMessage(_T("End CModuleInfo::GetImageBase"));
 
     return hr;
 }
@@ -464,19 +404,16 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetImageBase(_Out_ LPCBYTE*
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetCorHeader(_In_ DWORD cbValue, _Out_writes_(cbValue) BYTE* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetCorHeader"));
 
     IfNullRetPointer(pbValue);
 
-	if (m_pCorHeader == NULL)
-	{
-		CLogging::LogMessage(_T("Module has no cor header"));
-		return E_FAIL;
-	}
+    if (m_pCorHeader == NULL)
+    {
+        CLogging::LogMessage(_T("Module has no cor header"));
+        return E_FAIL;
+    }
 
     memcpy_s(pbValue, cbValue, m_pCorHeader, cbValue);
-
-    CLogging::LogMessage(_T("End CModuleInfo::GetCorHeader"));
 
     return hr;
 }
@@ -485,7 +422,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetCorHeader(_In_ DWORD cbV
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetEntrypointToken(_Out_ DWORD* pdwEntrypointToken)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetEntrypointToken"));
     IfNullRetPointer(pdwEntrypointToken);
     *pdwEntrypointToken = mdTokenNil;
 
@@ -498,8 +434,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetEntrypointToken(_Out_ DW
         return E_FAIL;
     }
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetEntrypointToken"));
-
     return hr;
 }
 
@@ -507,7 +441,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetEntrypointToken(_Out_ DW
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetModuleVersion(_In_ DWORD cbValue, _Out_writes_(cbValue) BYTE* pbValue)
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::GetModuleVersion"));
     IfNullRetPointer(pbValue);
 
     if (cbValue != sizeof(VS_FIXEDFILEINFO))
@@ -523,8 +456,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetModuleVersion(_In_ DWORD
 
     memcpy_s(pbValue, cbValue, m_pFixedFileVersion, sizeof(VS_FIXEDFILEINFO));
 
-    CLogging::LogMessage(_T("End CModuleInfo::GetModuleVersion"));
-
     return hr;
 }
 
@@ -532,8 +463,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetModuleVersion(_In_ DWORD
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::RequestRejit(_In_ mdToken methodToken)
 {
     HRESULT hr = S_OK;
-
-    CLogging::LogMessage(_T("Begin CModuleInfo::RequestRejit"));
 
     CComPtr<ICorProfilerInfo> pRealProfilerInfo;
     IfFailRet(m_pProfilerManager->GetRealCorProfilerInfo(&pRealProfilerInfo));
@@ -562,8 +491,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::RequestRejit(_In_ mdToken m
     }
 
     IfFailRet(pRealProfilerInfo4->RequestReJIT((ULONG)moduleIds.size(), moduleIds.data(), methodTokens.data()));
-
-    CLogging::LogMessage(_T("End CModuleInfo::RequestRejit"));
 
     return S_OK;
 }
@@ -634,7 +561,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetModuleTypeFlags()
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::ReadModuleHeaders()
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("Begin CModuleInfo::ReadModuleHeaders"));
 
     if (m_pModuleBaseLoadAddress == NULL)
     {
@@ -694,7 +620,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::ReadModuleHeaders()
     m_pCorHeader = pCLRHeader;
     m_tkEntrypoint = m_pCorHeader->EntryPointToken;
 
-    CLogging::LogMessage(_T("End CModuleInfo::ReadModuleHeaders"));
     return hr;
 }
 
@@ -752,7 +677,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::ResolveRva(_In_ DWORD rva, 
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::DetermineIfIsMscorlib()
 {
     HRESULT hr = S_OK;
-    CLogging::LogMessage(_T("End CModuleInfo::DetermineIfIsMscorlib"));
 
     if (m_bstrModuleName.Length() > 0)
     {
@@ -766,8 +690,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::DetermineIfIsMscorlib()
         }
     }
 
-    CLogging::LogMessage(_T("End CModuleInfo::DetermineIfIsMscorlib"));
-
     return hr;
 }
 
@@ -777,7 +699,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::ReadFixedFileVersion()
 
 #ifndef PLATFORM_UNIX
     // TODO: (linux)
-    CLogging::LogMessage(_T("Begin CModuleInfo::ReadFixedFileVersion"));
 
     if (m_bIsLoadedFromDisk)
     {
@@ -808,7 +729,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::ReadFixedFileVersion()
         CLogging::LogMessage(_T("CModuleInfo::ReadFixedFileVersion - Skipping fixed file version due to in-memory module"));
     }
 
-    CLogging::LogMessage(_T("End CModuleInfo::ReadFixedFileVersion"));
 #endif
     return S_OK;
 }
@@ -955,8 +875,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMethodInfoById(_In_ Func
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CProfilerManager::GetMethodInfoById"));
-
     IfNullRetPointer(ppMethodInfo);
     *ppMethodInfo = NULL;
 
@@ -976,8 +894,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMethodInfoById(_In_ Func
 
     *ppMethodInfo = pMethodInfo.Detach();
 
-    CLogging::LogMessage(_T("End CProfilerManager::GetMethodInfoById"));
-
     return S_OK;
 }
 
@@ -987,8 +903,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMethodInfoById(_In_ Func
 HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMethodInfoByToken(_In_ mdToken methodToken, _Out_ IMethodInfo** ppMethodInfo)
 {
     HRESULT hr = S_OK;
-
-    CLogging::LogMessage(_T("Starting CProfilerManager::GetMethodInfoByToken"));
 
     IfNullRetPointer(ppMethodInfo);
     *ppMethodInfo = NULL;
@@ -1001,8 +915,6 @@ HRESULT MicrosoftInstrumentationEngine::CModuleInfo::GetMethodInfoByToken(_In_ m
     IfFailRet(pMethodInfo->Initialize(false, false));
 
     *ppMethodInfo = pMethodInfo.Detach();
-
-    CLogging::LogMessage(_T("End CProfilerManager::GetMethodInfoByToken"));
 
     return S_OK;
 }

--- a/src/InstrumentationEngine/ProfilerManager.h
+++ b/src/InstrumentationEngine/ProfilerManager.h
@@ -179,7 +179,7 @@ namespace MicrosoftInstrumentationEngine
 
         // This is the client that asked to receive the raw ICorProfiler event
         // model rather than using the simplified instrumentation method model.
-        // 
+        //
         // We use a raw pointer here to address perf issues around locks & critical sections
         // that cause thread context switching. This implementation uses InterlockedExchange functions
         // to read/write the pointer and will produce an expected memory leak since there are no
@@ -349,8 +349,6 @@ namespace MicrosoftInstrumentationEngine
             // Send event to instrumentation methods
             for (CComPtr<TInterfaceType> pInstrumentationMethod : callbackVector)
             {
-                CLogging::LogMessage(_T("Sending event to Instrumentation Method"));
-
                 hr = (pInstrumentationMethod->*method)(parameters...);
 
                 CLogging::LogMessage(_T("Finished Sending event to Instrumentation Method. hr=%04x"), hr);
@@ -394,8 +392,6 @@ namespace MicrosoftInstrumentationEngine
 
             if (pCallback != nullptr)
             {
-                CLogging::LogMessage(_T("Sending event to raw ICorProfilerCallback"));
-
                 hr = (pCallback->*method)(parameters...);
 
                 CLogging::LogMessage(_T("Finished Sending event to raw ICorProfilerCallback. hr=%04x"), hr);
@@ -1052,10 +1048,8 @@ public:
     CSEHTranslatorHolder translatorHolder; \
     try \
     { \
-    CLogging::LogMessage(_T("Starting ProfilerCallback ") __FUNCTIONW__);
 
 #define PROF_CALLBACK_END \
-    CLogging::LogMessage(_T("Ending ProfilerCallback") __FUNCTIONW__); \
     translatorHolder.RestoreSEHTranslator(); \
     } \
     catch (CSehException sehException) \
@@ -1073,11 +1067,8 @@ public:
 #define PROF_CALLBACK_BEGIN \
     try \
     { \
-    CLogging::LogMessage(_T("Starting ProfilerCallback ") WCHAR_SPEC, __FUNCTION__);
-
 
 #define PROF_CALLBACK_END \
-    CLogging::LogMessage(_T("Ending ProfilerCallback ") WCHAR_SPEC, __FUNCTION__); \
     } \
     catch (...) \
     { \

--- a/src/InstrumentationEngine/SingleRetDefaultInstrumentation.cpp
+++ b/src/InstrumentationEngine/SingleRetDefaultInstrumentation.cpp
@@ -31,8 +31,6 @@ HRESULT MicrosoftInstrumentationEngine::CSingleRetDefaultInstrumentation::ApplyS
 {
     HRESULT hr = S_OK;
 
-    CLogging::LogMessage(_T("Starting CSingleRetDefaultInstrumentation::ApplySingleRetDefaultInstrumentation"));
-
     CComPtr<IMethodInfo> pMethodInfo;
     IfFailRet(m_pInstructionGraph->GetMethodInfo(&pMethodInfo));
 
@@ -113,7 +111,6 @@ HRESULT MicrosoftInstrumentationEngine::CSingleRetDefaultInstrumentation::ApplyS
     }
 
     m_pJumpTarget = pBranchTarget;
-    CLogging::LogMessage(_T("End CSingleRetDefaultInstrumentation::ApplySingleRetDefaultInstrumentation"));
 
     return hr;
 }

--- a/src/InstrumentationEngine/TypeCreator.cpp
+++ b/src/InstrumentationEngine/TypeCreator.cpp
@@ -24,8 +24,6 @@ HRESULT MicrosoftInstrumentationEngine::CTypeCreator::FromCorElement(_In_ CorEle
     IfNullRetPointer(ppType);
     *ppType = nullptr;
 
-    CLogging::LogMessage(_T("Starting CTypeCreator::FromCorElement"));
-
     switch (type)
     {
         case ELEMENT_TYPE_VOID:
@@ -57,14 +55,10 @@ HRESULT MicrosoftInstrumentationEngine::CTypeCreator::FromCorElement(_In_ CorEle
         }
     }
 
-    CLogging::LogMessage(_T("End CTypeCreator::FromCorElement"));
-
     return E_NOTIMPL;
 }
 HRESULT MicrosoftInstrumentationEngine::CTypeCreator::FromSignature(_In_ DWORD cbBuffer, _In_ const BYTE* pCorSignature, _Out_ IType ** ppType, _Out_opt_ DWORD* pdwSigSize)
 {
-    CLogging::LogMessage(_T("Starting CTypeCreator::FromSignature"));
-
     IfNullRetPointer(pCorSignature);
     IfNullRetPointer(pdwSigSize);
     IfNullRetPointer(ppType);
@@ -326,7 +320,6 @@ HRESULT MicrosoftInstrumentationEngine::CTypeCreator::FromSignature(_In_ DWORD c
         hr = E_FAIL;
     }
 
-    CLogging::LogMessage(_T("End CTypeCreator::FromSignature"));
     return hr;
 }
 


### PR DESCRIPTION
Address the first part of https://github.com/microsoft/CLRInstrumentationEngine/issues/148 where Message LogLevel is too verbose. This scrapes the repo and removes any LogMessage("Start/Begin/End [MethodName]") strings