### PR TITLE
Fix duplicate instrumentation method check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,18 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.45
++ BugFixes:
+  + Refactor duplicate instrumentation method check
 
 ## 1.0.44
 + New:
   + Add support for Windows ARM64 (Internal)
-+ BugFixes: 
++ BugFixes:
   + Fixed build scripts to explicitly point to v142 toolsets regardless of VS version
 + Updates:
   + Setup automated PR builds
   + Add linter for doc link fixes
-  
+
 ## 1.0.43
 + New:
   + On Unix, environment is now scanned for instrumentation methods instead of looking for hardcoded ProductionBreakpoints.

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -1103,7 +1103,7 @@ HRESULT CProfilerManager::InitializeCore(
     IfFailRet(DetermineClrVersion());
 
     //set event mask to be default one. Later host and Instrumentation methods may call it again
-    IfFailRet(this->SetEventMask(m_dwEventMask));
+    IfFailRet(SetEventMask(m_dwEventMask));
 
     m_pWrappedProfilerInfo = (ICorProfilerInfo*)(new CCorProfilerInfoWrapper(this, m_pRealProfilerInfo));
 

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -701,7 +701,6 @@ HRESULT CProfilerManager::LoadInstrumentationMethods(_In_ CConfigurationSource* 
             // Track duplicate guids
             m_instrumentationMethodGuids.push_back(currentMethodGuid);
         }
-        AddInstrumentationMethod(method, pSettingsEnum, &pInstrumentationMethod);
     }
 
     return S_OK;

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -666,17 +666,19 @@ HRESULT CProfilerManager::LoadInstrumentationMethods(_In_ CConfigurationSource* 
 
     CConfigurationLoader loader;
 
-    std::vector<CInstrumentationMethod*> tempMethods;
     std::vector<CInstrumentationMethod*> instrumentationMethods;
 
-    if (FAILED(loader.LoadConfiguration(bstrConfigPath, tempMethods)))
+    if (FAILED(loader.LoadConfiguration(bstrConfigPath, instrumentationMethods)))
     {
         CLogging::LogError(_T("Failed to load configuration file '%s'."), bstrConfigPath.m_str);
     }
 
-    // Remove methods with duplicate classIds
-    for (CInstrumentationMethod* method : tempMethods)
+    CComPtr<IEnumInstrumentationMethodSettings> pSettingsEnum;
+    IfFailRet(pConfigurationSource->EnumSettings(&pSettingsEnum));
+
+    for (CInstrumentationMethod* method : instrumentationMethods)
     {
+        // Skip methods that share duplicate classIds with ones already loaded.
         GUID currentMethodGuid = method->GetClassId();
         std::vector<GUID>::iterator it = std::find(m_instrumentationMethodGuids.begin(), m_instrumentationMethodGuids.end(), currentMethodGuid);
         if (it != m_instrumentationMethodGuids.end())
@@ -687,25 +689,19 @@ HRESULT CProfilerManager::LoadInstrumentationMethods(_In_ CConfigurationSource* 
                 CLogging::LogMessage(_T("CProfilerManager::LoadInstrumentationMethods - Instrumentation Method found with duplicate ClassId '%s' of another previously loaded method. Skipping."), wszCurrentMethodGuid);
             }
 
-            delete method;
+            continue;
         }
-        else
-        {
-            instrumentationMethods.push_back(method);
-            m_instrumentationMethodGuids.push_back(currentMethodGuid);
-        }
-    }
 
-    CComPtr<IEnumInstrumentationMethodSettings> pSettingsEnum;
-    IfFailRet(pConfigurationSource->EnumSettings(&pSettingsEnum));
-
-    for (CInstrumentationMethod* method : instrumentationMethods)
-    {
         // Reset the position of the enumerator before initializing the next instrumentation method
         IfFailRet(pSettingsEnum->Reset());
 
         IInstrumentationMethod* pInstrumentationMethod = nullptr;
-        this->AddInstrumentationMethod(method, pSettingsEnum, &pInstrumentationMethod);
+        if (S_OK == AddInstrumentationMethod(method, pSettingsEnum, &pInstrumentationMethod))
+        {
+            // Track duplicate guids
+            m_instrumentationMethodGuids.push_back(currentMethodGuid);
+        }
+        AddInstrumentationMethod(method, pSettingsEnum, &pInstrumentationMethod);
     }
 
     return S_OK;
@@ -860,7 +856,7 @@ HRESULT CProfilerManager::AddInstrumentationMethod(
     CComPtr<IEnumInstrumentationMethodSettings> pSettingsEnum;
     IfFailRet(pSource->EnumSettings(&pSettingsEnum));
 
-    return this->AddInstrumentationMethod(pInstrumentationMethod.release(), pSettingsEnum, ppInstrumentationMethod);
+    return AddInstrumentationMethod(pInstrumentationMethod.release(), pSettingsEnum, ppInstrumentationMethod);
 }
 
 HRESULT CProfilerManager::DisableProfiling()


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
CLR IE gracefully skips over instrumentation methods that fail to load. However, our duplicate classid checks on the config file happen before loading method dlls. This causes problems if methods are compiled for different architectures (eg. x64 and ARM64) and only the first config environment variable encountered will be used which may be the wrong arch.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Refactor duplicate check to happen while loading instrumentation methods, rather than on config file

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Local debug