### PR TITLE
Added debug build and test to signed builds for tests

### DIFF
--- a/build/Managed.props
+++ b/build/Managed.props
@@ -21,6 +21,7 @@
 
   <PropertyGroup>
     <DefineConstants Condition="'$(PublicRelease)' != 'True'">$(DefineConstants);ALLOWNOTSIGNED</DefineConstants>
+    <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants;DEBUG</DefineConstants>
     <EnableNetAnalyzers>true</EnableNetAnalyzers>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis\Sdl.Recommended.Error.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>

--- a/build/yaml/pipelines/signed.yaml
+++ b/build/yaml/pipelines/signed.yaml
@@ -22,6 +22,22 @@ stages:
       Configuration: Release
       IsMicroBuildInternal: true
 
+stages:
+- stage: BuildDebug
+  jobs:
+  # Binaries (Windows & Linux)
+  - template: ../jobs/binaries.yaml
+    parameters:
+      Configuration: Both
+
+- stage: TestDebug
+  dependsOn: BuildDebug
+  jobs:
+  # Tests (Windows)
+  - template: ../jobs/tests.yaml
+    parameters:
+      Configuration: Both
+
 - stage: Package
   jobs:
   # Packages (Windows & Linux)

--- a/build/yaml/pipelines/signed.yaml
+++ b/build/yaml/pipelines/signed.yaml
@@ -12,6 +12,21 @@ variables:
   TeamName: ClrInstrumentationEngine
 
 stages:
+- stage: BuildDebug
+  jobs:
+  # Binaries (Windows & Linux)
+  - template: ../jobs/binaries.yaml
+    parameters:
+      Configuration: Debug
+
+- stage: TestDebug
+  dependsOn: BuildDebug
+  jobs:
+  # Tests (Windows)
+  - template: ../jobs/tests.yaml
+    parameters:
+      Configuration: Debug
+
 - stage: Build
   jobs:
   # Binaries (Windows & Linux)
@@ -21,21 +36,6 @@ stages:
       SignType: $(SignType) # NOTE this string won't be replaced until runtime
       Configuration: Release
       IsMicroBuildInternal: true
-
-- stage: BuildDebug
-  jobs:
-  # Binaries (Windows & Linux)
-  - template: ../jobs/binaries.yaml
-    parameters:
-      Configuration: Both
-
-- stage: TestDebug
-  dependsOn: BuildDebug
-  jobs:
-  # Tests (Windows)
-  - template: ../jobs/tests.yaml
-    parameters:
-      Configuration: Both
 
 - stage: Package
   jobs:

--- a/build/yaml/pipelines/signed.yaml
+++ b/build/yaml/pipelines/signed.yaml
@@ -18,7 +18,7 @@ stages:
   - template: ../jobs/binaries.yaml
     parameters:
       Configuration: Debug
-      SignType: $(SignType)
+      SignType: None # Specifically never sign debug builds
 
 - stage: TestDebug
   dependsOn: BuildDebug

--- a/build/yaml/pipelines/signed.yaml
+++ b/build/yaml/pipelines/signed.yaml
@@ -22,7 +22,6 @@ stages:
       Configuration: Release
       IsMicroBuildInternal: true
 
-stages:
 - stage: BuildDebug
   jobs:
   # Binaries (Windows & Linux)

--- a/build/yaml/pipelines/signed.yaml
+++ b/build/yaml/pipelines/signed.yaml
@@ -18,6 +18,7 @@ stages:
   - template: ../jobs/binaries.yaml
     parameters:
       Configuration: Debug
+      SignType: $(SignType)
 
 - stage: TestDebug
   dependsOn: BuildDebug

--- a/tests/ApplicationInsightsCompatibility/Intercept.Shared.Tests/TestEngine.cs
+++ b/tests/ApplicationInsightsCompatibility/Intercept.Shared.Tests/TestEngine.cs
@@ -49,7 +49,7 @@ namespace ApplicationInsightsCompatibility
             vars.Add("MicrosoftInstrumentationEngine_FileLog",  "Dumps|Errors");
             //vars.Add("MicrosoftInstrumentationEngine_FileLogPath", ""); //can be overridden if needed
 
-#if ALLOWNOTSIGNED
+#if ALLOWNOTSIGNED || DEBUG
             vars.Add("MicrosoftInstrumentationEngine_DisableCodeSignatureValidation", "1");
 #endif
         }

--- a/tests/RawProfilerHook/RawProfilerHook.Tests/TestEngine/TestEngine.cs
+++ b/tests/RawProfilerHook/RawProfilerHook.Tests/TestEngine/TestEngine.cs
@@ -98,7 +98,7 @@ namespace RawProfilerHook.Tests
                 { "MicrosoftInstrumentationEngine_FileLog", "Dumps|Errors" },
                 { "MicrosoftInstrumentationEngine_FileLogPath", traceFilePath },
                 { "MicrosoftInstrumentationEngine_UserBuffer", "1" }
-#if ALLOWNOTSIGNED
+#if ALLOWNOTSIGNED || DEBUG
                 , { "MicrosoftInstrumentationEngine_DisableCodeSignatureValidation", "1"}
 #endif
             };


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Added build and test stages for debug builds when running signed builds. While it'd be best to just test release builds, there's a problem with some file generation there right now so this is the temporary solution to allow us to test something during the signed builds.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Added BuildDebug and TestDebug steps in signed.yaml, as extra unsigned builds.
- updated tests to always have _MicrosoftInstrumentationEngine_DisableCodeSignatureValidation = 1_ flag when running debug builds as the lack of this flag was causing test failures.
- As a side note: the _SignType: None_ piece of the yaml file is more formality as by default it's already set to none, but figured it would be good to be specific there.


###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->

