### PR TITLE
Check the value of variables, not just their existence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.46
++ BugFixes:
+  + Check the values for configuration variables
 
 ## 1.0.45
 + New:

--- a/src/InstrumentationEngine.ProfilerProxy/dllmain.cpp
+++ b/src/InstrumentationEngine.ProfilerProxy/dllmain.cpp
@@ -329,7 +329,7 @@ namespace ProfilerProxy
 
 #ifdef DEBUG
         WCHAR wszEnvVar[MAX_PATH];
-        if (GetEnvironmentVariable(_T("MicrosoftInstrumentationEngine_DebugWait"), wszEnvVar, MAX_PATH) > 0)
+        if (GetEnvironmentVariable(_T("MicrosoftInstrumentationEngine_DebugWait"), wszEnvVar, MAX_PATH) > 0 && wcscmp(wszEnvVar, _T("1")) == 0)
         {
             while (!IsDebuggerPresent())
             {

--- a/src/InstrumentationEngine/ProfilerManager.cpp
+++ b/src/InstrumentationEngine/ProfilerManager.cpp
@@ -47,15 +47,17 @@ CProfilerManager::CProfilerManager() :
     WCHAR wszEnvVar[MAX_PATH];
 
 #ifndef PLATFORM_UNIX
-    GetEnvironmentVariable(_T("MicrosoftInstrumentationEngine_MessageboxAtAttach"), wszEnvVar, MAX_PATH);
-    if (wcscmp(wszEnvVar, _T("1")) == 0)
+    if (GetEnvironmentVariable(_T("MicrosoftInstrumentationEngine_MessageboxAtAttach"), wszEnvVar, MAX_PATH) > 0 &&
+        wcscmp(wszEnvVar, _T("1")) == 0)
     {
         std::wstringstream mboxStream;
         DWORD pid = GetCurrentProcessId();
         mboxStream << _T("MicrosoftInstrumentationEngine ProfilerAttach. PID: ") << pid;
         MessageBoxW(NULL, mboxStream.str().c_str(), L"", MB_OK);
     }
-    if (GetEnvironmentVariable(_T("MicrosoftInstrumentationEngine_DebugWait"), wszEnvVar, MAX_PATH) > 0)
+
+    if (GetEnvironmentVariable(_T("MicrosoftInstrumentationEngine_DebugWait"), wszEnvVar, MAX_PATH) > 0 &&
+        wcscmp(wszEnvVar, _T("1")) == 0)
     {
         while (!IsDebuggerPresent())
         {
@@ -74,7 +76,8 @@ CProfilerManager::CProfilerManager() :
     // We consider this variable as secure as COR_ENABLE_PROFILER because we read it very early in process lifetime so malicious code
     // inside the process cannot modify it. Make sure you do not move this initialization logic and do not make it lazily initialized
     //
-    if (GetEnvironmentVariable(_T("MicrosoftInstrumentationEngine_DisableCodeSignatureValidation"), nullptr, 0) > 0)
+    if (GetEnvironmentVariable(_T("MicrosoftInstrumentationEngine_DisableCodeSignatureValidation"), wszEnvVar, MAX_PATH) > 0 &&
+        wcscmp(wszEnvVar, _T("1")) == 0)
     {
         m_bValidateCodeSignature = false;
     }

--- a/tests/ApplicationInsightsCompatibility/Intercept.Shared.Tests/TestEngine.cs
+++ b/tests/ApplicationInsightsCompatibility/Intercept.Shared.Tests/TestEngine.cs
@@ -50,7 +50,7 @@ namespace ApplicationInsightsCompatibility
             //vars.Add("MicrosoftInstrumentationEngine_FileLogPath", ""); //can be overridden if needed
 
 #if ALLOWNOTSIGNED
-            vars.Add("MicrosoftInstrumentationEngine_DisableCodeSignatureValidation", "true");
+            vars.Add("MicrosoftInstrumentationEngine_DisableCodeSignatureValidation", "1");
 #endif
         }
 

--- a/tests/RawProfilerHook/RawProfilerHook.Tests/TestEngine/TestEngine.cs
+++ b/tests/RawProfilerHook/RawProfilerHook.Tests/TestEngine/TestEngine.cs
@@ -99,7 +99,7 @@ namespace RawProfilerHook.Tests
                 { "MicrosoftInstrumentationEngine_FileLogPath", traceFilePath },
                 { "MicrosoftInstrumentationEngine_UserBuffer", "1" }
 #if ALLOWNOTSIGNED
-                , { "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation", "true"}
+                , { "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation", "1"}
 #endif
             };
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Adds additional check if these variables are set to 1:
* `MicrosoftInstrumentationEngine_DebugWait`
* `MicrosoftInstrumentationEngine_DisableCodeSignatureValidation`

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Add wcscmp to "1"
- Update tests that were setting these variables to "true"


###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Local debug