### PR TITLE
Update Newtonsoft.Json version

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,7 +4,9 @@
 <configuration>
     <packageSources>
         <clear />
+        <!-- Multiple package sources are required because the dotnet build tools need to be able to download SDKs from NuGet -->
         <add key="DNCENG-CoreClrPal" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/CoreClrPal/nuget/v3/index.json" />
+        <add key="dotnet-public" value="https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-public/nuget/v3/index.json" />
     </packageSources>
     <activePackageSource>
         <add key="All" value="(Aggregate source)" />

--- a/build/CommonBuild.Private.props
+++ b/build/CommonBuild.Private.props
@@ -50,6 +50,7 @@
         <MicrosoftNETTestSdkVersion>16.9.1</MicrosoftNETTestSdkVersion>
         <MSTestTestAdapterVersion>2.1.2</MSTestTestAdapterVersion>
         <MSTestTestFrameworkVersion>2.1.2</MSTestTestFrameworkVersion>
+        <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
         <WixVersion>3.11.1</WixVersion>
     </PropertyGroup>
 

--- a/src/Extensions.Base.Api.Tests/Extensions.Base.Api.Tests.csproj
+++ b/src/Extensions.Base.Api.Tests/Extensions.Base.Api.Tests.csproj
@@ -16,6 +16,8 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="$(MicrosoftNETTestSdkVersion)" />
     <PackageReference Include="MSTest.TestAdapter" Version="$(MSTestTestAdapterVersion)" />
     <PackageReference Include="MSTest.TestFramework" Version="$(MSTestTestFrameworkVersion)" />
+    <!-- Used to upgrade to a higher version than what is provided from indirect dependencies. -->
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
   </ItemGroup>
   <Import Project="$(EnlistmentRoot)\build\Managed.targets" />
 </Project>

--- a/src/Tests/Directory.Build.props
+++ b/src/Tests/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <!-- Used to upgrade to a higher version than what is provided from indirect dependencies. -->
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+</Project>

--- a/tests/Directory.Build.props
+++ b/tests/Directory.Build.props
@@ -1,0 +1,6 @@
+<Project>
+  <ItemGroup>
+    <!-- Used to upgrade to a higher version than what is provided from indirect dependencies. -->
+    <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonVersion)" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
###### Summary
Update Newtonsoft.Json version to latest version.

###### Change Log
- Update Newtonsoft.Json version to 13.0.1
- Add dotnet-public feed to NuGet.config to consume dotnet build dependencies.

###### Test Methodology
Change only affects tests. Tested with local build. Tests should be run in pipeline build.