### PR TITLE
Use Docker base images from MCR

### DIFF
--- a/src/unix/docker/dockerfiles/build/alpine/Dockerfile
+++ b/src/unix/docker/dockerfiles/build/alpine/Dockerfile
@@ -1,9 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-# This is the base image that coreclr uses to build its alpine/linux-musl release
-# REFERENCE: https://github.com/dotnet/coreclr/blob/v2.1.0-preview2-26406-04/buildpipeline/pipelines.json
-FROM microsoft/dotnet-buildtools-prereqs:alpine-3.6-3148f11-20171119021156
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-20211214164113-8a6f4f3
 
 WORKDIR /
 

--- a/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
+++ b/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # This image is based on the public Ubuntu 18.04 LTS image
-FROM ubuntu:18.04
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:18.04
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
###### Summary
Update Dockerfiles to use base images from MCR


###### Change Log
- Use MCR images for the base of the build images