### PR TITLE
Add directory check to fileloggersink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Please format the changes as follows:
   + Add ARM64 environment variable support
 + BugFixes:
   + Refactor duplicate instrumentation method check
-  + Allow FileLogPath to not require a trailing path separator
+  + Allow FileLogPath to handle directories without trailing path separator
 
 ## 1.0.44
 + New:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,18 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.45
++ Updates:
+  + Allow FileLogPath to not require a trailing path separator
 
 ## 1.0.44
 + New:
   + Add support for Windows ARM64 (Internal)
-+ BugFixes: 
++ BugFixes:
   + Fixed build scripts to explicitly point to v142 toolsets regardless of VS version
 + Updates:
   + Setup automated PR builds
   + Add linter for doc link fixes
-  
+
 ## 1.0.43
 + New:
   + On Unix, environment is now scanned for instrumentation methods instead of looking for hardcoded ProductionBreakpoints.

--- a/docs/environment_variables.md
+++ b/docs/environment_variables.md
@@ -40,7 +40,7 @@ These are the environment variables and values that aid in troubleshooting the C
 | Variable | Value | Description |
 |-|-|-|
 MicrosoftInstrumentationEngine_DebugWait|1|Suspends the process until the debugger is attached.
-MicrosoftInstrumentationEngine_FileLogPath|"[FULL PATH TO LOGGING FILE]"|File to host the event logs. This requires LogLevel to be set. If multiple processes are profiled, then use a directory (`[path]\` or `[path]\.`) so that each process generates its own log file: `ProfilerLog_[processId].txt`
+MicrosoftInstrumentationEngine_FileLogPath|"[FULL PATH TO LOGGING FILE]"|File to host the event logs. This requires LogLevel to be set. If multiple processes are profiled, then use a directory (optional trailing slash) so that each process generates its own log file: `ProfilerLog_[processId].txt`
 MicrosoftInstrumentationEngine_DisableCodeSignatureValidation|1|Disables signature validation
 MicrosoftInstrumentationEngine_IsPreinstalled|1|The preinstalled site extension for CLRIE sets this to help users know that the applicationHost.xdt file for the preinstalled extension was applied. The Application Insights private site extension won't set this.
 MicrosoftInstrumentationEngine_LatestPath|D:\Program Files (x86)\SiteExtensions\InstrumentationEngine\\[LATEST VERSION]|This environment variable is available in Azure App Service v91+ and allows private site extensions to reference the path to the latest preinstalled InstrumentationEngine.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -122,17 +122,16 @@ The EventLoggerSink is restricted to Error messages to reduce noise.
 
 File logging is configured not only by the LogLevel variable but also the `MicrosoftInstrumentationEngine_FileLogPath` variable to specify where the log file is generated. If the FileLogPath is set to an existing directory (optional trailing slash), then the filename defaults to "ProfilerLog_PID.txt" where PID is the process id. 
 
-The CFileLoggerSink  will try taking an exclusive lock on the file so if the file already exists and is unlocked then log messages will be appended.
+The CFileLoggerSink will try taking an exclusive lock on the file so if the file already exists and is unlocked then log messages will be appended.
 
 This logic can be demonstrated with the following table (assume `C:\Folder\` exists)
 
 |Variable Value|Comments|Resolved LogFile Path|
 |:--|:--|:--|
-|C:\Folder\ or C:\Folder\\. |Existing folder with trailing slash|C:\Folder\Profiler_PID.txt|
-|C:\Folder|Existing folder, no trailling slash|C:\Folder\Profiler_PID.txt|
-|C:\Folder\File.txt|`File.txt` created if not exist|C:\Folder\File.txt|
-|C:\Folder\File|`File` created if not exist, doesn't exist as a folder|C:\Folder\File|
-|C:\Folder2\File.txt|Nonexistent folder|[no file]|
+|"C:\Folder\ "<br/>"C:\Folder\\."<br/>"C:\Folder"|Existing folder (optional trailing slash)|C:\Folder\Profiler_PID.txt|
+|"C:\Folder\File.txt"|`File.txt` created if not exist|C:\Folder\File.txt|
+|"C:\Folder\File"|`File` doesn't exist as a folder, created if not exist|C:\Folder\File|
+|"C:\Folder2\File.txt"|Nonexistent folder|[no file]|
 
 For legacy reasons, CLRIE also supports `MicrosoftInstrumentationEngine_FileLog` variable which supercedes the global log level.
 

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -130,7 +130,7 @@ This logic can be demonstrated with the following table (assume `C:\Folder\` exi
 |:--|:--|:--|
 |"C:\Folder\ "<br/>"C:\Folder\\."<br/>"C:\Folder"|Existing folder (optional trailing slash)|C:\Folder\Profiler_PID.txt|
 |"C:\Folder\File.txt"|`File.txt` created if not exist|C:\Folder\File.txt|
-|"C:\Folder\File"|`File` doesn't exist as a folder, created if not exist|C:\Folder\File|
+|"C:\Folder\File"|`File` doesn't exist as a folder, created as a file if not exist|C:\Folder\File|
 |"C:\Folder2\File.txt"|Nonexistent folder|[no file]|
 
 For legacy reasons, CLRIE also supports `MicrosoftInstrumentationEngine_FileLog` variable which supercedes the global log level.

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -48,7 +48,6 @@ Combination of flags can be set using the `|` character such as `Errors|Messages
 
 See FileLoggerSink section for details around `MicrosoftInstrumentationEngine_FileLogPath` and `MicrosoftInstrumentationEngine_FileLog`.
 
-
 ## Logging Classes <a name="loggingclasses" />
 There are three key classes that make up the Logging infrastructure:
 * [CLogging](#clogging)
@@ -121,7 +120,19 @@ The EventLoggerSink is restricted to Error messages to reduce noise.
 
 #### CFileLoggerSink ([.h](../src/InstrumentationEngine.Lib/FileLoggerSink.h)|[.cpp](../src/InstrumentationEngine.Lib/FileLoggerSink.cpp))
 
-File logging is configured not only by the LogLevel variable but also the `MicrosoftInstrumentationEngine_FileLogPath` variable to specify where the log file is generated. If the FileLogPath is set to a directory, then the filename defaults to "ProfilerLog_PID.txt" where PID is the process id.
+File logging is configured not only by the LogLevel variable but also the `MicrosoftInstrumentationEngine_FileLogPath` variable to specify where the log file is generated. If the FileLogPath is set to an existing directory (optional trailing slash), then the filename defaults to "ProfilerLog_PID.txt" where PID is the process id. 
+
+The CFileLoggerSink  will try taking an exclusive lock on the file so if the file already exists and is unlocked then log messages will be appended.
+
+This logic can be demonstrated with the following table (assume `C:\Folder\` exists)
+
+|Variable Value|Comments|Resolved LogFile Path|
+|:--|:--|:--|
+|C:\Folder\ or C:\Folder\\. |Existing folder with trailing slash|C:\Folder\Profiler_PID.txt|
+|C:\Folder|Existing folder, no trailling slash|C:\Folder\Profiler_PID.txt|
+|C:\Folder\File.txt|`File.txt` created if not exist|C:\Folder\File.txt|
+|C:\Folder\File|`File` created if not exist, doesn't exist as a folder|C:\Folder\File|
+|C:\Folder2\File.txt|Nonexistent folder|[no file]|
 
 For legacy reasons, CLRIE also supports `MicrosoftInstrumentationEngine_FileLog` variable which supercedes the global log level.
 

--- a/src/InstrumentationEngine.Lib/FileLoggerSink.cpp
+++ b/src/InstrumentationEngine.Lib/FileLoggerSink.cpp
@@ -91,7 +91,7 @@ HRESULT CFileLoggerSink::Reset(_In_ LoggingFlags defaultFlags, _Out_ LoggingFlag
             // Check if fileName is actually a directory, meaning the path separator was left off
             if ((GetFileAttributes(m_tsPathCandidate.c_str()) & FILE_ATTRIBUTE_DIRECTORY) != 0)
             {
-                wcscat_s(wszDirectory, wszFile);
+                wcscat_s(wszDirectory, _MAX_DIR, wszFile);
                 isDirectory = true;
             }
         }

--- a/src/InstrumentationEngine.Lib/FileLoggerSink.cpp
+++ b/src/InstrumentationEngine.Lib/FileLoggerSink.cpp
@@ -90,7 +90,7 @@ HRESULT CFileLoggerSink::Reset(_In_ LoggingFlags defaultFlags, _Out_ LoggingFlag
         {
             // Check if fileName is actually a directory, meaning the path separator was left off
             DWORD fileFlags = GetFileAttributes(m_tsPathCandidate.c_str());
-            if ((fileFlags & INVALID_FILE_ATTRIBUTES) != INVALID_FILE_ATTRIBUTES && // path exists
+            if (fileFlags != INVALID_FILE_ATTRIBUTES && // path exists
                 (fileFlags & FILE_ATTRIBUTE_DIRECTORY) != 0) // is a directory
             {
                 wcscat_s(wszDirectory, _MAX_DIR, wszFile);

--- a/src/InstrumentationEngine.Lib/FileLoggerSink.cpp
+++ b/src/InstrumentationEngine.Lib/FileLoggerSink.cpp
@@ -89,7 +89,9 @@ HRESULT CFileLoggerSink::Reset(_In_ LoggingFlags defaultFlags, _Out_ LoggingFlag
         else 
         {
             // Check if fileName is actually a directory, meaning the path separator was left off
-            if ((GetFileAttributes(m_tsPathCandidate.c_str()) & FILE_ATTRIBUTE_DIRECTORY) != 0)
+            DWORD fileFlags = GetFileAttributes(m_tsPathCandidate.c_str());
+            if ((fileFlags & INVALID_FILE_ATTRIBUTES) != INVALID_FILE_ATTRIBUTES && // path exists
+                (fileFlags & FILE_ATTRIBUTE_DIRECTORY) != 0) // is a directory
             {
                 wcscat_s(wszDirectory, _MAX_DIR, wszFile);
                 isDirectory = true;


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Currently `MicrosoftInstrumentationEngine_FileLogPath` requires a path separator at the end to determine if the path is a directory. This adds a check to see if the path is an existing directory when the path separator is left off.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Refactor FileLoggerSink to check if FIleLogPath is set to existing directory

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Local debug