### PR TITLE
Fix package restore issues in build.ps1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,18 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.45
++ BugFixes:
+  + Address package restore issue with Build.ps1
 
 ## 1.0.44
 + New:
   + Add support for Windows ARM64 (Internal)
-+ BugFixes: 
++ BugFixes:
   + Fixed build scripts to explicitly point to v142 toolsets regardless of VS version
 + Updates:
   + Setup automated PR builds
   + Add linter for doc link fixes
-  
+
 ## 1.0.43
 + New:
   + On Unix, environment is now scanned for instrumentation methods instead of looking for hardcoded ProductionBreakpoints.

--- a/build.ps1
+++ b/build.ps1
@@ -252,34 +252,40 @@ if (!$SkipBuild)
         # The $env:NUGET_PACKAGES variable overrides the globalPackagesFolder set in nuget.config.
         # This clears it out temporarily for proper nuget restore behavior.
         $tempGlobalCache = $env:NUGET_PACKAGES
-        $env:NUGET_PACKAGES = $null
 
-        # Clean up bin & obj folder if exists
-        if (Test-Path "$repoPath\bin\$configuration")
+        try
         {
-            Remove-Item -Force -Recurse "$repoPath\bin\$configuration"
-        }
+            $env:NUGET_PACKAGES = $null
 
-        if (Test-Path "$repoPath\obj\")
+            # Clean up bin & obj folder if exists
+            if (Test-Path "$repoPath\bin\$configuration")
+            {
+                Remove-Item -Force -Recurse "$repoPath\bin\$configuration"
+            }
+
+            if (Test-Path "$repoPath\obj\")
+            {
+                Remove-Item -Force -Recurse "$repoPath\obj\"
+            }
+
+            # dotnet restore defaults to Debug|Any CPU, which requires the /p:platform specification in order to replicate NuGet restore behavior.
+            $dotnetRestoreArgs = "restore `"$repoPath\InstrumentationEngine.sln`" --configfile `"$configFile`""
+            if ($ARM64)
+            {
+                $dotnetRestoreArgs = "$dotnetRestoreArgs /p:IncludeARM64=True"
+            }
+
+            Invoke-ExpressionHelper -Executable "dotnet" -Arguments $dotnetRestoreArgs -Activity 'dotnet Restore Solution'
+
+            # NuGet restore disregards platform/configuration
+            $nugetRestoreArgs = "restore `"$repoPath\NativeNugetRestore.sln`" -configfile `"$configFile`""
+            Invoke-ExpressionHelper -Executable "nuget" -Arguments $nugetRestoreArgs -Activity 'nuget Restore Solution'
+        }
+        finally 
         {
-            Remove-Item -Force -Recurse "$repoPath\obj\"
+            # Restore global variable
+            $env:NUGET_PACKAGES = $tempGlobalCache
         }
-
-        # dotnet restore defaults to Debug|Any CPU, which requires the /p:platform specification in order to replicate NuGet restore behavior.
-        $dotnetRestoreArgs = "restore `"$repoPath\InstrumentationEngine.sln`" --configfile `"$configFile`""
-        if ($ARM64)
-        {
-            $dotnetRestoreArgs = "$dotnetRestoreArgs /p:IncludeARM64=True"
-        }
-
-        Invoke-ExpressionHelper -Executable "dotnet" -Arguments $dotnetRestoreArgs -Activity 'dotnet Restore Solution'
-
-        # NuGet restore disregards platform/configuration
-        $nugetRestoreArgs = "restore `"$repoPath\NativeNugetRestore.sln`" -configfile `"$configFile`""
-        Invoke-ExpressionHelper -Executable "nuget" -Arguments $nugetRestoreArgs -Activity 'nuget Restore Solution'
-
-        # Restore global variable
-        $env:NUGET_PACKAGES = $tempGlobalCache
     }
 
     # Build InstrumentationEngine.sln

--- a/build.ps1
+++ b/build.ps1
@@ -249,6 +249,10 @@ if (!$SkipBuild)
 {
     if (!$SkipCleanAndRestore)
     {
+        # Remove $env:NUGET_PACKAGES global variable if set
+        $tempNugetPackages = $env:NUGET_PACKAGES
+        $env:NUGET_PACKAGES = $null
+
         # Clean up bin & obj folder if exists
         if (Test-Path "$repoPath\bin\$configuration")
         {
@@ -272,6 +276,9 @@ if (!$SkipBuild)
         # NuGet restore disregards platform/configuration
         $nugetRestoreArgs = "restore `"$repoPath\NativeNugetRestore.sln`" -configfile `"$configFile`""
         Invoke-ExpressionHelper -Executable "nuget" -Arguments $nugetRestoreArgs -Activity 'nuget Restore Solution'
+
+        # Restore global variable
+        $env:NUGET_PACKAGES = $tempNugetPackages
     }
 
     # Build InstrumentationEngine.sln

--- a/build.ps1
+++ b/build.ps1
@@ -242,15 +242,16 @@ Verify-DotnetExists
 $configFile = "$repoPath\NuGet.config"
 if ($ARM64)
 {
-    $configFile = "$repoPath\NuGet.internal.config"   
+    $configFile = "$repoPath\NuGet.internal.config"
 }
 
 if (!$SkipBuild)
 {
     if (!$SkipCleanAndRestore)
     {
-        # Remove $env:NUGET_PACKAGES global variable if set
-        $tempNugetPackages = $env:NUGET_PACKAGES
+        # The $env:NUGET_PACKAGES variable overrides the globalPackagesFolder set in nuget.config.
+        # This clears it out temporarily for proper nuget restore behavior.
+        $tempGlobalCache = $env:NUGET_PACKAGES
         $env:NUGET_PACKAGES = $null
 
         # Clean up bin & obj folder if exists
@@ -268,7 +269,7 @@ if (!$SkipBuild)
         $dotnetRestoreArgs = "restore `"$repoPath\InstrumentationEngine.sln`" --configfile `"$configFile`""
         if ($ARM64)
         {
-            $dotnetRestoreArgs = "$dotnetRestoreArgs /p:IncludeARM64='True'"
+            $dotnetRestoreArgs = "$dotnetRestoreArgs /p:IncludeARM64=True"
         }
 
         Invoke-ExpressionHelper -Executable "dotnet" -Arguments $dotnetRestoreArgs -Activity 'dotnet Restore Solution'
@@ -278,7 +279,7 @@ if (!$SkipBuild)
         Invoke-ExpressionHelper -Executable "nuget" -Arguments $nugetRestoreArgs -Activity 'nuget Restore Solution'
 
         # Restore global variable
-        $env:NUGET_PACKAGES = $tempNugetPackages
+        $env:NUGET_PACKAGES = $tempGlobalCache
     }
 
     # Build InstrumentationEngine.sln


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Address $env:NUGET_PACKAGES overriding the globalPackagesFolder set in our nuget.config.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Clear the global variable before package restoring
- Fix single-quotes in msbuild properties

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Local build