### PR TITLE
Migrate to VS2022 with v143 toolset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Please format the changes as follows:
 ## 1.0.46
 + BugFixes:
   + Check the values for configuration variables
++ Updates:
+  + Use VS2022 with v143 toolsets and latest Win10 SDK
 
 ## 1.0.45
 + New:

--- a/README.md
+++ b/README.md
@@ -25,20 +25,16 @@ The CLR Instrumentation Engine is a profiler implementation and is enabled and c
 
 Please read [Contributing](CONTRIBUTING.md) for details on the Contributor License Agreement (CLA) and the process for submitting pull requests to us.
 
-This repo builds using Visual Studio 2019 and requires the following components:
+This repo builds using Visual Studio 2022 and requires the following components:
 
 |Component Id|Component Friendly Name|
 |:--|:--
 Microsoft.Component.MSBuild|MSBuild
 Microsoft.VisualStudio.Workload.NativeDesktop|Desktop development with C++ (Workload)
-Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.Spectre|C++ v14.29 (16.11) ATL for v142 build tools with Spectre Mitigations (x86 & x64)
-Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64.Spectre|MSVC v142 - VS 2019 C++ x64/x86 Spectre-mitigated libs (v14.29-16.11)	
+Microsoft.VisualStudio.Component.VC.ATL.Spectre|C++ ATL for latest v143 build tools with Spectre Mitigations (x86 & x64)
+Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre|MSVC v143 - VS 2022 C++ x64/x86 Spectre-mitigated libs (Latest)
 
-The following component IDs work for VS 2019 but not VS 2022 because they implicitly upversion to the latest (ie. v143 and v14.3x)
-* Microsoft.VisualStudio.Component.VC.ATL.Spectre 
-* Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre
-
-Optionally, in order to develop Wixproj files in Visual Studio, you will need to install the [Wix Toolset Visual 2019 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2019Extension), also known as the "Votive" extension.
+Optionally, in order to develop Wixproj files in Visual Studio, you will need to install the [Wix Toolset Visual 2022 Extension](https://marketplace.visualstudio.com/items?itemName=WixToolset.WixToolsetVisualStudio2022Extension), also known as the "Votive" extension.
 
 * [Design Notes](DESIGN-NOTES.md) - the overall design for CLR Instrumentation Engine.
 * [Build](docs/build.md) - how to run local builds.

--- a/build.ps1
+++ b/build.ps1
@@ -157,39 +157,27 @@ if (-not ($repoPath))
 }
 
 ###
-# Picks up msbuild from vs2019 installation
+# Picks up msbuild from vs2022 installation
 ###
-$Vs2019Requirements = [System.Collections.ArrayList]@(
+$Vs2022Requirements = [System.Collections.ArrayList]@(
     'Microsoft.Component.MSBuild'
     'Microsoft.VisualStudio.Workload.NativeDesktop'
     'Microsoft.VisualStudio.Component.VC.ATL.Spectre'
-    'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
-)
-
-$VsNextRequirements = [System.Collections.ArrayList]@(
-    'Microsoft.Component.MSBuild'
-    'Microsoft.VisualStudio.Workload.NativeDesktop'
-    'Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.Spectre'
-    'Microsoft.VisualStudio.Component.VC.14.29.16.11.x86.x64.Spectre'
+    'Microsoft.VisualStudio.Component.VC.Runtimes.x86.x64.Spectre'
 )
 
 if ($ARM64)
 {
-    $Vs2019Requirements.Add('Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre')
-    $Vs2019Requirements.Add('Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre')
-
-    $VsNextRequirements.Add('Microsoft.VisualStudio.Component.VC.14.29.16.11.ATL.ARM64.Spectre')
-    $VsNextRequirements.Add('Microsoft.VisualStudio.Component.VC.14.29.16.11.ARM64.Spectre')
+    $Vs2022Requirements.Add('Microsoft.VisualStudio.Component.VC.ATL.ARM64.Spectre')
+    $Vs2022Requirements.Add('Microsoft.VisualStudio.Component.VC.Runtimes.ARM64.Spectre')
 }
 
-Write-Verbose "Compatible VS2019 must have these installed components: `n$($Vs2019Requirements | % {"  $_"} | Out-String)`n"
-Write-Verbose "If none are found, searching for any VS installation with these installed components: `n$($VsNextRequirements | % {"  $_"} | Out-String)`n"
+Write-Verbose "Compatible VS2022 must have these installed components: `n$($Vs2022Requirements | % {"  $_"} | Out-String)`n"
 Write-Warning "Using a VS developer command prompt skips this check."
 
 $vswhere = "`"${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe`""
 
-$filterArgsFor2019 = "-latest -prerelease -requires $($Vs2019Requirements -join ' ') -property installationPath -version `"[16.0,17.0)`""
-$filterArgsForNext = "-latest -prerelease -requires $($VsNextRequirements -join ' ') -property installationPath"
+$filterArgsFor2022 = "-latest -prerelease -requires $($Vs2022Requirements -join ' ') -property installationPath -version `"[17.0,18.0)`""
 
 # Restrict the VS version if running from a context that has the VSINSTALLDIR env variable (e.g. Developer Command Prompt).
 # This will make sure that VisualStudioVersion matches the VS version of MSBuild in order to avoid mismatches (e.g. using a Dev15
@@ -203,13 +191,8 @@ if ($env:VSINSTALLDIR)
 
 if (-not $installationPath -or -not (Test-Path "$installationPath"))
 {
-    Write-Verbose "Search for compatible VS2019..."
-    $installationPath = Invoke-Expression "& $vswhere $filterArgsFor2019"
-    if (-not $installationPath -or -not (Test-Path "$installationPath"))
-    {
-        Write-Verbose "Unable to find compatible VS2019. Search for any compatible VS..."
-        $installationPath = Invoke-Expression "& $vswhere $filterArgsForNext"
-    }
+    Write-Verbose "Search for compatible VS2022..."
+    $installationPath = Invoke-Expression "& $vswhere $filterArgsFor2022"
 
     if (-not $installationPath -or -not (Test-Path "$installationPath"))
     {

--- a/build/CommonBuild.Private.props
+++ b/build/CommonBuild.Private.props
@@ -47,7 +47,7 @@
         <ApplicationInsightsAgentInterceptVersion>2.4.0</ApplicationInsightsAgentInterceptVersion>
         <LegacyApplicationInsightsAgentInterceptVersion>2.0.1</LegacyApplicationInsightsAgentInterceptVersion>
         <MicroBuildCoreVersion>0.4.1</MicroBuildCoreVersion>
-        <MicrosoftNETTestSdkVersion>16.9.1</MicrosoftNETTestSdkVersion>
+        <MicrosoftNETTestSdkVersion>17.1.0</MicrosoftNETTestSdkVersion>
         <MSTestTestAdapterVersion>2.1.2</MSTestTestAdapterVersion>
         <MSTestTestFrameworkVersion>2.1.2</MSTestTestFrameworkVersion>
         <NETFrameworkReferenceVersion>1.0.2</NETFrameworkReferenceVersion>

--- a/build/CommonBuild.Private.props
+++ b/build/CommonBuild.Private.props
@@ -54,6 +54,12 @@
     </PropertyGroup>
 
     <PropertyGroup>
+      <!-- See Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static.targets
+           Microsoft.GoogleTest only supports up to v142 toolset. This flag overrides that check -->
+      <Force-Enable-Microsoft-googletest-v140-windesktop-msvcstl-static-rt-static>true</Force-Enable-Microsoft-googletest-v140-windesktop-msvcstl-static-rt-static>
+    </PropertyGroup>
+
+    <PropertyGroup>
         <MsiSuffix Condition=" '$(Configuration)' == 'Debug' ">_$(Configuration)</MsiSuffix>
     </PropertyGroup>
 

--- a/build/CommonBuild.Private.props
+++ b/build/CommonBuild.Private.props
@@ -47,7 +47,7 @@
         <ApplicationInsightsAgentInterceptVersion>2.4.0</ApplicationInsightsAgentInterceptVersion>
         <LegacyApplicationInsightsAgentInterceptVersion>2.0.1</LegacyApplicationInsightsAgentInterceptVersion>
         <MicroBuildCoreVersion>0.4.1</MicroBuildCoreVersion>
-        <MicrosoftNETTestSdkVersion>17.1.0</MicrosoftNETTestSdkVersion>
+        <MicrosoftNETTestSdkVersion>17.0.0</MicrosoftNETTestSdkVersion>
         <MSTestTestAdapterVersion>2.1.2</MSTestTestAdapterVersion>
         <MSTestTestFrameworkVersion>2.1.2</MSTestTestFrameworkVersion>
         <NETFrameworkReferenceVersion>1.0.2</NETFrameworkReferenceVersion>

--- a/build/CommonBuild.Private.props
+++ b/build/CommonBuild.Private.props
@@ -50,6 +50,7 @@
         <MicrosoftNETTestSdkVersion>16.9.1</MicrosoftNETTestSdkVersion>
         <MSTestTestAdapterVersion>2.1.2</MSTestTestAdapterVersion>
         <MSTestTestFrameworkVersion>2.1.2</MSTestTestFrameworkVersion>
+        <NETFrameworkReferenceVersion>1.0.2</NETFrameworkReferenceVersion>
         <WixVersion>3.11.1</WixVersion>
     </PropertyGroup>
 

--- a/build/Unmanaged.props
+++ b/build/Unmanaged.props
@@ -48,8 +48,8 @@
     <UseOfAtl>Static</UseOfAtl>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>Unicode</CharacterSet>
-    <PlatformToolset>v142</PlatformToolset>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <PlatformToolset>v143</PlatformToolset>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup Label="Configuration" Condition="'$(Configuration)'=='Release'">

--- a/build/yaml/jobs/codeanalysis/apiscan.yaml
+++ b/build/yaml/jobs/codeanalysis/apiscan.yaml
@@ -13,7 +13,7 @@ jobs:
   # No dependencies. Requires Build Stages to ensure that binaries are built
 
   pool:
-    name: VSEngSS-MicroBuild2019-1ES
+    name: VSEngSS-MicroBuild2022-1ES
     demands:
     - msbuild
     - visualstudio

--- a/build/yaml/jobs/codeanalysis/binskim.yaml
+++ b/build/yaml/jobs/codeanalysis/binskim.yaml
@@ -11,7 +11,7 @@ jobs:
   # No dependencies. Requires Build Stages to ensure that binaries are built
 
   pool:
-    name: VSEngSS-MicroBuild2019-1ES
+    name: VSEngSS-MicroBuild2022-1ES
 
   workspace:
     clean: all

--- a/build/yaml/jobs/codeanalysis/buildanalyzer.yaml
+++ b/build/yaml/jobs/codeanalysis/buildanalyzer.yaml
@@ -13,7 +13,7 @@ jobs:
   displayName: Run build analyzer (${{ parameters.Analyzer }}, ${{ parameters.Platform }})
 
   pool:
-      name: VSEngSS-MicroBuild2019-1ES
+      name: VSEngSS-MicroBuild2022-1ES
       demands:
       - msbuild
       - vstest

--- a/build/yaml/jobs/codeanalysis/policheck.yaml
+++ b/build/yaml/jobs/codeanalysis/policheck.yaml
@@ -9,7 +9,7 @@ jobs:
   displayName: Code Analysis - PoliCheck
 
   pool:
-    name: VSEngSS-MicroBuild2019-1ES
+    name: VSEngSS-MicroBuild2022-1ES
 
   workspace:
     clean: all

--- a/build/yaml/jobs/linux/packages.yaml
+++ b/build/yaml/jobs/linux/packages.yaml
@@ -18,12 +18,12 @@ jobs:
 
   pool:
     ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
-      name: VSEngSS-MicroBuild2019-1ES
+      name: VSEngSS-MicroBuild2022-1ES
       demands:
       - msbuild
       - vstest
     ${{ if not(eq('true', parameters.IsMicroBuildInternal)) }}:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
   workspace:
     clean: outputs

--- a/build/yaml/jobs/postpackage.yaml
+++ b/build/yaml/jobs/postpackage.yaml
@@ -11,7 +11,7 @@ jobs:
     Packaging.EnableSBOMSigning: true
 
   pool:
-    name: VSEngSS-MicroBuild2019-1ES
+    name: VSEngSS-MicroBuild2022-1ES
 
   workspace:
     clean: outputs

--- a/build/yaml/jobs/windows/binaries.yaml
+++ b/build/yaml/jobs/windows/binaries.yaml
@@ -23,12 +23,12 @@ jobs:
 
   pool:
     ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
-      name: VSEngSS-MicroBuild2019-1ES
+      name: VSEngSS-MicroBuild2022-1ES
       demands:
       - msbuild
       - vstest
     ${{ if not(eq('true', parameters.IsMicroBuildInternal)) }}:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
   workspace:
     clean: outputs

--- a/build/yaml/jobs/windows/packages.yaml
+++ b/build/yaml/jobs/windows/packages.yaml
@@ -17,12 +17,12 @@ jobs:
       ${{ insert }}: ${{ parameters.MatrixStrategy }}
   pool:
     ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
-      name: VSEngSS-MicroBuild2019-1ES
+      name: VSEngSS-MicroBuild2022-1ES
       demands:
       - msbuild
       - vstest
     ${{ if not(eq('true', parameters.IsMicroBuildInternal)) }}:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
   workspace:
     clean: outputs

--- a/build/yaml/jobs/windows/tests.yaml
+++ b/build/yaml/jobs/windows/tests.yaml
@@ -18,12 +18,12 @@ jobs:
 
   pool:
     ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
-      name: VSEngSS-MicroBuild2019-1ES
+      name: VSEngSS-MicroBuild2022-1ES
       demands:
       - msbuild
       - vstest
     ${{ if not(eq('true', parameters.IsMicroBuildInternal)) }}:
-      vmImage: windows-2019
+      vmImage: windows-2022
 
   workspace:
     clean: outputs

--- a/build/yaml/steps/codeanalysis/cpp.yaml
+++ b/build/yaml/steps/codeanalysis/cpp.yaml
@@ -13,5 +13,5 @@ steps:
     language: cpp
     continueOnError: true
     condition: succeeded()
-    buildCommandsString: '"%ProgramFiles(x86)%\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && msbuild $(Build.SourcesDirectory)\InstrumentationEngine.sln /t:rebuild /p:Platform=$(Platform) /p:Configuration=$(Configuration)'
+    buildCommandsString: '"%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && msbuild $(Build.SourcesDirectory)\InstrumentationEngine.sln /t:rebuild /p:Platform=$(Platform) /p:Configuration=$(Configuration)'
 

--- a/build/yaml/steps/windows/binaries.yaml
+++ b/build/yaml/steps/windows/binaries.yaml
@@ -27,7 +27,7 @@ steps:
   displayName: 'Build InstrumentationEngine.sln'
   inputs:
     solution: InstrumentationEngine.sln
-    msbuildVersion: 16.0
+    msbuildVersion: 17.0
     platform: $(Platform)
     configuration: $(Configuration)
     msbuildArguments: /bl:"$(Build.ArtifactStagingDirectory)\logs\Build_Windows_$(Platform)_$(Configuration).binlog"

--- a/build/yaml/steps/windows/packages.yaml
+++ b/build/yaml/steps/windows/packages.yaml
@@ -22,7 +22,7 @@ steps:
   displayName: 'Build solution InstrumentationEngine.Packages.sln $(Platform)'
   inputs:
     solution: src/InstrumentationEngine.Packages.sln
-    msbuildVersion: 16.0
+    msbuildVersion: 17.0
     platform: $(Platform)
     configuration: $(Configuration)
     msbuildArguments: '/p:InputBinCfgRoot="${{ parameters.WindowsBinRoot }}" /bl:"$(Build.ArtifactStagingDirectory)\logs\Package_Windows_$(LogPlatform)_$(Configuration).binlog"'

--- a/build/yaml/steps/windows/vstest.yaml
+++ b/build/yaml/steps/windows/vstest.yaml
@@ -8,12 +8,13 @@ parameters:
   RunTitle: ''
 
 steps:
+# https://github.com/microsoft/azure-pipelines-tasks/issues/15537
+# Don't specify VsTestVersion
 - task: VSTest@2
   displayName: 'Run Tests: $(Platform)\${{ parameters.SubFolder }}*Tests*.dll'
   inputs:
     testAssemblyVer2: '${{ parameters.SubFolder }}*Tests*.dll'
     searchFolder: '$(Build.ArtifactStagingDirectory)\binaries-windows-$(Configuration)\$(Platform)'
-    vsTestVersion: 17.0
     runInParallel: false
     codeCoverageEnabled: false
     runSettingsFile: tests/TestSettings/$(RunSettingsFile)

--- a/build/yaml/steps/windows/vstest.yaml
+++ b/build/yaml/steps/windows/vstest.yaml
@@ -13,7 +13,7 @@ steps:
   inputs:
     testAssemblyVer2: '${{ parameters.SubFolder }}*Tests*.dll'
     searchFolder: '$(Build.ArtifactStagingDirectory)\binaries-windows-$(Configuration)\$(Platform)'
-    vsTestVersion: 16.0
+    vsTestVersion: 17.0
     runInParallel: false
     codeCoverageEnabled: false
     runSettingsFile: tests/TestSettings/$(RunSettingsFile)

--- a/docs/build.md
+++ b/docs/build.md
@@ -40,13 +40,13 @@ testing with both our internal Microsoft products as well as the products of ext
 ### Windows
 
 On Windows we use MSBuild, with `.vcxproj` files to build native binaries and `.csproj` files to build the NuGet/Zip packages.
-1. Install Visual Studio 2019 with the following Workloads and Components:
+1. Install Visual Studio 2022 with the following Workloads and Components:
     - **[Workload]** .NET desktop development
     - **[Workload]** Desktop development with C++
-    - **[Component]** Windows 10 SDK (10.0.18362)
-    - **[Component]** Visual C++ ATL for x86 and x64
-    - **[Component]** VC++ 2019 version v14.2x Libs for Spectre (x86 and x64)
-2. Open `InstrumentationEngine.sln` and `src/InstrumentationEngine.Packages.sln` in Visual Studio 2019
+    - **[Component]** Windows 10 SDK (latest)
+    - **[Component]** C++ ATL for latest v143 build tools with Spectre Mitigations (x86 & x64)
+    - **[Component]** MSVC v143 - VS 2022 C++ x64/x86 Spectre-mitigated libs (Latest)
+2. Open `InstrumentationEngine.sln` and `src/InstrumentationEngine.Packages.sln` in Visual Studio 2022
 3. Either run "Build Solution" for a single configuration, or "Build > Batch Build..." to build all configurations
 (Debug|Release with x86|x64|AnyCPU).
 

--- a/src/Common.Lib/Common.Lib.vcxproj
+++ b/src/Common.Lib/Common.Lib.vcxproj
@@ -33,12 +33,12 @@
     <ProjectGuid>{A0585FAB-548F-44B3-BCBE-9242CBC26A19}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>CommonLib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(EnlistmentRoot)\build\ClrInstrumentationEngine.cpp.props" />

--- a/src/Dependencies/LegacyDependencies.csproj
+++ b/src/Dependencies/LegacyDependencies.csproj
@@ -20,7 +20,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\build\Common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept" Version="$(LegacyApplicationInsightsAgentInterceptVersion)">

--- a/src/Dependencies/NativeDependencies.csproj
+++ b/src/Dependencies/NativeDependencies.csproj
@@ -32,7 +32,7 @@
     </When>
     <Otherwise>
       <PropertyGroup>
-        <TargetFramework>net461</TargetFramework>
+        <TargetFramework>net462</TargetFramework>
       </PropertyGroup>
       <ItemGroup>
         <PackageReference Include="Microsoft.ApplicationInsights.Agent.Intercept" Version="$(ApplicationInsightsAgentInterceptVersion)">

--- a/src/Dependencies/NativeTestDependencies.csproj
+++ b/src/Dependencies/NativeTestDependencies.csproj
@@ -20,7 +20,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\build\Common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.googletest.v140.windesktop.msvcstl.static.rt-static" Version="1.8.1.3">

--- a/src/Dependencies/WixDependencies.csproj
+++ b/src/Dependencies/WixDependencies.csproj
@@ -20,7 +20,7 @@
   <Import Project="$(MSBuildThisFileDirectory)..\..\build\Common.props" />
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Wix" Version="$(WixVersion)" />

--- a/src/Extensions.Base.Api.Tests/Extensions.Base.Api.Tests.csproj
+++ b/src/Extensions.Base.Api.Tests/Extensions.Base.Api.Tests.csproj
@@ -6,7 +6,7 @@
   <PropertyGroup>
     <RootNamespace>Extensions.Base.Api.Tests</RootNamespace>
     <AssemblyName>Extensions.Base.Api.Tests</AssemblyName>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
   </PropertyGroup>
   <ItemGroup>
@@ -16,6 +16,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="$(NETFrameworkReferenceVersion)" />
   </ItemGroup>
   <Import Project="$(EnlistmentRoot)\build\Managed.targets" />
 </Project>

--- a/src/Extensions.Base.Api/Extensions.Base.Api.csproj
+++ b/src/Extensions.Base.Api/Extensions.Base.Api.csproj
@@ -6,10 +6,9 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.Diagnostics.Instrumentation.Extensions.Base</RootNamespace>
     <AssemblyName>Microsoft.Diagnostics.Instrumentation.Extensions.Base</AssemblyName>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
     <NoStdLib>true</NoStdLib>
     <ShouldSign>true</ShouldSign>
     <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>
@@ -83,6 +82,9 @@
     </Compile>
   </ItemGroup>
   <Import Project="$(EnlistmentRoot)\build\Managed.targets" />
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net40" Version="$(NETFrameworkReferenceVersion)" />
+  </ItemGroup>
   <Target Name="BeforeBuild">
     <Error Text="Unsupported platform: $(Platform)" Condition="'$(Platform)' != 'AnyCPU'" />
     <Error Text="Unsupported configuration: $(Configuration)" Condition="'$(Configuration)' != 'Debug' And '$(Configuration)' != 'Release'" />

--- a/src/InstrumentationEngine.Api/InstrumentationEngine.Api.vcxproj
+++ b/src/InstrumentationEngine.Api/InstrumentationEngine.Api.vcxproj
@@ -36,12 +36,12 @@
     <ProjectGuid>{D68DA75E-9194-44CB-9196-FF7FDC7EA3D5}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>InstrumentationEngine.Api</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(EnlistmentRoot)\build\ClrInstrumentationEngine.cpp.props" />

--- a/src/InstrumentationEngine.Lib/InstrumentationEngine.Lib.vcxproj
+++ b/src/InstrumentationEngine.Lib/InstrumentationEngine.Lib.vcxproj
@@ -33,12 +33,12 @@
     <ProjectGuid>{7507E5DD-D4D8-4617-9124-A76341004AAB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>InstrumentationEngine.Lib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(EnlistmentRoot)\build\ClrInstrumentationEngine.cpp.props" />

--- a/src/InstrumentationEngine.ProfilerProxy.Lib/InstrumentationEngine.ProfilerProxy.Lib.vcxproj
+++ b/src/InstrumentationEngine.ProfilerProxy.Lib/InstrumentationEngine.ProfilerProxy.Lib.vcxproj
@@ -33,12 +33,12 @@
     <ProjectGuid>{dab53f24-d55a-4759-b100-5b7fefbf6d08}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>InstrumentationEngineProfilerProxyLib</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Label="Configuration">
     <ConfigurationType>StaticLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(EnlistmentRoot)\build\ClrInstrumentationEngine.cpp.props" />

--- a/src/InstrumentationEngine.ProfilerProxy/InstrumentationEngine.ProfilerProxy.vcxproj
+++ b/src/InstrumentationEngine.ProfilerProxy/InstrumentationEngine.ProfilerProxy.vcxproj
@@ -43,9 +43,9 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{78F69D10-7F29-4645-AD77-91A2D06FF7F4}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <RootNamespace>CLRInstrumentationEngineProfilerProxy</RootNamespace>
     <RC_VERSION_FILE_DESCRIPTION>CLR Instrumentation Engine Profiler Proxy</RC_VERSION_FILE_DESCRIPTION>

--- a/src/InstrumentationEngine/InstrumentationEngine.vcxproj
+++ b/src/InstrumentationEngine/InstrumentationEngine.vcxproj
@@ -33,9 +33,9 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{659CA07D-C239-48EF-B5F1-E8C7D96916CB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <RC_VERSION_FILE_DESCRIPTION>Microsoft Instrumentation Engine</RC_VERSION_FILE_DESCRIPTION>
   </PropertyGroup>

--- a/src/Tests/CommonLibTests/CommonLibTests.vcxproj
+++ b/src/Tests/CommonLibTests/CommonLibTests.vcxproj
@@ -33,9 +33,9 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{df259ed5-4041-4089-8a55-d0c7e695ee3c}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/Tests/InstrEngineTests/InstrEngineTests/InstrEngineTests.csproj
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/InstrEngineTests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'EnlistmentRoot.marker'))\build\Managed.props" />
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1;net50;net60</TargetFrameworks>
+    <TargetFrameworks>net462;netcoreapp3.1;net50;net60</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <RootNamespace>InstrEngineTests</RootNamespace>
   </PropertyGroup>

--- a/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.vcxproj
+++ b/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.vcxproj
@@ -46,7 +46,7 @@
   <PropertyGroup>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
     <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
     <IgnoreImportLibrary>true</IgnoreImportLibrary>
   </PropertyGroup>

--- a/src/Tests/InstrumentationEngineLibTests/InstrumentationEngineLibTests.vcxproj
+++ b/src/Tests/InstrumentationEngineLibTests/InstrumentationEngineLibTests.vcxproj
@@ -33,9 +33,9 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{B1FFBD51-80A9-41D6-BC54-07B7E0DE7CF6}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/src/Tests/RemoteUnitTestExecutor.Host/RemoteUnitTestExecutor.Host.csproj
+++ b/src/Tests/RemoteUnitTestExecutor.Host/RemoteUnitTestExecutor.Host.csproj
@@ -9,7 +9,7 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), EnlistmentRoot.marker))\build\Managed.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net45</TargetFrameworks>
+        <TargetFrameworks>net462</TargetFrameworks>
         <OutputType>Exe</OutputType>
         <AssemblyName>RemoteUnitTestExecutor.Host_x86</AssemblyName>
         <RootNamespace>RemoteUnitTestExecutor.Host</RootNamespace>
@@ -18,6 +18,10 @@
         <LangVersion>9.0</LangVersion>
         <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     </PropertyGroup>
+    
+    <ItemGroup>
+      <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="$(NETFrameworkReferenceVersion)" />
+    </ItemGroup>
 
     <Import Project="$(EnlistmentRoot)\build\Managed.targets" />
 </Project>

--- a/src/Tests/RemoteUnitTestExecutor/RemoteUnitTestExecutor.csproj
+++ b/src/Tests/RemoteUnitTestExecutor/RemoteUnitTestExecutor.csproj
@@ -8,7 +8,7 @@
     <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), EnlistmentRoot.marker))\build\Managed.props" />
 
     <PropertyGroup>
-        <TargetFrameworks>net45</TargetFrameworks>
+        <TargetFrameworks>net462</TargetFrameworks>
         <RuntimeIdentifiers>win7-x86</RuntimeIdentifiers>
         <OutputType>Exe</OutputType>
         <RootNamespace>RemoteUnitTestExecutor</RootNamespace>
@@ -24,6 +24,7 @@
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
         <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
         <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+        <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="$(NETFrameworkReferenceVersion)" />
     </ItemGroup>
 
     <Import Project="$(EnlistmentRoot)\build\Managed.targets" />

--- a/tests/ApplicationInsightsCompatibility/Intercept.2.0.1.Tests/Intercept.2.0.1.Tests.csproj
+++ b/tests/ApplicationInsightsCompatibility/Intercept.2.0.1.Tests/Intercept.2.0.1.Tests.csproj
@@ -16,7 +16,7 @@
     <Platforms>x64;x86;AnyCPU;ARM64</Platforms>
     <RootNamespace>Intercept_2_0_1.Tests</RootNamespace>
     <AssemblyName>Intercept.2.0.1.Tests_$(Platform)</AssemblyName>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PlatformTarget Condition="'$(Platform)'=='ARM64'">ARM64</PlatformTarget>
   </PropertyGroup>
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="$(NETFrameworkReferenceVersion)" />
   </ItemGroup>
   <Import Project="..\Intercept.Shared.Tests\Shared.projitems" Label="Shared" />
   <Import Project="$(EnlistmentRoot)\build\Managed.targets" />

--- a/tests/ApplicationInsightsCompatibility/Intercept.Latest.Tests/Intercept.Latest.Tests.csproj
+++ b/tests/ApplicationInsightsCompatibility/Intercept.Latest.Tests/Intercept.Latest.Tests.csproj
@@ -18,7 +18,7 @@
     <Platforms>x64;x86;AnyCPU;ARM64</Platforms>
     <RootNamespace>Intercept.Latest.Tests</RootNamespace>
     <AssemblyName>Intercept.Latest.Tests_$(Platform)</AssemblyName>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PlatformTarget Condition="'$(Platform)'=='ARM64'">ARM64</PlatformTarget>
   </PropertyGroup>
@@ -34,6 +34,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="$(NETFrameworkReferenceVersion)" />
   </ItemGroup>
   <Import Project="..\Intercept.Shared.Tests\Shared.projitems" Label="Shared" />
   <Import Project="$(EnlistmentRoot)\build\Managed.targets" />

--- a/tests/InstrumentationEngine.Lib.Tests/InstrumentationEngine.Lib.Tests.vcxproj
+++ b/tests/InstrumentationEngine.Lib.Tests/InstrumentationEngine.Lib.Tests.vcxproj
@@ -32,9 +32,9 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{91391A70-818D-442E-B847-7EA2F2C4B2C7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/tests/InstrumentationEngine.ProfilerProxy.Tests/InstrumentationEngine.ProfilerProxy.Tests.vcxproj
+++ b/tests/InstrumentationEngine.ProfilerProxy.Tests/InstrumentationEngine.ProfilerProxy.Tests.vcxproj
@@ -32,9 +32,9 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{1c6954d1-1a98-4149-8d2c-b0d49d03a832}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
-    <WindowsTargetPlatformVersion>10.0.18362.0</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v143</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />

--- a/tests/RawProfilerHook/RawProfilerHook.Tests/RawProfilerHook.Tests.csproj
+++ b/tests/RawProfilerHook/RawProfilerHook.Tests/RawProfilerHook.Tests.csproj
@@ -19,7 +19,7 @@
     <Platforms>x64;x86;AnyCPU;ARM64</Platforms>
     <RootNamespace>RawProfilerHook.Tests</RootNamespace>
     <AssemblyName>RawProfilerHook.Tests_$(Platform)</AssemblyName>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PlatformTarget Condition="'$(Platform)'=='ARM64'">ARM64</PlatformTarget>
   </PropertyGroup>
@@ -27,6 +27,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies.net45" Version="$(NETFrameworkReferenceVersion)" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Tests\RemoteUnitTestExecutor\RemoteUnitTestExecutor.csproj" />


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Migrate all references of VS2019 to VS2022

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Update docs
- Update buildscripts
- Update Projects with the following changes
  - TargetFramework 4.0 or 4.5 -> 4.6.2
  - Toolset version v142 -> v143
  - Windows SDK Version 10.0 (latest)

 ###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Local & pipeline builds