### PR TITLE
Always use ubuntu-latest vmImage

### DIFF
--- a/build/yaml/jobs/linux/binaries.yaml
+++ b/build/yaml/jobs/linux/binaries.yaml
@@ -17,13 +17,7 @@ jobs:
       ${{ insert }}: ${{ parameters.MatrixStrategy }}
 
   pool:
-    ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
-      name: DotNet-Build
-      demands:
-      - docker
-      - sh
-    ${{ if not(eq('true', parameters.IsMicroBuildInternal)) }}:
-      vmImage: ubuntu-latest
+    vmImage: ubuntu-latest
 
   workspace:
     clean: outputs


### PR DESCRIPTION
This merges `release` to `main` to be able to always use ubuntu-latest when building the Linux binaries.