### PR TITLE
Revert InstrumentationEngine.h header change

### DIFF
--- a/src/InstrumentationEngine.Api/InstrumentationEngine.h
+++ b/src/InstrumentationEngine.Api/InstrumentationEngine.h
@@ -453,7 +453,7 @@ typedef interface IInstrumentationMethodAttach IInstrumentationMethodAttach;
 
 /* header files for imported files */
 #include "ocidl.h"
-#include <clrprofiler.h>
+#include "corprof.h"
 
 #ifdef __cplusplus
 extern "C"{


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
The InstrumentationEngine.idl generates InstrumentationEngine.h and applies `#include "corprof.h"`. I had accidentally modified this generated file.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Revert InstrumentationEngine.h

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Local build