### PR TITLE
Fix StaticAnalysis build

### DIFF
--- a/build/yaml/steps/codeanalysis/cpp.yaml
+++ b/build/yaml/steps/codeanalysis/cpp.yaml
@@ -13,5 +13,5 @@ steps:
     language: cpp
     continueOnError: true
     condition: succeeded()
-    buildCommandsString: '"%ProgramFiles(x86)%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && msbuild $(Build.SourcesDirectory)\InstrumentationEngine.sln /t:rebuild /p:Platform=$(Platform) /p:Configuration=$(Configuration)'
+    buildCommandsString: '"%ProgramFiles%\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsMSBuildCmd.bat" && msbuild $(Build.SourcesDirectory)\InstrumentationEngine.sln /t:rebuild /p:Platform=$(Platform) /p:Configuration=$(Configuration)'
 

--- a/src/Common.Lib/systemstring.cpp
+++ b/src/Common.Lib/systemstring.cpp
@@ -27,7 +27,7 @@ namespace CommonLib
         }
     };
 
-    HRESULT ErrnoToHResult(int& err) 
+    HRESULT ErrnoToHResult(int& err)
     {
         HRESULT hr;
         switch (err)
@@ -44,7 +44,7 @@ namespace CommonLib
         return E_FAIL;
     }
 
-    HRESULT SystemString::Convert(_In_ const CHAR* lpzStr, _Inout_ tstring& result)
+    HRESULT SystemString::Convert(_In_z_ const CHAR* lpzStr, _Inout_ tstring& result)
     {
         if (lpzStr == nullptr)
         {
@@ -79,7 +79,7 @@ namespace CommonLib
         return S_OK;
     }
 
-    HRESULT SystemString::Convert(_In_ const WCHAR* lpzwStr, _Inout_ string& result)
+    HRESULT SystemString::Convert(_In_z_ const WCHAR* lpzwStr, _Inout_ string& result)
     {
         if (lpzwStr == nullptr)
         {
@@ -126,7 +126,7 @@ namespace CommonLib
 #else
 
 
-    HRESULT SystemString::Convert(_In_ const WCHAR* lpzwStr, _Inout_ string& result)
+    HRESULT SystemString::Convert(_In_z_ const WCHAR* lpzwStr, _Inout_ string& result)
     {
 
         // WideCharToMultiByte will null check lpzwStr, so we don't need to.
@@ -147,7 +147,7 @@ namespace CommonLib
         return HRESULT_FROM_WIN32(errorCode);
     }
 
-    HRESULT SystemString::Convert(_In_ const CHAR* lpzStr, _Inout_ tstring& result)
+    HRESULT SystemString::Convert(_In_z_ const CHAR* lpzStr, _Inout_ tstring& result)
     {
         // MultiByteToWideChar will null check lpzStr, so we don't need to.
         int required = MultiByteToWideChar(CP_UTF8, 0, lpzStr, /*null terminated*/ -1, nullptr, 0);

--- a/src/Common.Lib/systemstring.h
+++ b/src/Common.Lib/systemstring.h
@@ -20,7 +20,7 @@ namespace CommonLib
     /// or wide-character (Windows) strings. Useful for converting strings between
     /// Linux and Windows.
     /// </summary>
-    class SystemString 
+    class SystemString
     {
     public:
         /// <summary>
@@ -28,7 +28,7 @@ namespace CommonLib
         /// </summary>
         /// <param name="converted">The converted string</param>
         /// <returns>S_OK for success. Error code otherwise.</returns>
-        static HRESULT Convert(_In_ const WCHAR*, _Inout_ std::string& converted);
+        static HRESULT Convert(_In_z_ const WCHAR*, _Inout_ std::string& converted);
 
         /// <summary>
         /// Utility function to convert a UTF8 (Linux) string to a UTF16LE (Windows) string.
@@ -36,7 +36,7 @@ namespace CommonLib
         /// <param name="lpzStr">The input string.</param>
         /// <param name="result">The output string.</param>
         /// <returns>S_OK for success, error otherwise.</returns>
-        static HRESULT Convert(_In_ const CHAR* lpzStr, _Inout_ tstring& result);
+        static HRESULT Convert(_In_z_ const CHAR* lpzStr, _Inout_ tstring& result); // lgtm[cpp/inconsistentsal] SAL annoations match definition in cpp file
     };
 
 }

--- a/src/Common.Lib/systemstring.h
+++ b/src/Common.Lib/systemstring.h
@@ -36,7 +36,7 @@ namespace CommonLib
         /// <param name="lpzStr">The input string.</param>
         /// <param name="result">The output string.</param>
         /// <returns>S_OK for success, error otherwise.</returns>
-        static HRESULT Convert(_In_z_ const CHAR* lpzStr, _Inout_ tstring& result); // lgtm[cpp/inconsistentsal] SAL annoations match definition in cpp file
+        static HRESULT Convert(_In_z_ const CHAR* lpzStr, _Inout_ tstring& result); // lgtm[cpp/inconsistentsal] SAL annotations match definition in cpp file
     };
 
 }

--- a/src/InstrumentationEngine/ArrayType.cpp
+++ b/src/InstrumentationEngine/ArrayType.cpp
@@ -10,7 +10,7 @@ MicrosoftInstrumentationEngine::CArrayType::CArrayType(_In_ IType* relatedType, 
     DEFINE_REFCOUNT_NAME(CArrayType);
 }
 
-HRESULT MicrosoftInstrumentationEngine::CArrayType::AddToSignature(_In_ ISignatureBuilder* pSignatureBuilder)
+HRESULT MicrosoftInstrumentationEngine::CArrayType::AddToSignature(_In_ ISignatureBuilder* pSignatureBuilder) // lgtm[cpp/inconsistentsal] SAL annotations match declaration in h file
 {
     HRESULT hr = S_OK;
     IfFailRet(CCompositeType::AddToSignature(pSignatureBuilder));


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
VS2022 is 64bit so we need to pull from program files instead. Also dealt with some warnings.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Change path for vsmsbuildcmd.bat to ProgramFiles instead of ProgramFIles(x86)
- Add Semmle suppression for false positives

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Ran internal static analysis build