### PR TITLE
Fix race condition when generating version file

### DIFF
--- a/after.InstrumentationEngine.sln.targets
+++ b/after.InstrumentationEngine.sln.targets
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+     Licensed under the MIT License. -->
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!--
+        Msbuild supports solution build hooks with 
+            $(MSBuildProjectDirectory)\before.{SolutionFile}.sln.targets 
+        and 
+            $(MSBuildProjectDirectory)\after.{SolutionFile}.sln.targets.
+    -->
+    <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), EnlistmentRoot.marker))\build\Common.props" />
+    <Target Name="GenerateVersionFile" AfterTargets="Build">
+        <PropertyGroup>
+            <VersionFile Condition="'$(VersionFile)'==''">version.txt</VersionFile>
+            <VersionFilePath>$(BinConfiguration)\$(VersionFile)</VersionFilePath>
+        </PropertyGroup>
+
+        <!-- Write new version to intermediate file if the version is different. -->
+        <MakeDir Directories="$(BinConfiguration)" />
+        <WriteLinesToFile File="$(VersionFilePath)"
+          Lines="$(ReleaseVersion)"
+          Overwrite="true"
+          WriteOnlyWhenDifferent="true"/>
+        <Message Importance="high" Text="Writing '$(VersionFilePath)' with version '$(ReleaseVersion)'" />
+    </Target>
+</Project>

--- a/build/Version.targets
+++ b/build/Version.targets
@@ -45,20 +45,4 @@
             <ResourceCompile Include="$(CommonBuildPropsLocation)\bldver.rc" />
         </ItemGroup>
     </Target>
-
-    <Target Name="GenerateVersionFile" BeforeTargets="PrepareForBuild">
-        <PropertyGroup>
-            <VersionFile Condition="'$(VersionFile)'==''">version.txt</VersionFile>
-            <VersionFilePath>$(BinConfiguration)\$(VersionFile)</VersionFilePath>
-        </PropertyGroup>
-
-        <!-- Write new version to intermediate file if the version is different. -->
-        <MakeDir Directories="$(BinConfiguration)" />
-        <WriteLinesToFile File="$(VersionFilePath)"
-          Lines="$(ReleaseVersion)"
-          Overwrite="true"
-          WriteOnlyWhenDifferent="true"/>
-        <Message Importance="high" Text="Writing '$(VersionFilePath)' with version '$(ReleaseVersion)'" />
-    </Target>
-
 </Project>


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
Previously, the version.targets was being invoked for several projects. This works fine locally but ran into race conditions on build machines.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Move GenerateVersionFile to after.solution.sln.targets file so it runs once.


###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
