### PR TITLE
Add ARM64 env support & update docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,18 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.45
++ New:
+  + Add ARM64 environment variable support
 
 ## 1.0.44
 + New:
   + Add support for Windows ARM64 (Internal)
-+ BugFixes: 
++ BugFixes:
   + Fixed build scripts to explicitly point to v142 toolsets regardless of VS version
 + Updates:
   + Setup automated PR builds
   + Add linter for doc link fixes
-  
+
 ## 1.0.43
 + New:
   + On Unix, environment is now scanned for instrumentation methods instead of looking for hardcoded ProductionBreakpoints.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -36,7 +36,6 @@ The CLR Instrumentation Engine checks for environment variables with these prefi
 * x64: `MicrosoftInstrumentationEngine_ConfigPath64_`
 * x86: `MicrosoftInstrumentationEngine_ConfigPath32_`
 
-
 The value of these variables should be a **full path** to the *.config file.
 
 ### Testing Custom Instrumentation Method

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -32,8 +32,10 @@ Priority|Integer ordering for InstrumentationMethod consumption. Higher priority
 ### Config Environment Variable
 
 The CLR Instrumentation Engine checks for environment variables with these prefixes:
-* 64bit: `MicrosoftInstrumentationEngine_ConfigPath64_`
-* 32bit: `MicrosoftInstrumentationEngine_ConfigPath32_`
+* ARM64: `MicrosoftInstrumentationEngine_ConfigPathARM64_`
+* x64: `MicrosoftInstrumentationEngine_ConfigPath64_`
+* x86: `MicrosoftInstrumentationEngine_ConfigPath32_`
+
 
 The value of these variables should be a **full path** to the *.config file.
 

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -12,6 +12,7 @@ COR_ENABLE_PROFILING|1|The CLR will only connect to a profiler if this is set to
 COR_PROFILER|"{324F817A-7420-4E6D-B3C1-143FBED6D855}"|The CLR will search for the CLSID or ProgID specified.|
 COR_PROFILER_PATH_32 (see below)|"[FULL PATH TO MicrosoftInstrumentationEngine_x86.dll or InstrumentationEngine.ProfilerProxy_x86.dll]"|Skips the registry lookup, uses the 32bit dll from the path.
 COR_PROFILER_PATH_64 (see below)|"[FULL PATH TO MicrosoftInstrumentationEngine_x64.dll or InstrumentationEngine.ProfilerProxy_x64.dll]"|Skips the registry lookup, uses the 64bit dll from the path.
+COR_PROFILER_PATH_ARM64|"[FULL PATH TO MicrosoftInstrumentationEngine_arm64.dll]"|Skips the registry lookup, uses the arm64 dll from the path. This is only supported on .NET framework 4.8.1+
 
 Alternatively, for CoreCLR:
 
@@ -21,6 +22,7 @@ CORECLR_ENABLE_PROFILING|1|The CoreCLR will only connect to a profiler if this i
 CORECLR_PROFILER|"{324F817A-7420-4E6D-B3C1-143FBED6D855}"|The CoreCLR will search for the CLSID or ProgID specified.
 CORECLR_PROFILER_PATH_32 (see below)|"[FULL PATH TO MicrosoftInstrumentationEngine_x86.dll or InstrumentationEngine.ProfilerProxy_x86.dll]"|Skips the registry lookup, uses the 32bit dll from the path.
 CORECLR_PROFILER_PATH_64 (see below)|"[FULL PATH TO MicrosoftInstrumentationEngine_x64.dll or InstrumentationEngine.ProfilerProxy_x64.dll]"|Skips the registry lookup, uses the 64bit dll from the path.
+CORECLR_PROFILER_PATH_ARM64 (see below)|"[FULL PATH TO MicrosoftInstrumentationEngine_arm64.dll]"|Skips the registry lookup, uses the arm64 dll from the path. This is only supported on .NET 6+
 
 > Please see [Profiler Proxy](profilerproxy.md) for details on using the Profiler Proxy dll. We recommend setting the COR_PROFILER variables to
 the proxy whenever applicable since it redirects to the latest CLRIE installed on every process re/start.
@@ -58,7 +60,7 @@ For reference, InstrumentationEngine versions are expected to be in one of the b
 
 | Variable | Value | Description |
 |-|-|-|
-InstrumentationEngineProxy_UseDebug|1|Toggles the proxy to **only** consider versions with `_debug` suffix. 
+InstrumentationEngineProxy_UseDebug|1|Toggles the proxy to **only** consider versions with `_debug` suffix.
 InstrumentationEngineProxy_UsePreview|1|Toggles the proxy to also consider versions with `-build###` suffix.
 InstrumentationEngineProxy_UseSpecificVersion|1.0.0-build1234|Forces the proxy to only use the specific folder version.
 
@@ -69,7 +71,7 @@ The RawProfilerHook allows one additional profiler that has not yet on-boarded t
 | Variable | Value | Description |
 |-|-|-|
 MicrosoftInstrumentationEngine_RawProfilerHook|"{GUID}"|This would be the value set to CORECLR/COR_PROFILER.
-MicrosoftInstrumentationEngine_RawProfilerHookPath_32/64|"[FULL PATH TO raw profiler dll]"|This would be the value set to CORECLR/COR_PROFILER_PATH_32/64.
+MicrosoftInstrumentationEngine_RawProfilerHookPath_32/64/ARM64|"[FULL PATH TO raw profiler dll]"|This would be the value set to CORECLR/COR_PROFILER_PATH_32/64/ARM64.
 
 ## Deprecated as of Version 1.0.22
 The following variables allowed custom ExtensionHosts for the InstrumentationEngine. The responsibility of the ExtensionsHost involves setting

--- a/src/ExtensionsCommon/NativeInstanceMethodsCodeInjector.cpp
+++ b/src/ExtensionsCommon/NativeInstanceMethodsCodeInjector.cpp
@@ -97,12 +97,10 @@ namespace Instrumentation
 
 		const auto NumberOfExtraMethodParameters = 1;
 
-#if defined(_M_X64)
+#if (defined(_M_X64)) || (defined(_M_ARM64))
 		const auto NativeObjThisPointerElementType = ELEMENT_TYPE_I8;
 #elif defined(_M_IX86)
 		const auto NativeObjThisPointerElementType = ELEMENT_TYPE_I4;
-#elif defined(_M_ARM64)
-		const auto NativeObjThisPointerElementType = ELEMENT_TYPE_I8;
 #else
 		static_assert(true, "Unsupported processor architecture");
 #endif
@@ -189,21 +187,19 @@ namespace Instrumentation
 	{
 		IInstructionSptr spLoadNativeObjAddressInstruction;
 
-#if defined(_M_X64)
+#if (defined(_M_X64)) || (defined(_M_ARM64))
 		IfFailRet(
 			spInstructionFactory->CreateLongOperandInstruction(
 			Cee_Ldc_I8,
 			pInstance,
 			&spLoadNativeObjAddressInstruction));
-#endif
-#if defined(_M_IX86)
+#elif defined(_M_IX86)
 		IfFailRet(
 			spInstructionFactory->CreateIntOperandInstruction(
 			Cee_Ldc_I4,
 			pInstance,
 			&spLoadNativeObjAddressInstruction));
-#endif
-#if (!defined(_M_X64)) && !defined(_M_IX86)
+#else
 		static_assert(true, "Unsupported processor architecture");
 #endif
 
@@ -226,21 +222,19 @@ namespace Instrumentation
 	{
 		IInstructionSptr spLoadCallbackAddress;
 
-#if defined(_M_X64)
+#if (defined(_M_X64)) || (defined(_M_ARM64))
 		IfFailRet(
 			spInstructionFactory->CreateLongOperandInstruction(
 			Cee_Ldc_I8,
 			pMethod,
 			&spLoadCallbackAddress));
-#endif
-#if defined(_M_IX86)
+#elif defined(_M_IX86)
 		IfFailRet(
 			spInstructionFactory->CreateIntOperandInstruction(
 			Cee_Ldc_I4,
 			pMethod,
 			&spLoadCallbackAddress));
-#endif
-#if (!defined(_M_X64)) && !defined(_M_IX86)
+#else
 		static_assert(true, "Unsupported processor architecture");
 #endif
 

--- a/src/InstrumentationEngine.Lib/ConfigurationLocator.h
+++ b/src/InstrumentationEngine.Lib/ConfigurationLocator.h
@@ -22,10 +22,12 @@ namespace MicrosoftInstrumentationEngine
         static constexpr const char s_cEnvironmentVariableNameValueSeparator = '=';
         static constexpr const char s_cEnvironmentVariablePathDelimiter = ':';
 #else  // PLATFORM_UNIX
-#if defined(_WIN64)
-        static constexpr const WCHAR* s_wszConfigurationPathEnvironmentVariablePrefix = _T("MicrosoftInstrumentationEngine_ConfigPath64_");
-#else
+#ifdef _M_IX86
         static constexpr const WCHAR* s_wszConfigurationPathEnvironmentVariablePrefix = _T("MicrosoftInstrumentationEngine_ConfigPath32_");
+#elif defined(_M_ARM64)
+        static constexpr const WCHAR* s_wszConfigurationPathEnvironmentVariablePrefix = _T("MicrosoftInstrumentationEngine_ConfigPathARM64_");
+#else
+        static constexpr const WCHAR* s_wszConfigurationPathEnvironmentVariablePrefix = _T("MicrosoftInstrumentationEngine_ConfigPath64_");
 #endif
         static constexpr const WCHAR* s_wszEnvironmentVariableNameValueSeparator = _T("=");
         static constexpr const WCHAR* s_wszEnvironmentVariablePathDelimiter = _T(";");

--- a/src/InstrumentationEngine.Lib/RawProfilerHookSettingsReader.cpp
+++ b/src/InstrumentationEngine.Lib/RawProfilerHookSettingsReader.cpp
@@ -10,8 +10,12 @@ namespace MicrosoftInstrumentationEngine
     LPCWSTR cszRawProfilerHookPathVariableNameNoBitness = L"MicrosoftInstrumentationEngine_RawProfilerHookPath";
 #ifdef X86
     LPCWSTR cszRawProfilerHookPathVariableName = L"MicrosoftInstrumentationEngine_RawProfilerHookPath_32";
-#else
+#elif defined(_M_X64)
     LPCWSTR cszRawProfilerHookPathVariableName = L"MicrosoftInstrumentationEngine_RawProfilerHookPath_64";
+#elif defined(_M_ARM64)
+    LPCWSTR cszRawProfilerHookPathVariableName = L"MicrosoftInstrumentationEngine_RawProfilerHookPath_ARM64";
+#else
+    static_assert(true, "Unsupported processor architecture");
 #endif
 
     CRawProfilerHookSettingsReader::CRawProfilerHookSettingsReader() noexcept


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Provide users a way to specify ARM64 instrumentation methods and profilers. 

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Add support for ARM64: 
  - `MicrosoftInstrumentationEngine_ConfigPathARM64_` prefix
  - `MicrosoftInstrumentationEngine_RawProfilerHookPath_ARM64` variable
- Update docs


###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Local debug