### PR TITLE
Unblock PR builds

### DIFF
--- a/src/Tests/InstrEngineTests/InstrEngineTests/TargetAppCompiler.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TargetAppCompiler.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
-#pragma warning disable CA1506
+#pragma warning disable CA1506 // Avoid excessive class coupling
+#pragma warning disable CA1305 // Specify IFormatProvider
 
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -259,3 +260,6 @@ namespace InstrEngineTests
         }
     }
 }
+
+#pragma warning restore CA1506 // Avoid excessive class coupling
+#pragma warning restore CA1305 // Specify IFormatProvider


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Current PR builds are blocked with the error:
```
##[error]src\Tests\InstrEngineTests\InstrEngineTests\TargetAppCompiler.cs(134,75): Error CA1305: The behavior of '{0}' could vary based on the current user's locale settings. Provide a value for the 'IFormatProvider' argument.
```

Since this is a test file, I am suppressing the warning.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Disable warning CA1305

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
PR Build