### PR TITLE
Build in the latest VS Preview

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,3 +12,16 @@ indent_style = space
 indent_size = 4
 end_of_line = crlf
 trim_trailing_whitespace = true
+
+[{*.cs, *.vb}]
+dotnet_diagnostic.CA1707.severity = none
+dotnet_diagnostic.CA1852.severity = none
+dotnet_diagnostic.CA1014.severity = none
+dotnet_diagnostic.CA1805.severity = none
+dotnet_diagnostic.CA1502.severity = none
+dotnet_diagnostic.CA1813.severity = none
+dotnet_diagnostic.CA5392.severity = none
+dotnet_diagnostic.CA1822.severity = none
+dotnet_diagnostic.CA1016.severity = none
+dotnet_diagnostic.CA1031.severity = none
+dotnet_diagnostic.CA1711.severity = none

--- a/InstrumentationEngine.sln
+++ b/InstrumentationEngine.sln
@@ -20,6 +20,7 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "InstrumentationEngine.Lib.T
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{0574D1C6-A8BE-436A-A25F-7954F6515CDA}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		CHANGELOG.md = CHANGELOG.md
 	EndProjectSection
 EndProject
@@ -84,12 +85,6 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RemoteUnitTestExecutor.Host", "src\Tests\RemoteUnitTestExecutor.Host\RemoteUnitTestExecutor.Host.csproj", "{F356AF58-F432-415D-BE13-44228F265CEF}"
 EndProject
 Global
-	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\Common.Headers\Common.Headers.vcxitems*{0d4a6caa-80d9-4e41-859f-c14205fd45c4}*SharedItemsImports = 9
-		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{c1aaa703-5e32-45c0-a69d-f46d1c659ae4}*SharedItemsImports = 13
-		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{e4d25b2c-e362-4660-a2fd-ada2b7c1fd77}*SharedItemsImports = 5
-		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{ead25b2c-e362-4660-a2fd-ad82b7c1fd77}*SharedItemsImports = 5
-	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		CodeAnalysis.Managed|Any CPU = CodeAnalysis.Managed|Any CPU
 		CodeAnalysis.Managed|ARM64 = CodeAnalysis.Managed|ARM64
@@ -783,5 +778,11 @@ Global
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {16628EC2-6C46-4DEF-B260-8848FC916254}
+	EndGlobalSection
+	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\Common.Headers\Common.Headers.vcxitems*{0d4a6caa-80d9-4e41-859f-c14205fd45c4}*SharedItemsImports = 9
+		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{c1aaa703-5e32-45c0-a69d-f46d1c659ae4}*SharedItemsImports = 13
+		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{e4d25b2c-e362-4660-a2fd-ada2b7c1fd77}*SharedItemsImports = 5
+		tests\ApplicationInsightsCompatibility\Intercept.Shared.Tests\Shared.projitems*{ead25b2c-e362-4660-a2fd-ad82b7c1fd77}*SharedItemsImports = 5
 	EndGlobalSection
 EndGlobal

--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,12 @@
 <configuration>
     <packageSources>
         <clear />
+        <!-- Multiple package sources are required because the dotnet build tools need to be able to download SDKs from NuGet -->
         <add key="DNCENG-CoreClrPal" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/CoreClrPal/nuget/v3/index.json" />
+        <add key="dotnet31" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet3.1/nuget/v3/index.json" />
+        <add key="dotnet5" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet5/nuget/v3/index.json" />
+        <add key="dotnet6" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet6/nuget/v3/index.json" />
+        <add key="dotnet7" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet7/nuget/v3/index.json" />
     </packageSources>
     <activePackageSource>
         <add key="All" value="(Aggregate source)" />

--- a/build/Managed.props
+++ b/build/Managed.props
@@ -21,7 +21,7 @@
 
   <PropertyGroup>
     <DefineConstants Condition="'$(PublicRelease)' != 'True'">$(DefineConstants);ALLOWNOTSIGNED</DefineConstants>
-    <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants;DEBUG</DefineConstants>
+    <DefineConstants Condition="'$(Configuration)' == 'Debug'">$(DefineConstants);DEBUG</DefineConstants>
     <EnableNetAnalyzers>true</EnableNetAnalyzers>
     <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)CodeAnalysis\Sdl.Recommended.Error.ruleset</CodeAnalysisRuleSet>
     <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>

--- a/src/Extensions.Base.Api.Tests/ExtensionsBaseCallbacks.cs
+++ b/src/Extensions.Base.Api.Tests/ExtensionsBaseCallbacks.cs
@@ -19,6 +19,8 @@ namespace ProfilerCallbacksTests
 
         private readonly object thisObj = new object();
         private readonly object returnValue = new object();
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "CA2201:Do not raise reserved exception types", Justification = "This is specifically used for test code.")]
         private readonly Exception exception = new Exception();
 
         private CallbackStubIsCalled callbacksStub;

--- a/src/Extensions.Base.Api/PublicContract.cs
+++ b/src/Extensions.Base.Api/PublicContract.cs
@@ -344,6 +344,7 @@ namespace _System.Diagnostics
             }
         }
 
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "CA1502:Method has cyclomatic complexity of '29'", Justification = "This function is not changed often, and should not be updated.")]
         public static void ApplicationInsights_RemoveCallbacks(int methodId, int argsCount)
         {
             switch (argsCount)

--- a/src/InstrumentationEngine.Attach/NativeMethods.cs
+++ b/src/InstrumentationEngine.Attach/NativeMethods.cs
@@ -10,6 +10,7 @@ namespace Microsoft.InstrumentationEngine
     {
         [DllImport("kernel32.dll", SetLastError = true)]
         [return: MarshalAs(UnmanagedType.Bool)]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Security", "CA5392:Use DefaultDllImportSearchPaths attribute for P/Invokes", Justification = "Function exists in kernel32.dll, which has special loading logic controlled by the kernel.")]
         public static extern bool IsWow64Process([In] IntPtr hProcess, [Out] out bool wow64Process);
     }
 }

--- a/src/Tests/InstrEngineTests/InstrEngineTests/NativeMethods.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/NativeMethods.cs
@@ -9,10 +9,15 @@ namespace InstrEngineTests
 {
     internal class NativeMethods
     {
+
+        // Disable warning because kernel32.dll has special loading logic in the kernel
+#pragma warning disable CA5392 // Use DefaultDllImportSearchPaths attribute for P/Invokes
         [DllImport("kernel32.dll")]
         public static extern int GetComPlusPackageInstallStatus();
 
         [DllImport("kernel32.dll")]
         public static extern bool SetComPlusPackageInstallStatus(int flag);
+
+#pragma warning restore CA5392 // Use DefaultDllImportSearchPaths attribute for P/Invokes
     }
 }

--- a/src/Tests/RemoteUnitTestExecutor.Host/RemoteUnitTestExecutor.Host.csproj
+++ b/src/Tests/RemoteUnitTestExecutor.Host/RemoteUnitTestExecutor.Host.csproj
@@ -11,7 +11,7 @@
     <PropertyGroup>
         <TargetFrameworks>net462</TargetFrameworks>
         <OutputType>Exe</OutputType>
-        <AssemblyName>RemoteUnitTestExecutor.Host_x86</AssemblyName>
+        <AssemblyName>RemoteUnitTestExecutor.Host.x86</AssemblyName>
         <RootNamespace>RemoteUnitTestExecutor.Host</RootNamespace>
         <!-- Make assembly PE32 (32-bit PE header; forces .NET Framework 32-bit) -->
         <PlatformTarget>x86</PlatformTarget>

--- a/src/Tests/RemoteUnitTestExecutor/Program.cs
+++ b/src/Tests/RemoteUnitTestExecutor/Program.cs
@@ -1,6 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+#pragma warning disable CA1303 // Do not pass literals as localized parameters
+
 namespace RemoteUnitTestExecutor
 {
     using System;

--- a/src/Tests/RemoteUnitTestExecutor/TestBase.cs
+++ b/src/Tests/RemoteUnitTestExecutor/TestBase.cs
@@ -9,7 +9,7 @@ namespace RemoteUnitTestExecutor
     /// </summary>
     public abstract class TestBase : ITestBase
     {
-        public TestBase()
+        protected TestBase()
         {
             TestResult = new TestResult();
         }

--- a/tests/ApplicationInsightsCompatibility/Intercept.2.0.1.Tests/Intercept.2.0.1.Tests.csproj
+++ b/tests/ApplicationInsightsCompatibility/Intercept.2.0.1.Tests/Intercept.2.0.1.Tests.csproj
@@ -15,7 +15,7 @@
   <PropertyGroup>
     <Platforms>x64;x86;AnyCPU;ARM64</Platforms>
     <RootNamespace>Intercept_2_0_1.Tests</RootNamespace>
-    <AssemblyName>Intercept.2.0.1.Tests_$(Platform)</AssemblyName>
+    <AssemblyName>Intercept.2.0.1.Tests.$(Platform)</AssemblyName>
     <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PlatformTarget Condition="'$(Platform)'=='ARM64'">ARM64</PlatformTarget>

--- a/tests/ApplicationInsightsCompatibility/Intercept.Latest.Tests/Intercept.Latest.Tests.csproj
+++ b/tests/ApplicationInsightsCompatibility/Intercept.Latest.Tests/Intercept.Latest.Tests.csproj
@@ -8,16 +8,16 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), EnlistmentRoot.marker))\build\Managed.props" />
   <PropertyGroup Condition="'$(Platform)' == 'x86'">
     <DefineConstants>$(DefineConstants);X86</DefineConstants>
-    <AssemblyName>Intercept.Latest.Tests_x86</AssemblyName>
+    <AssemblyName>Intercept.Latest.Tests.x86</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Platform)' == 'x64'">
     <DefineConstants>$(DefineConstants);X64</DefineConstants>
-    <AssemblyName>Intercept.Latest.Tests_x64</AssemblyName>
+    <AssemblyName>Intercept.Latest.Tests.x64</AssemblyName>
   </PropertyGroup>
   <PropertyGroup>
     <Platforms>x64;x86;AnyCPU;ARM64</Platforms>
     <RootNamespace>Intercept.Latest.Tests</RootNamespace>
-    <AssemblyName>Intercept.Latest.Tests_$(Platform)</AssemblyName>
+    <AssemblyName>Intercept.Latest.Tests.$(Platform)</AssemblyName>
     <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PlatformTarget Condition="'$(Platform)'=='ARM64'">ARM64</PlatformTarget>

--- a/tests/RawProfilerHook/RawProfilerHook.Tests/RawProfilerHook.Tests.csproj
+++ b/tests/RawProfilerHook/RawProfilerHook.Tests/RawProfilerHook.Tests.csproj
@@ -18,7 +18,7 @@
   <PropertyGroup>
     <Platforms>x64;x86;AnyCPU;ARM64</Platforms>
     <RootNamespace>RawProfilerHook.Tests</RootNamespace>
-    <AssemblyName>RawProfilerHook.Tests_$(Platform)</AssemblyName>
+    <AssemblyName>RawProfilerHook.Tests.$(Platform)</AssemblyName>
     <TargetFramework>net462</TargetFramework>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
     <PlatformTarget Condition="'$(Platform)'=='ARM64'">ARM64</PlatformTarget>

--- a/tests/RawProfilerHook/RawProfilerHook/CoRawProfilerHook.cpp
+++ b/tests/RawProfilerHook/RawProfilerHook/CoRawProfilerHook.cpp
@@ -75,7 +75,7 @@ HRESULT STDMETHODCALLTYPE CCoRawProfilerHook::ModuleLoadFinished(
     WCHAR modName[MAX_PATH];
     HRESULT hr = S_OK;
 
-    const WCHAR* testModuleName = L"RawProfilerHook.Tests_x"
+    const WCHAR* testModuleName = L"RawProfilerHook.Tests.x"
 #if defined(_X86_)
         L"86"
 #else


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Build in the latest VS Preview

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Add dotnet nuget feeds to nuget.config
  This is needed because the dotnet build tools frequently
  update, and we need access to newer SDKs. It is not
  feasible to continue to upload packages from nuget.org to
  our own feed.
- Fix some issues with code analysis.
  The VS code analysis tools are moving away from ruleset
  suppressions, and toward suppressions in code and in .editorconfig
  files. We add our global suppressions to the .editorconfig,
  and make some more targeted suppressions inside the affected
  code, or fix the error found by code analysis. The ruleset is
  still here for compatibility with older VS.
- Change the <Assembly>_<arch> projects to be <Assembly>.<arch>
  instead. This is due to a bug in codeanalysis, which is no
  longer suppressing the rule that disallows underscores in
  assembly names. Since this is blocking our build, and the
  rule only applies to our test binaries, this PR just works
  around the bug.


###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Local build, all automated tests pass.