### PR TITLE
Address "CredentialProvider.Microsoft plugin failed to start"

### DIFF
--- a/build/yaml/steps/windows/dotnetrestore.yaml
+++ b/build/yaml/steps/windows/dotnetrestore.yaml
@@ -9,6 +9,21 @@ parameters:
   IsMicroBuildInternal: false
 
 steps:
+# NuGet Credential Provider Issue: https://github.com/microsoft/artifacts-credprovider/issues/91#issuecomment-530907753
+- task: NuGetCommand@2
+  displayName: 'Clear Local Cache'
+  inputs:
+    command: 'custom'
+    arguments: 'locals http-cache -Clear'
+
+- task: PowerShell@2
+  displayName: 'Set NUGET_PLUGIN Env Vars'
+  inputs:
+    targetType: 'inline'
+    script: |
+      Write-Host "##vso[task.setvariable variable=NUGET_PLUGIN_HANDSHAKE_TIMEOUT_IN_SECONDS]20"
+      Write-Host "##vso[task.setvariable variable=NUGET_PLUGIN_REQUEST_TIMEOUT_IN_SECONDS]20"
+
 - task: NuGetAuthenticate@0
   inputs:
     forceReinstallCredentialProvider: true


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Addressing issue where restore fails due to credentialprovider plugin failing to start
`Problem starting the plugin 'C:\Users\cloudtest\.nuget\plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll'. Plugin 'CredentialProvider.Microsoft' failed within 5.044 seconds with exit code -1.`

Applying workaround specified in https://github.com/microsoft/artifacts-credprovider/issues/91#issuecomment-530907753

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Clear local nuget http cache and extend timeout for restore

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Test signed build