### PR TITLE
Add reference to private feed hosting ARM64 sdk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,6 +164,7 @@ OperationTracking/Msbuild.OperationTracking.Mixed Platforms.*
 *.err
 *.prf
 *.wrn
+*.binlog
 
 *_i.h
 *_h.h

--- a/NuGet.config
+++ b/NuGet.config
@@ -5,6 +5,7 @@
     <packageSources>
         <clear />
         <add key="DNCENG-CoreClrPal" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/CoreClrPal/nuget/v3/index.json" />
+        <add key="privateDependency" value="https://pkgs.dev.azure.com/devdiv/DevDiv/_packaging/ClrInstrumentationEngine-PrivateDependency/nuget/v3/index.json" />
     </packageSources>
     <activePackageSource>
         <add key="All" value="(Aggregate source)" />

--- a/build.ps1
+++ b/build.ps1
@@ -224,7 +224,7 @@ if (!$SkipBuild)
         Invoke-ExpressionHelper -Executable "dotnet" -Arguments $dotnetRestoreArgs -Activity 'dotnet Restore Solutions'
 
         # NuGet restore disregards platform/configuration
-        $nugetRestoreArgs = "restore $repoPath\NativeNugetRestore.sln -configfile $repoPath\NuGet.config"
+        $nugetRestoreArgs = "restore `"$repoPath\NativeNugetRestore.sln`" -configfile `"$repoPath\NuGet.config`""
         Invoke-ExpressionHelper -Executable "nuget" -Arguments $nugetRestoreArgs -Activity 'nuget Restore Solutions'
     }
 

--- a/build.ps1
+++ b/build.ps1
@@ -215,7 +215,7 @@ if (!$SkipBuild)
         }
 
         # dotnet restore defaults to Debug|Any CPU, which requires the /p:platform specification in order to replicate NuGet restore behavior.
-        $dotnetRestoreArgs = "restore $repoPath\InstrumentationEngine.sln --configfile $repoPath\NuGet.config /p:platform=`"Any CPU`""
+        $dotnetRestoreArgs = "restore `"$repoPath\InstrumentationEngine.sln`" --configfile `"$repoPath\NuGet.config`" /p:platform=`"Any CPU`""
         if ($ARM64)
         {
             $dotnetRestoreArgs = "$dotnetRestoreArgs /p:IncludeARM64='True'"

--- a/build.ps1
+++ b/build.ps1
@@ -275,7 +275,7 @@ if (!$SkipPackaging)
     Invoke-ExpressionHelper -Executable "dotnet" -Arguments $restoreArgs -Activity 'dotnet Restore Solutions'
 
     # Build InstrumentationEngine.Packages.sln
-    $buildArgsInit = "$repoPath\src\InstrumentationEngine.Packages.sln /p:configuration=`"$configuration`" /p:SignType=$SignType /p:BuildVersion=$BuildVersion /clp:$($clParams) /m"
+    $buildArgsInit = "`"$repoPath\src\InstrumentationEngine.Packages.sln`" /p:configuration=`"$configuration`" /p:SignType=$SignType /p:BuildVersion=$BuildVersion /clp:$($clParams) /m"
     $buildArgs = [System.Collections.ArrayList]@(
         "$buildArgsInit /p:platform=`"x86`""
         "$buildArgsInit /p:platform=`"x64`""

--- a/build.ps1
+++ b/build.ps1
@@ -260,21 +260,33 @@ if (!$SkipPackaging)
 
     # NuGet restore disregards platform/configuration
     # dotnet restore defaults to Debug|Any CPU, which requires the /p:platform specification in order to replicate NuGet restore behavior.
-    $restoreArgsInit = "restore $repoPath\src\InstrumentationEngine.Packages.sln --configfile $repoPath\NuGet.config"
-    $restoreArgs = @(
+    $restoreArgsInit = "restore `"$repoPath\src\InstrumentationEngine.Packages.sln`" --configfile $repoPath\NuGet.config"
+    $restoreArgs = [System.Collections.ArrayList]@(
         "$restoreArgsInit /p:platform=`"x86`""
         "$restoreArgsInit /p:platform=`"x64`""
         "$restoreArgsInit /p:platform=`"Any CPU`""
     )
+
+    if ($ARM64)
+    {
+        $restoreArgs.Add("$restoreArgsInit /p:platform=`"ARM64`"")
+    }
+
     Invoke-ExpressionHelper -Executable "dotnet" -Arguments $restoreArgs -Activity 'dotnet Restore Solutions'
 
     # Build InstrumentationEngine.Packages.sln
     $buildArgsInit = "$repoPath\src\InstrumentationEngine.Packages.sln /p:configuration=`"$configuration`" /p:SignType=$SignType /p:BuildVersion=$BuildVersion /clp:$($clParams) /m"
-    $buildArgs = @(
+    $buildArgs = [System.Collections.ArrayList]@(
         "$buildArgsInit /p:platform=`"x86`""
         "$buildArgsInit /p:platform=`"x64`""
         "$buildArgsInit /p:platform=`"Any CPU`""
     )
+
+    if ($ARM64)
+    {
+        $buildArgs.Add("$buildArgsInit /p:platform=`"ARM64`"")
+    }
+
     Invoke-ExpressionHelper -Executable "$msbuild" -Arguments $buildArgs -Activity 'Build InstrumentationEngine.Packages.sln'
 }
 

--- a/src/Dependencies/NativeDependencies.csproj
+++ b/src/Dependencies/NativeDependencies.csproj
@@ -43,6 +43,11 @@
           <PrivateAssets>All</PrivateAssets>
         </PackageReference>
       </ItemGroup>
+      <ItemGroup Condition="'$(IncludeARM64)'=='True'">
+        <PackageReference Include="Microsoft.VisualStudio.ARM64.SDK" Version="17.0.0">
+          <ExcludeAssets>All</ExcludeAssets>
+        </PackageReference>
+      </ItemGroup>
     </Otherwise>
   </Choose>
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />

--- a/src/InstrumentationEngine/InstrumentationEngine.vcxproj
+++ b/src/InstrumentationEngine/InstrumentationEngine.vcxproj
@@ -81,7 +81,7 @@
       <AdditionalLibraryDirectories Condition="'$(Platform)'=='ARM64'">$(WindowsSDK_LibraryPath_arm64);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>InstrumentationEngine.Lib.lib;kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;msxml6.lib;version.lib;Faultrep.lib;Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Platform)'!='ARM64'">mscoree.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalDependencies Condition="'$(Platform)'=='ARM64'">C:\Users\willxie\Downloads\microsoft.visualstudio.arm64.sdk.17.0.0.nupkg\lib\mscoree.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(Platform)'=='ARM64'">$(PackagesDir)\microsoft.visualstudio.arm64.sdk\17.0.0\lib\mscoree.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions Condition="'$(Platform)'=='Win32'">/SafeSEH %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Support build script to build ARM64 (for internal-use only)

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Add reference to privateDependency feed hosting the internal ARM64 SDK
- Fix Build script restore to align with yaml pipelines
- Ignore binlogs


###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
local build