### PR TITLE
Add `$schema` to `cgmanifest.json`

### DIFF
--- a/src/unix/docker/context/components/cmake/cgmanifest.json
+++ b/src/unix/docker/context/components/cmake/cgmanifest.json
@@ -1,16 +1,17 @@
 {
-    "Registrations": [ 
-        {
-            "Component": { 
-                "Type": "other", 
-                "other": {
-                    "Name": "cmake",
-                    "Version": "3.20.2",
-                    "DownloadUrl": " https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2.tar.gz",
-                    "SHA256CHECK": "aecf6ecb975179eb3bb6a4a50cae192d41e92b9372b02300f9e8f1d5f559544e"
-                }
-            },
-            "DevelopmentDependency": true
+  "$schema": "https://json.schemastore.org/component-detection-manifest.json",
+  "Registrations": [
+    {
+      "Component": {
+        "Type": "other",
+        "other": {
+          "Name": "cmake",
+          "Version": "3.20.2",
+          "DownloadUrl": " https://github.com/Kitware/CMake/releases/download/v3.20.2/cmake-3.20.2.tar.gz",
+          "SHA256CHECK": "aecf6ecb975179eb3bb6a4a50cae192d41e92b9372b02300f9e8f1d5f559544e"
         }
-    ]
+      },
+      "DevelopmentDependency": true
+    }
+  ]
 }


### PR DESCRIPTION
This pull request adds the JSON schema for `cgmanifest.json`.

## FAQ

### Why?

A JSON schema helps you to ensure that your `cgmanifest.json` file is valid.
JSON schema validation is a build-in feature in most modern IDEs like Visual Studio and Visual Studio Code.
Most modern IDEs also provide code-completion for JSON schemas.

### How can I validate my `cgmanifest.json` file?

Most modern IDEs like Visual Studio and Visual Studio Code have a built-in feature to validate JSON files.
You can also use [this small script](https://github.com/JamieMagee/verify-cgmanifest) to validate your `cgmanifest.json` file.

### Why does it suggest camel case for the properties?

Component Detection is able to read camel case and pascal case properties.
However, the JSON schema doesn't have a case-insensitive mode.
We therefore suggest camel case as it's the most common format for JSON.

### Why is the diff so large?

To deserialize the `cgmanifest.json` file, we use [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
However, to serialize the JSON again we use [`prettier`](https://prettier.io/).
We found that, in general, it gave smaller diffs than the default [`JSON.stringify()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) function.