### PR TITLE
Assemble IL in Embedded Resources

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,6 +12,7 @@ indent_style = space
 indent_size = 4
 end_of_line = crlf
 trim_trailing_whitespace = true
+file_header_template = Copyright (c) Microsoft Corporation. All rights reserved.\nLicensed under the MIT License.
 
 [{*.cs, *.vb}]
 dotnet_diagnostic.CA1707.severity = none
@@ -25,3 +26,6 @@ dotnet_diagnostic.CA1822.severity = none
 dotnet_diagnostic.CA1016.severity = none
 dotnet_diagnostic.CA1031.severity = none
 dotnet_diagnostic.CA1711.severity = none
+
+[{*.csproj, *.vcxproj, *.xml}]
+indent_size = 2

--- a/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResourceUtils.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResourceUtils.cs
@@ -1,0 +1,160 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Security;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InstrEngineTests
+{
+
+    /// <summary>
+    /// A temporary file that was extracted from an embedded resource. The file will
+    /// be placed in a folder under the test's profile directory.
+    /// </summary>
+    internal interface IEmbeddedResourceFile
+    {
+        /// <summary>
+        /// Path to the extracted file.
+        /// </summary>
+        string FilePath { get; }
+
+        /// <summary>
+        /// The original name of the resource.
+        /// </summary>
+
+        string ResourceName { get; }
+    }
+
+    internal class EmbeddedResourceUtils
+    {
+
+        private const string EmbeddedResourcesPath = "InstrEngineTests.EmbeddedResources";
+        private static readonly object ExtractionLock = new object();
+
+        /// <inheritdoc/>
+        internal class EmbeddedResourceFile : IEmbeddedResourceFile
+        {
+            private FileInfo _tempFile;
+
+            /// <inheritdoc/> 
+            public string FilePath => _tempFile.FullName;
+
+            /// <inheritdoc/>
+            public string ResourceName { get; }
+
+            public EmbeddedResourceFile(FileInfo tempFile, string resourceName)
+            {
+                _tempFile = tempFile;
+                ResourceName = resourceName;
+            }
+
+            internal void CopyFromStream(Stream stream)
+            {
+                using (var writeStream = _tempFile.Open(FileMode.CreateNew, FileAccess.Write, FileShare.Read))
+                {
+                    stream.CopyTo(writeStream);
+                }
+            }
+        }
+
+        public static string ReadEmbeddedResourceFile(string file, bool required = true)
+        {
+            Stream stream = GetEmbeddedResource(file, required);
+            if (stream == null)
+            {
+                return null;
+            }
+
+            using (StreamReader reader = new StreamReader(stream))
+            {
+                return reader.ReadToEnd();
+            }
+        }
+
+        /// <summary>
+        /// Looks for the given embedded resource, and extracts it to the test assets folder.
+        /// If the file was previously extracted, it is not overwritten.
+        /// </summary>
+        /// <param name="resourceName">The name of the resource.</param>
+        /// <param name="required">True if an error should occur when the resource is not found.</param>
+        /// <returns>An IEmbeddedResourceFile that has info about the extracted file.</returns>
+        public static IEmbeddedResourceFile GetTestResourceFile(string resourceName, bool required = true)
+        {
+            // Don't allow parallel tests to overwrite extracted files.
+            lock (ExtractionLock)
+            {
+                Stream stream = GetEmbeddedResource(resourceName, required);
+                if (stream == null)
+                {
+                    return null;
+                }
+                using (stream)
+                {
+                    DirectoryInfo resourceDirectory = new DirectoryInfo(PathUtils.GetResourcesFolder());
+                    resourceDirectory.Create();
+
+                    string tempFileName = Path.Combine(PathUtils.GetResourcesFolder(), resourceName);
+                    FileInfo fileInfo = new FileInfo(tempFileName);
+                    var embeddedResource = new EmbeddedResourceFile(fileInfo, resourceName);
+                    try
+                    {
+                        if (!fileInfo.Exists)
+                        {
+                            embeddedResource.CopyFromStream(stream);
+                        }
+
+                        return embeddedResource;
+                    }
+                    catch (Exception e)
+                    {
+                        Assert.Fail(e.Message);
+                    }
+                }
+
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Deletes all test resource files that have been previously extracted.
+        /// </summary>
+        public static void CleanTestResourceFiles()
+        {
+            lock (ExtractionLock)
+            {
+                DirectoryInfo resourceDirectory = new DirectoryInfo(PathUtils.GetResourcesFolder());
+                if (resourceDirectory.Exists)
+                {
+                    foreach (FileInfo f in resourceDirectory.EnumerateFiles())
+                    {
+                        f.Delete();
+                    }
+                }
+            }
+        }
+
+        private static Stream GetEmbeddedResource(string fileName, bool required = true)
+        {
+            Assert.IsNotNull(fileName);
+
+            var fullPath = FormattableString.Invariant($"{EmbeddedResourcesPath}.{fileName}");
+
+            var stream = typeof(EmbeddedResourceUtils).Assembly.GetManifestResourceStream(fullPath);
+
+            if (required)
+            {
+                Assert.IsNotNull(stream, "Could not find embedded resource {0}", fullPath);
+            }
+
+            return stream;
+        }
+    }
+}

--- a/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResources/ByRefLikeInvalidCSharp.il
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResources/ByRefLikeInvalidCSharp.il
@@ -1,0 +1,631 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Console { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
+.assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
+
+.assembly InvalidCSharp { }
+
+//
+// Begin invalid
+//
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericClass_Invalid`1<T>
+    extends [System.Runtime]System.Object
+{
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        ldarg.0
+        call instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+}
+
+.class interface public auto ansi abstract InvalidCSharp.GenericInterface_Invalid`1<T>
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericValueType_Invalid`1<T>
+    extends [System.Runtime]System.ValueType
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericByRefLike_Invalid`1<T>
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+}
+
+//
+// End invalid
+//
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericClass_Over`1<byreflike T>
+    extends [System.Runtime]System.Object
+{
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        ldarg.0
+        call instance void [System.Runtime]System.Object::.ctor()
+        ret
+    }
+}
+
+.class interface public auto ansi abstract InvalidCSharp.GenericInterface_Over`1<byreflike T>
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericValueType_Over`1<byreflike T>
+    extends [System.Runtime]System.ValueType
+{
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericByRefLike_Over`1<byreflike T>
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+
+    .field public !T Field
+
+    .method public hidebysig
+        instance object BoxAsObject(!T) cil managed
+    {
+        ldarg.1
+        box !T
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxUnboxAny(!T) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            box !T
+            unbox.any !T
+        // End sequence
+        pop
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxBranch(!T) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            box !T
+            brfalse.s NEXT_1
+        // End sequence
+        NEXT_1:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            brfalse NEXT_2
+        // End sequence
+        NEXT_2:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            brtrue.s NEXT_3
+        // End sequence
+        NEXT_3:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            brtrue NEXT_4
+        // End sequence
+        NEXT_4:
+
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxBranch_WithSideEffects(!T&) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            brfalse.s NEXT_1
+        // End sequence
+        NEXT_1:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            brfalse NEXT_2
+        // End sequence
+        NEXT_2:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            brtrue.s NEXT_3
+        // End sequence
+        NEXT_3:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            brtrue NEXT_4
+        // End sequence
+        NEXT_4:
+
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxIsinstUnboxAny(!T) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType
+            unbox.any !T
+        // End sequence
+        pop
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxIsinstBranch(!T) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType
+            brfalse.s NEXT_1
+        // End sequence
+        NEXT_1:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType
+            brfalse NEXT_2
+        // End sequence
+        NEXT_2:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType
+            brtrue.s NEXT_3
+        // End sequence
+        NEXT_3:
+
+        ldarg.1
+        // Begin sequence
+            box !T
+            isinst ByRefLikeType
+            brtrue NEXT_4
+        // End sequence
+        NEXT_4:
+
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool BoxIsinstBranch_WithSideEffects(!T&) cil managed
+    {
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            isinst ByRefLikeType
+            brfalse.s NEXT_1
+        // End sequence
+        NEXT_1:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            isinst ByRefLikeType
+            brfalse NEXT_2
+        // End sequence
+        NEXT_2:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            isinst ByRefLikeType
+            brtrue.s NEXT_3
+        // End sequence
+        NEXT_3:
+
+        ldarg.1
+        // Begin sequence
+            ldobj !T // Side-effect
+            box !T
+            isinst ByRefLikeType
+            brtrue NEXT_4
+        // End sequence
+        NEXT_4:
+
+        ldc.i4.1
+        ret
+    }
+
+    .method public hidebysig
+        instance bool AllocArrayOfT() cil managed aggressiveinlining
+    {
+        ldc.i4.1
+        newarr !T
+        ldnull
+        cgt.un
+        ret
+    }
+
+    .method public hidebysig
+        instance bool AllocMultiDimArrayOfT() cil managed
+    {
+        ldc.i4.1
+        ldc.i4.1
+        newobj instance void !T[0..., 0...]::.ctor(int32, int32)
+        ldnull
+        cgt.un
+        ret
+    }
+
+    .method public hidebysig
+        instance bool InstanceOfT(
+            object o
+        ) cil managed
+    {
+        ldarg.1
+        isinst !T
+        ldnull
+        cgt.un
+        ret
+    }
+
+    .method public hidebysig
+        instance void CastToT(
+            object o
+        ) cil managed
+    {
+        ldarg.1
+        castclass !T
+        pop
+        ret
+    }
+
+    .method public hidebysig
+        instance void UnboxToT(
+            object o
+        ) cil managed
+    {
+        ldarg.1
+        unbox.any !T
+        pop
+        ret
+    }
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.GenericClass_WithStaticField`1<byreflike T>
+    extends [System.Runtime]System.Object
+{
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor () cil managed
+    {
+        .locals init (
+            [0] !T,
+            [1] !T
+        )
+
+        ldarg.0
+        call instance void [System.Runtime]System.Object::.ctor()
+
+        ldloca.s 0
+        initobj !T
+
+        ldloc.0
+        stsfld !0 class InvalidCSharp.GenericClass_WithStaticField`1<!T>::StaticField
+        ldsfld !0 class InvalidCSharp.GenericClass_WithStaticField`1<!T>::StaticField
+        stloc.1
+        ret
+    }
+
+    .field public static !T StaticField
+}
+
+.class public sequential ansi sealed beforefieldinit ByRefLikeType
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+}
+
+.class public auto ansi abstract sealed beforefieldinit Exec
+    extends [System.Runtime]System.Object
+{
+    .method public hidebysig static
+        string GenericClass() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericClass_Over`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericInterface() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericInterface_Over`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericValueType() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericValueType_Over`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericByRefLike() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        string GenericClass_Invalid() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericClass_Invalid`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericInterface_Invalid() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericInterface_Invalid`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericValueType_Invalid() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericValueType_Invalid`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+    .method public hidebysig static
+        string GenericByRefLike_Invalid() cil managed
+    {
+        ldtoken valuetype InvalidCSharp.GenericByRefLike_Invalid`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        object BoxAsObject() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance object valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxAsObject(!0)
+        ret
+    }
+
+    .method public hidebysig static
+        bool BoxUnboxAny() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxUnboxAny(!0)
+        ret
+    }
+
+    .method public hidebysig static
+        bool BoxBranch() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>,
+            [1] bool
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxBranch(!0)
+        pop
+
+        ldloca.s 0
+        ldloca.s 0
+        ldflda !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxBranch_WithSideEffects(!0&)
+
+        ret
+    }
+
+    .method public hidebysig static
+        bool BoxIsinstUnboxAny() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxIsinstUnboxAny(!0)
+        ret
+    }
+
+    .method public hidebysig static
+        bool BoxIsinstBranch() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+
+        ldloca.s 0
+        ldloc 0
+        ldfld !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxIsinstBranch(!0)
+        pop
+
+        ldloca.s 0
+        ldloca.s 0
+        ldflda !0 valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::Field
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::BoxIsinstBranch_WithSideEffects(!0&)
+
+        ret
+    }
+
+    .method public hidebysig static
+        void AllocArrayOfT_Invalid() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::AllocArrayOfT()
+        pop
+        ret
+    }
+
+    .method public hidebysig static
+        void AllocMultiDimArrayOfT_Invalid() cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::AllocMultiDimArrayOfT()
+        pop
+        ret
+    }
+
+    .method public hidebysig static
+        string GenericClassWithStaticField_Invalid() cil managed
+    {
+        ldtoken class InvalidCSharp.GenericClass_WithStaticField`1<valuetype ByRefLikeType>
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle)
+        callvirt instance string [System.Runtime]System.Object::ToString()
+        ret
+    }
+
+    .method public hidebysig static
+        bool InstanceOfT(object) cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldarg.0
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::InstanceOfT(object)
+        ret
+    }
+
+    .method public hidebysig static
+        void CastToT(object) cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldarg.0
+        call instance void valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::CastToT(object)
+        ret
+    }
+
+    .method public hidebysig static
+        void UnboxToT(object) cil managed
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldloca.s 0
+        ldarg.0
+        call instance void valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::UnboxToT(object)
+        ret
+    }
+
+    .method public hidebysig static
+        bool TypeLoadExceptionAvoidsInline(bool) cil managed noinlining
+    {
+        .locals init (
+            [0] valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        )
+
+        ldloca.s 0
+        initobj valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>
+        ldarg.0
+        brfalse.s DONTCALL
+
+        ldloca.s 0
+        call instance bool valuetype InvalidCSharp.GenericByRefLike_Over`1<valuetype ByRefLikeType>::AllocArrayOfT()
+        br.s DONE
+
+        // Negate the input and return
+        DONTCALL: ldarg.0
+        ldc.i4.0
+        ceq
+
+        DONE: ret
+    }
+}

--- a/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResources/RefFieldInvalidCSharp.il
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/EmbeddedResources/RefFieldInvalidCSharp.il
@@ -1,0 +1,188 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+.assembly extern System.Runtime { .publickeytoken = (B0 3F 5F 7F 11 D5 0A 3A ) }
+
+.assembly InvalidCSharp { }
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.InvalidStructWithRefField
+    extends [System.Runtime]System.ValueType
+{
+    // Type requires IsByRefLikeAttribute to be valid.
+    .field public string& Invalid
+}
+
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.InvalidRefFieldAlignment
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field [0] public int16 Field
+    .field [2] public int32& Invalid
+}
+
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.InvalidObjectRefRefFieldOverlap
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field [0] public object Field
+    .field [0] public int32& Invalid
+}
+
+// This is invalid metadata and is unable to be loaded.
+// -  [field sig] (0x80131815 (VER_E_FIELD_SIG))
+//
+// .class public sequential ansi sealed beforefieldinit InvalidCSharp.InvalidStructWithStaticRefField
+//     extends [System.Runtime]System.ValueType
+// {
+//     .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+//         01 00 00 00
+//     )
+//     .field public static string& Invalid
+// }
+
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.IntPtrRefFieldOverlap
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field [0] public native int Field
+    .field [0] public int32& Invalid
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.InnerValidByRef
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field public int32& Field
+    .field public int32 Size
+}
+
+.class public explicit ansi sealed beforefieldinit InvalidCSharp.IntPtrOverlapWithInnerFieldType
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field [0] public native int Field
+    // This field's valid Type would illegally overlap this type's first field using a precise GC.
+    .field [0] public valuetype InvalidCSharp.InnerValidByRef Invalid
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.WithRefField
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field public string& Str
+
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor (
+            string&
+        ) cil managed
+    {
+        ldarg.0
+        ldarg.1
+        stfld string& InvalidCSharp.WithRefField::Str
+        ret
+    }
+
+    .method public hidebysig
+        instance bool ConfirmFieldInstance (
+            string
+        ) cil managed
+    {
+        ldarg.0
+        ldfld string& InvalidCSharp.WithRefField::Str
+        ldind.ref
+        ldarg.1
+        ceq
+        ret
+    }
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.WithRefStructField
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field public valuetype InvalidCSharp.WithRefField& Field
+
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor (
+            valuetype InvalidCSharp.WithRefField&
+        ) cil managed
+    {
+        ldarg.0
+        ldarg.1
+        stfld valuetype InvalidCSharp.WithRefField& InvalidCSharp.WithRefStructField::Field
+        ret
+    }
+
+    .method public hidebysig
+        instance bool ConfirmFieldInstance (
+            valuetype InvalidCSharp.WithRefField&
+        ) cil managed
+    {
+        ldarg.0
+        ldfld valuetype InvalidCSharp.WithRefField& InvalidCSharp.WithRefStructField::Field
+        ldind.ref
+        ldarg.1
+        ldind.ref
+        ceq
+        ret
+    }
+}
+
+.class public sequential ansi sealed beforefieldinit InvalidCSharp.WithTypedReferenceField`1<T>
+    extends [System.Runtime]System.ValueType
+{
+    .custom instance void [System.Runtime]System.Runtime.CompilerServices.IsByRefLikeAttribute::.ctor() = (
+        01 00 00 00
+    )
+    .field public typedref Field
+
+    .method public hidebysig specialname rtspecialname
+        instance void .ctor (
+            !T&
+        ) cil managed
+    {
+        ldarg.0
+        ldarg.1
+        mkrefany !T
+        stfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
+        ret
+    }
+
+    .method public hidebysig
+        instance class [System.Runtime]System.Type GetFieldType () cil managed
+    {
+        ldarg.0
+        ldfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
+        refanytype
+        call class [System.Runtime]System.Type [System.Runtime]System.Type::GetTypeFromHandle(valuetype [System.Runtime]System.RuntimeTypeHandle )
+        ret
+    }
+
+    .method public hidebysig
+        instance bool ConfirmFieldInstance (
+            !T
+        ) cil managed
+    {
+        ldarg.0
+        ldfld typedref valuetype InvalidCSharp.WithTypedReferenceField`1<!T>::Field
+        refanyval !T
+        ldind.ref
+        ldarg.1
+        ceq
+        ret
+    }
+}

--- a/src/Tests/InstrEngineTests/InstrEngineTests/InstrEngineTests.csproj
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/InstrEngineTests.csproj
@@ -11,6 +11,10 @@
     <IsPackable>false</IsPackable>
     <RootNamespace>InstrEngineTests</RootNamespace>
   </PropertyGroup>
+  <PropertyGroup>
+    <NetCoreVersion>7.0.0-preview.4.22229.4</NetCoreVersion>
+    <IlAsmLocation>$(NuGetPackageRoot)\microsoft.netcore.ilasm\$(NetCoreVersion)\runtimes\native\ilasm.exe</IlAsmLocation>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Remove="EmbeddedResources\**" />
     <EmbeddedResource Include="EmbeddedResources\**" />
@@ -21,6 +25,9 @@
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
     <PackageReference Include="coverlet.collector" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NET.Sdk.IL" Version="$(NetCoreVersion)" />
+    <PackageReference Include="Microsoft.NETCore.ILAsm" Version="$(NetCoreVersion)" />
+    <PackageReference Include="Microsoft.NETCore.ILDAsm" Version="$(NetCoreVersion)" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\Baselines\AddBranchTargets_ArrayForeachTest.xml">
@@ -493,6 +500,11 @@
       <Link>TestScripts\MultiReturn_SwitchTest.xml</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+  </ItemGroup>
+  <ItemGroup Condition="Exists('$(ILAsmLocation)')">
+    <EmbeddedResource Include="$(ILAsmLocation)">
+      <Link>EmbeddedResources\ilasm.exe</Link>
+    </EmbeddedResource>
   </ItemGroup>
   <Import Project="$(EnlistmentRoot)\build\Managed.targets" />
 </Project>

--- a/src/Tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
@@ -11,6 +11,7 @@ namespace InstrEngineTests
         private const string BaselinesFolder = "Baselines";
         private const string TestResultsFolder = "TestResults";
         private const string TestScriptsFolder = "TestScripts";
+        private const string ResourcesFolder = "ExtractedResources";
 
         // All paths are relative to the AnyCPU binaries directory e.g. bin\Debug\AnyCPU
         public const string BaselinesBinPath = @".\" + BaselinesFolder;
@@ -25,6 +26,11 @@ namespace InstrEngineTests
         public static string GetAssetsPath()
         {
             return Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+        }
+
+        public static string GetResourcesFolder()
+        {
+            return Path.Combine(GetAssetsPath(), ResourcesFolder);
         }
 
         public static string GetBaselinesPath()

--- a/src/Tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
@@ -76,8 +76,9 @@ namespace InstrEngineTests
             if (!BinaryRecompiled)
             {
                 BinaryRecompiled = true;
+                EmbeddedResourceUtils.CleanTestResourceFiles();
                 TargetAppCompiler.DeleteExistingBinary(PathUtils.GetAssetsPath());
-                TargetAppCompiler.ComplileCSharpTestCode(PathUtils.GetAssetsPath());
+                TargetAppCompiler.CompileTestCode(PathUtils.GetAssetsPath());
             }
 
             DeleteOutputFileIfExist(output);

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TargetAppCompiler.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TargetAppCompiler.cs
@@ -166,8 +166,13 @@ namespace InstrEngineTests
 #endif
             };
 
+
             Platform platform = Platform.AnyCpu;
-            if (is64bit.HasValue)
+            if (TestUtils.IsArmProcess)
+            {
+                platform = is64bit.Value ? Platform.Arm64 : Platform.Arm;
+            }
+            else
             {
                 platform = is64bit.Value ? Platform.X64 : Platform.X86;
             }

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TargetAppCompiler.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TargetAppCompiler.cs
@@ -168,13 +168,16 @@ namespace InstrEngineTests
 
 
             Platform platform = Platform.AnyCpu;
-            if (TestUtils.IsArmProcess)
+            if (is64bit.HasValue)
             {
-                platform = is64bit.Value ? Platform.Arm64 : Platform.Arm;
-            }
-            else
-            {
-                platform = is64bit.Value ? Platform.X64 : Platform.X86;
+                if (TestUtils.IsArmProcess)
+                {
+                    platform = is64bit.Value ? Platform.Arm64 : Platform.Arm;
+                }
+                else
+                {
+                    platform = is64bit.Value ? Platform.X64 : Platform.X86;
+                }
             }
 
             CSharpCompilationOptions compilationOptions = new CSharpCompilationOptions(outputKind)

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestAppAssembler.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestAppAssembler.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InstrEngineTests
+{
+    internal class TestAppAssembler
+    {
+        internal static bool AssembleFile(IEmbeddedResourceFile embeddedResource, string directoryPath, string assemblyName, bool isDebug, bool is64Bit, bool isExe = false)
+        {
+            ProcessStartInfo psi = new ProcessStartInfo();
+            IEmbeddedResourceFile ilasm = EmbeddedResourceUtils.GetTestResourceFile("ilasm.exe");
+            if (ilasm == null)
+            {
+                return false;
+            }
+
+            psi.FileName = ilasm.FilePath;
+            psi.RedirectStandardError = true;
+            psi.RedirectStandardOutput = true;
+            psi.UseShellExecute = false;
+            string debugSwitch = isDebug ? "/DEBUG=OPT" : string.Empty;
+            string bitSwitch = is64Bit ? "/X64" : "/32BITPREFERRED";
+            string outputType = isExe ? "/EXE" : "/DLL";
+            string extension = isExe ? "exe" : "dll";
+            string outputFile = Path.Combine(directoryPath, FormattableString.Invariant($"{assemblyName}.{extension}"));
+            psi.Arguments = FormattableString.Invariant($"{debugSwitch} {bitSwitch} {outputType} /OUTPUT=\"{outputFile}\" \"{embeddedResource.FilePath}\"");
+            Process p = Process.Start(psi);
+            p.WaitForExit();
+            string stdOut = p.StandardOutput.ReadToEnd();
+            string stdErr = p.StandardError.ReadToEnd();
+            Assert.IsTrue(p.ExitCode == 0, FormattableString.Invariant($"Assembly failed for '{embeddedResource.FilePath}' : {stdOut} \n\n {stdErr}"));
+            return p.ExitCode == 0;
+        }
+    }
+}

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestAppAssembler.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestAppAssembler.cs
@@ -19,6 +19,7 @@ namespace InstrEngineTests
         {
             ProcessStartInfo psi = new ProcessStartInfo();
             IEmbeddedResourceFile ilasm = EmbeddedResourceUtils.GetTestResourceFile("ilasm.exe");
+            Assert.IsFalse(ilasm == null, "Could not find ilasm.exe");
             if (ilasm == null)
             {
                 return false;
@@ -30,6 +31,10 @@ namespace InstrEngineTests
             psi.UseShellExecute = false;
             string debugSwitch = isDebug ? "/DEBUG=OPT" : string.Empty;
             string bitSwitch = is64Bit ? "/X64" : "/32BITPREFERRED";
+            if (TestUtils.IsArmProcess)
+            {
+                bitSwitch = is64Bit ? "/ARM64" : "/ARM";
+            }
             string outputType = isExe ? "/EXE" : "/DLL";
             string extension = isExe ? "exe" : "dll";
             string outputFile = Path.Combine(directoryPath, FormattableString.Invariant($"{assemblyName}.{extension}"));

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestUtils.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestUtils.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InstrEngineTests
+{
+    internal class TestUtils
+    {
+        public static bool IsArmProcess
+        {
+            get
+            {
+                switch (RuntimeInformation.ProcessArchitecture)
+                {
+                    case Architecture.Arm:
+                    case Architecture.Arm64:
+                        return true;
+                    case Architecture.X86:
+                    case Architecture.X64:
+                        return false;
+                    default:
+                        Assert.Fail($"Unsupported Architecture {RuntimeInformation.ProcessArchitecture}");
+                        return false;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Assemble IL in Embedded Resources

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->

1) Add ILASM to test project
2) Copy ilasm as an embedded resource into the InstrEngineTests assembly
3) Add il files to embedded resources
4) Refactor the compiler helpers to extract embedded resources as files
5) Invoke ilasm to assemble the embedded il

Note: I think that ILASM is only available for Windows, so we may need
to update our build steps, in the future, to run ILASM for assembly il
files, and embed them into the instrumentation engine tests, or bundle
them as part of the deployment.


###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->

Local build, local unit tests. No production code has changed. I manually verified that ILASM is running during tests.