### PR TITLE
Remove /CETCOMPAT for ARM64 builds 

### DIFF
--- a/src/Common.Lib/Common.Lib.vcxproj
+++ b/src/Common.Lib/Common.Lib.vcxproj
@@ -53,7 +53,7 @@
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/src/Extensions.Base/Extensions.Base.vcxproj
+++ b/src/Extensions.Base/Extensions.Base.vcxproj
@@ -57,7 +57,7 @@
       <ValidateAllParameters>true</ValidateAllParameters>
     </Midl>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <ModuleDefinitionFile>.\HostExtension.def</ModuleDefinitionFile>
       <AdditionalDependencies>kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;mscoree.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalOptions Condition="'$(Configuration)'=='Release'">/debugtype:cv,fixup %(AdditionalOptions)</AdditionalOptions>

--- a/src/InstrumentationEngine.Api/InstrumentationEngine.Api.vcxproj
+++ b/src/InstrumentationEngine.Api/InstrumentationEngine.Api.vcxproj
@@ -58,7 +58,7 @@
       <AdditionalIncludeDirectories>$(EnlistmentRoot)\inc\clr\prof;$(EnlistmentRoot)\inc\clr\extra;$(NETFXKitsDir)\Include\um;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </Midl>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <SubSystem>Windows</SubSystem>
     </Link>
   </ItemDefinitionGroup>

--- a/src/InstrumentationEngine.Lib/InstrumentationEngine.Lib.vcxproj
+++ b/src/InstrumentationEngine.Lib/InstrumentationEngine.Lib.vcxproj
@@ -56,7 +56,7 @@
       <AdditionalIncludeDirectories>..\..\inc\clr\inc;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </Midl>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <SubSystem>Windows</SubSystem>
     </Link>
     <Lib>

--- a/src/InstrumentationEngine.ProfilerProxy.Lib/InstrumentationEngine.ProfilerProxy.Lib.vcxproj
+++ b/src/InstrumentationEngine.ProfilerProxy.Lib/InstrumentationEngine.ProfilerProxy.Lib.vcxproj
@@ -52,7 +52,7 @@
       <WarningLevel>Level3</WarningLevel>
     </ClCompile>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/src/InstrumentationEngine.ProfilerProxy/InstrumentationEngine.ProfilerProxy.vcxproj
+++ b/src/InstrumentationEngine.ProfilerProxy/InstrumentationEngine.ProfilerProxy.vcxproj
@@ -80,7 +80,7 @@
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/src/InstrumentationEngine/InstrumentationEngine.vcxproj
+++ b/src/InstrumentationEngine/InstrumentationEngine.vcxproj
@@ -76,7 +76,7 @@
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/src/TestHostExtension/TestsHostExtension.vcxproj
+++ b/src/TestHostExtension/TestsHostExtension.vcxproj
@@ -47,7 +47,7 @@
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <AdditionalLibraryDirectories>$(VCInstallDir)UnitTest\lib;$(VCInstallDir)Auxiliary\VS\UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;mscoree.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalDependencies Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">kernel32.lib;user32.lib;gdi32.lib;winspool.lib;comdlg32.lib;advapi32.lib;shell32.lib;ole32.lib;oleaut32.lib;uuid.lib;odbc32.lib;odbccp32.lib;mscoree.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/src/Tests/CommonLibTests/CommonLibTests.vcxproj
+++ b/src/Tests/CommonLibTests/CommonLibTests.vcxproj
@@ -71,7 +71,7 @@
   </ItemGroup>
   <ItemDefinitionGroup>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <AdditionalDependencies>msxml6.lib;%(AdditionalDependencies);PathCch.lib</AdditionalDependencies>
       <AdditionalOptions Condition="'$(Platform)'=='Win32'">/SafeSEH %(AdditionalOptions)</AdditionalOptions>
     </Link>

--- a/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.vcxproj
+++ b/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.vcxproj
@@ -82,7 +82,7 @@
       <AdditionalIncludeDirectories>$(IntDir);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ResourceCompile>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <RegisterOutput>false</RegisterOutput>

--- a/src/Tests/InstrumentationEngineLibTests/InstrumentationEngineLibTests.vcxproj
+++ b/src/Tests/InstrumentationEngineLibTests/InstrumentationEngineLibTests.vcxproj
@@ -73,7 +73,7 @@
   </ItemGroup>
   <ItemDefinitionGroup>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <AdditionalDependencies>msxml6.lib;%(AdditionalDependencies);PathCch.lib</AdditionalDependencies>
       <AdditionalOptions Condition="'$(Platform)'=='Win32'">/SafeSEH %(AdditionalOptions)</AdditionalOptions>
     </Link>

--- a/tests/InstrumentationEngine.Lib.Tests/InstrumentationEngine.Lib.Tests.vcxproj
+++ b/tests/InstrumentationEngine.Lib.Tests/InstrumentationEngine.Lib.Tests.vcxproj
@@ -61,7 +61,7 @@
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OutDir);..\..\inc;$(VCInstallDir)UnitTest\lib;$(VCInstallDir)Auxiliary\VS\UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/tests/InstrumentationEngine.ProfilerProxy.Tests/InstrumentationEngine.ProfilerProxy.Tests.vcxproj
+++ b/tests/InstrumentationEngine.ProfilerProxy.Tests/InstrumentationEngine.ProfilerProxy.Tests.vcxproj
@@ -61,7 +61,7 @@
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <AdditionalLibraryDirectories>$(OutDir);..\..\src\InstrumentationEngine.ProfilerProxy.Lib;..\..\inc;$(VCInstallDir)UnitTest\lib;$(VCInstallDir)Auxiliary\VS\UnitTest\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>

--- a/tests/RawProfilerHook/RawProfilerHook/RawProfilerHook.vcxproj
+++ b/tests/RawProfilerHook/RawProfilerHook/RawProfilerHook.vcxproj
@@ -57,7 +57,7 @@
       <ValidateAllParameters>true</ValidateAllParameters>
     </Midl>
     <Link>
-      <CETCompat>true</CETCompat>
+      <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
       <ModuleDefinitionFile>.\RawProfilerHook.def</ModuleDefinitionFile>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Fix internal signed build which errors out with
`Error LNK1246: '/CETCOMPAT' not compatible with 'ARM64' target machine; link without '/CETCOMPAT'`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Restrict /CETCOMPAT to non-ARM64 builds.


###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Internal signed build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=5882479&view=results