### PR TITLE
Fix build scripts to use v142 toolsets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.44
++ BugFixes: 
+  + Fixed build scripts to explicitly point to v142 toolsets
 
 ## 1.0.43
 + New:

--- a/README.md
+++ b/README.md
@@ -31,8 +31,12 @@ This repo builds using Visual Studio 2019 and requires the following components:
 |:--|:--
 Microsoft.Component.MSBuild|MSBuild
 Microsoft.VisualStudio.Workload.NativeDesktop|Desktop development with C++ (Workload)
-Microsoft.VisualStudio.Component.VC.ATL.Spectre|C++ ATL for latest v142 build tools with Spectre Mitigations (x86 & x64)
-Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre|MSVC v142 - VS 2019 C++ x64/x86 Spectre-mitigated libs (v14.2x)
+Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.Spectre|C++ v14.29 (16.11) ATL for v142 build tools with Spectre Mitigations (x86 & x64)
+Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64.Spectre|MSVC v142 - VS 2019 C++ x64/x86 Spectre-mitigated libs (v14.29-16.11)	
+
+The following component IDs work for VS 2019 but not VS 2022 because they implicitly upversion to the latest (ie. v143 and v14.3x)
+* Microsoft.VisualStudio.Component.VC.ATL.Spectre 
+* Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre
 
 Optionally, in order to develop Wixproj files in Visual Studio, you will need to install the [Wix Toolset Visual 2019 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2019Extension), also known as the "Votive" extension.
 

--- a/build.ps1
+++ b/build.ps1
@@ -158,8 +158,8 @@ if (-not ($repoPath))
 $VsRequirements = @(
     'Microsoft.Component.MSBuild'
     'Microsoft.VisualStudio.Workload.NativeDesktop'
-    'Microsoft.VisualStudio.Component.VC.ATL.Spectre'
-    'Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre'
+    'Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.Spectre'
+    'Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64.Spectre'
 )
 
 Write-Verbose "Checking for VS installation with these installed components: `n`n$($VsRequirements | Out-String)`n"

--- a/build/yaml/jobs/tests.yaml
+++ b/build/yaml/jobs/tests.yaml
@@ -34,7 +34,7 @@ jobs:
         Debug_AnyCPU:
           Configuration: 'Debug'
           Platform: 'AnyCPU'
-          RunSettingsFile: 'x86.runsettings'
+          RunSettingsFile: 'x64.runsettings'
 
 # Linux Binaries (TBD)
 #- template: linux/tests.yaml

--- a/build/yaml/steps/azuredevops/usedotnet.yaml
+++ b/build/yaml/steps/azuredevops/usedotnet.yaml
@@ -9,12 +9,14 @@ steps:
     inputs:
       packageType: 'sdk'
       version: '3.1.x'
+      performMultiLevelLookup: true
 
   - task: UseDotNet@2
     displayName: 'Install .NET 5.0 SDK'
     inputs:
       packageType: 'sdk'
       version: '5.0.x'
+      performMultiLevelLookup: true
 
   - task: UseDotNet@2
     displayName: 'Install .NET 6.0 SDK'
@@ -22,3 +24,4 @@ steps:
       packageType: 'sdk'
       version: '6.0.x'
       includePreviewVersions: true
+      performMultiLevelLookup: true

--- a/build/yaml/steps/windows/dotnettest.yaml
+++ b/build/yaml/steps/windows/dotnettest.yaml
@@ -13,9 +13,6 @@ steps:
   inputs:
     command: test
     arguments: >-
-      --no-build
-      --configuration
-      $(Configuration)
       --settings
       "tests/TestSettings/$(RunSettingsFile)"
       $(Build.ArtifactStagingDirectory)\binaries-windows-$(Configuration)\$(Platform)\${{ parameters.SubFolder }}*Tests*.dll


### PR DESCRIPTION
Builds were working for VS2019, however there is a bug with having that + VS2022 installed side-by-side where atlbase.h is not found. This is likely due to some intrinsic lookup by MSVC toolsets that conflict or gets confused. Updating the build scripts to point directly to v142 helps mitigate this for users in the future.

Also fixed managed tests to use x64 runsettings as C:\hostedtoolcache\windows\dotnet\dotnet.exe is now failing when using x86.