### PR TITLE
[PR Validation] Validate that all Markdown links are alive

### DIFF
--- a/.github/config.json
+++ b/.github/config.json
@@ -1,3 +1,0 @@
-{
-    "aliveStatusCodes": [200, 203]
-}

--- a/.github/config.json
+++ b/.github/config.json
@@ -1,0 +1,3 @@
+{
+    "aliveStatusCodes": [200, 203]
+}

--- a/.github/linters/check_links_config.json
+++ b/.github/linters/check_links_config.json
@@ -1,0 +1,6 @@
+{
+    "aliveStatusCodes": [200, 203],
+    "ignorePatterns": [
+        { "pattern": "^https://github.com/microsoft/InstrumentationEngine-Intercept" }
+      ]
+}

--- a/.github/linters/check_links_config.json
+++ b/.github/linters/check_links_config.json
@@ -1,6 +1,3 @@
 {
-    "aliveStatusCodes": [200, 203],
-    "ignorePatterns": [
-        { "pattern": "^https://github.com/microsoft/InstrumentationEngine-Intercept" }
-      ]
+    "aliveStatusCodes": [200, 203]
 }

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,0 +1,14 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+on:
+  pull_request:
+    branches:
+    - main
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: gaurav-nelson/github-action-markdown-link-check@v1

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -1,6 +1,8 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
+name: Markdown Links Check
+
 on:
   pull_request:
     branches:

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,5 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
-      with:
-         config-file: .github/linters/check_links_config.json
+        with:
+          config-file: .github/linters/check_links_config.json

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -12,3 +12,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      with:
+         config-file: .github/linters/check_links_config.json

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -14,3 +14,5 @@ jobs:
       - uses: gaurav-nelson/github-action-markdown-link-check@v1
         with:
           config-file: .github/linters/check_links_config.json
+          use-quiet-mode: 'yes'
+          use-verbose-mode: 'no'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any addi
 ## Pull Request Process
 
 1. Ensure the README.md and any documentation are up-to-date with details of changes made. This will help maintain the accuracy of the documentation to the current state of the code.
-2. Increment the semantic version number and date in the [Version.props](build/version.props) file if necessary. The CLR Instrumentation Engine follows the [semantic versioning](https://semver.org/) scheme.
+2. Increment the semantic version number and date in the [Version.props](build/Version.props) file if necessary. The CLR Instrumentation Engine follows the [semantic versioning](https://semver.org/) scheme.
 3. Submit your Pull Requests and notify clrieowners@microsoft.com. We will initiate the Pull Request validation build if we have no concerns with your changes.
 3. Once at least two approvals are given for the PR, you may merge your changes.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,7 +6,7 @@ The CLRIE's goal is to provide the foundation for cooperation among profilers. B
 
 ## Released Versions
 
-* [Latest Updates](changelog.md)
+* [Latest Updates](CHANGELOG.md)
 
 ## Upcoming Milestones and Releases
 

--- a/docs/scenarios/azure.md
+++ b/docs/scenarios/azure.md
@@ -169,6 +169,7 @@ leverage CLRIE and some do not.
 See [Application Insights Overview](https://docs.microsoft.com/azure/azure-monitor/app/app-insights-overview)
 
 Also refer to Application Insights extension
+<!-- markdown-link-check-disable-next-line -->
 [design specs](https://github.com/Microsoft/InstrumentationEngine-Intercept/blob/develop/design-principles.md)
 
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Add a new workflow that runs on every PR which validates that all Markdown links are alive or point to real repo files.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Add `markdown-link-check.yml` workflow.
- Add config file to handle links to restricted access pages.
- Fix links that weren't case sensitive which break on Unix systems.
- Ignore private GitHub repo links.

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
https://github.com/microsoft/CLRInstrumentationEngine/actions/runs/1925295981