### PR TITLE
Fix Nagler tests to run on Linux

### DIFF
--- a/build/yaml/jobs/linux/tests.yaml
+++ b/build/yaml/jobs/linux/tests.yaml
@@ -3,9 +3,16 @@
 
 # Job Template: Test Linux Binaries
 
+parameters:
+  MatrixStrategy: {}
+
 jobs:
 - job: Test_Linux_Binaries
   displayName: Linux Tests
+
+  strategy:
+    matrix:
+      ${{ insert }}: ${{ parameters.MatrixStrategy }}
 
   pool:
     ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
@@ -21,11 +28,6 @@ jobs:
     configuration: Debug
 
   steps:
-#  - download: current
-#    patterns: |
-#      binaries-windows-$(Configuration)/AnyCPU/**
-#      binaries-linux-ubuntu-$(Configuration)/ClrInstrumentationEngine/**
-
   - template: ../../steps/azuredevops/downloadbuildartifacts.yaml
     parameters:
       ArtifactName: binaries-windows-$(Configuration)
@@ -36,15 +38,15 @@ jobs:
 
   # Simulate DeploymentItem by copying the Linux binaries
   - task: CopyFiles@2
-    displayName: Setup Linux binaries for tests 
+    displayName: Setup Linux binaries for tests
     inputs:
       sourceFolder: $(Build.StagingDirectory)/binaries-linux-ubuntu-$(Configuration)/ClrInstrumentationEngine/
-      targetFolder: $(Build.StagingDirectory)/binaries-windows-$(Configuration)/AnyCPU/net70/
+      targetFolder: $(Build.StagingDirectory)/binaries-windows-$(Configuration)/AnyCPU/$(TargetFrameworkFolder)/
 
   - task: UseDotNet@2
-    displayName: 'Use .NET 7 sdk'
+    displayName: 'Use .NET sdk'
     inputs:
-      version: 7.0.x
+      version: $(NetSdkVersion)
       includePreviewVersions: true
       installationPath: $(Agent.TempDirectory)/dotnet
 
@@ -56,10 +58,8 @@ jobs:
     displayName: 'Run Tests: InstrEngineTests.dll'
     inputs:
       command: test
-      workingDirectory: $(Agent.TempDirectory)/dotnet 
-      arguments: $(Build.StagingDirectory)/binaries-windows-$(Configuration)/AnyCPU/net70/InstrEngineTests.dll
+      workingDirectory: $(Agent.TempDirectory)/dotnet
+      arguments: $(Build.StagingDirectory)/binaries-windows-$(Configuration)/AnyCPU/$(TargetFrameworkFolder)/InstrEngineTests.dll
       testRunTitle: Linux Nagler Tests
       publishTestResults: true
     condition: succeededOrFailed()
-
-  #- script: $(Agent.TempDirectory)/dotnet $(Pipeline.Workspace)/binaries-windows-Debug/AnyCPU/net70/InstrEngineTests.dll

--- a/build/yaml/jobs/linux/tests.yaml
+++ b/build/yaml/jobs/linux/tests.yaml
@@ -1,0 +1,65 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Job Template: Test Linux Binaries
+
+jobs:
+- job: Test_Linux_Binaries
+  displayName: Linux Tests
+
+  pool:
+    ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+      name: AzurePipelines-EO
+      demands: ImageOverride -equals AzurePipelinesUbuntu20.04compliant
+    ${{ else }}:
+      vmImage: ubuntu-latest
+
+  workspace:
+    clean: outputs
+
+  variables:
+    configuration: Debug
+
+  steps:
+#  - download: current
+#    patterns: |
+#      binaries-windows-$(Configuration)/AnyCPU/**
+#      binaries-linux-ubuntu-$(Configuration)/ClrInstrumentationEngine/**
+
+  - template: ../../steps/azuredevops/downloadbuildartifacts.yaml
+    parameters:
+      ArtifactName: binaries-windows-$(Configuration)
+
+  - template: ../../steps/azuredevops/downloadbuildartifacts.yaml
+    parameters:
+      ArtifactName: binaries-linux-ubuntu-$(Configuration)
+
+  # Simulate DeploymentItem by copying the Linux binaries
+  - task: CopyFiles@2
+    displayName: Setup Linux binaries for tests 
+    inputs:
+      sourceFolder: $(Build.StagingDirectory)/binaries-linux-ubuntu-$(Configuration)/ClrInstrumentationEngine/
+      targetFolder: $(Build.StagingDirectory)/binaries-windows-$(Configuration)/AnyCPU/net70/
+
+  - task: UseDotNet@2
+    displayName: 'Use .NET 7 sdk'
+    inputs:
+      version: 7.0.x
+      includePreviewVersions: true
+      installationPath: $(Agent.TempDirectory)/dotnet
+
+  # Environment variable used by tests
+  - bash: |
+      echo "##vso[task.setvariable variable=DOTNET_EXE]$(Agent.TempDirectory)/dotnet/dotnet"
+
+  - task: DotNetCoreCLI@2
+    displayName: 'Run Tests: InstrEngineTests.dll'
+    inputs:
+      command: test
+      workingDirectory: $(Agent.TempDirectory)/dotnet 
+      arguments: $(Build.StagingDirectory)/binaries-windows-$(Configuration)/AnyCPU/net70/InstrEngineTests.dll
+      testRunTitle: Linux Nagler Tests
+      publishTestResults: true
+    condition: succeededOrFailed()
+
+  #- script: $(Agent.TempDirectory)/dotnet $(Pipeline.Workspace)/binaries-windows-Debug/AnyCPU/net70/InstrEngineTests.dll

--- a/build/yaml/jobs/tests.yaml
+++ b/build/yaml/jobs/tests.yaml
@@ -38,3 +38,11 @@ jobs:
 
 # Test Linux Binaries
 - template: linux/tests.yaml
+  parameters:
+    MatrixStrategy:
+      NET_Next:
+        TargetFrameworkFolder: net70
+        NetSdkVersion: 7.x
+      NET_LTS:
+        TargetFrameworkFolder: net60
+        NetSdkVersion: 6.x

--- a/build/yaml/jobs/tests.yaml
+++ b/build/yaml/jobs/tests.yaml
@@ -36,5 +36,5 @@ jobs:
           Platform: 'AnyCPU'
           RunSettingsFile: 'x64.runsettings'
 
-# Linux Binaries (TBD)
-#- template: linux/tests.yaml
+# Test Linux Binaries
+- template: linux/tests.yaml

--- a/build/yaml/steps/azuredevops/downloadbuildartifacts.yaml
+++ b/build/yaml/steps/azuredevops/downloadbuildartifacts.yaml
@@ -6,6 +6,7 @@
 parameters:
   ArtifactName: ''
   ItemPattern: '**'
+  DownloadPath: $(Build.ArtifactStagingDirectory)
 
 steps:
 # download Artifacts
@@ -14,5 +15,5 @@ steps:
   inputs:
     downloadType: single
     artifactName: ${{ parameters.ArtifactName }}
-    downloadPath: $(Build.ArtifactStagingDirectory)
+    downloadPath: ${{ parameters.DownloadPath }}
     itemPattern: ${{ parameters.ItemPattern }}

--- a/docs/test.md
+++ b/docs/test.md
@@ -35,5 +35,22 @@ Verbose|Sets msbuild verbosity to `normal`. By default, verbosity is set to `Err
 
 ### Linux
 
-Currently there are no unit tests support for Linux. However, Linux builds will run via PR validations. Please contact
-clrieowners@microsoft.com for more details.
+#### Prerequisites
+
+The following technologies/tools are required in order to run Linux tests on Windows. These instructions were tested for Ubuntu 18.04 LTS and may require adjustments for other distros/versions.
+
+* WSL (Windows Subsystem for Linux) 2.0 with Ubuntu 18.04 LTS
+  - WSL is available on Windows 10 Build 19041+ and Windows 11.
+  - Run this in a command prompt `wsl --install -d Ubuntu-18.04` or download Ubuntu 18.04 from the Microsoft Store. Restart as needed and setup a user/pass for your account.
+* Docker Desktop for Linux (Ubuntu)
+  - Follow the instructions from the official docs https://docs.docker.com/engine/install/ubuntu/
+
+#### Steps
+
+1. On Windows, build InstrumentationEngine for Debug AnyCPU (which builds managed projects and dlls) 
+  - You can also run `dotnet build InstrumentationEngine.sln` in the interactive container session from step 2 instead. 
+2. Run `src\scripts\DockerLocalBuild.ps1 -Wsl -BuildDockerImage -Interactive -RebuildImage`. This will build a docker container and drop you in an interactive session. By default builds for Ubuntu/Debian; set `-CLib musl` if you want to build for Alpine Linux instead.
+3. Run `./src/build.sh` within the interactive session. This builds the native shared object files (.so).
+4. Run `dotnet test bin/Debug/AnyCPU/net70/InstrEngineTests.dll`
+
+Please contact clrieowners@microsoft.com for any details or questions.

--- a/src/Common.Lib/XmlNode.cpp
+++ b/src/Common.Lib/XmlNode.cpp
@@ -82,7 +82,15 @@ namespace CommonLib
         name = pName.m_str;
 
     #else
-        IfFailRet(SystemString::Convert((const char*)m_pNode->name, name));
+        // LibXML2 will return an empty string for comment node names so we mark it as '#comment'.
+        if (m_pNode->type == XML_COMMENT_NODE)
+        {
+            name = _T("#comment");
+        }
+        else
+        {
+            IfFailRet(SystemString::Convert((const char*)m_pNode->name, name));
+        }
     #endif
 
         return S_OK;

--- a/src/InstrumentationEngine.Attach/InstrumentationEngine.Attach.csproj
+++ b/src/InstrumentationEngine.Attach/InstrumentationEngine.Attach.csproj
@@ -42,7 +42,11 @@
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta1.20104.2" />
   </ItemGroup>
   <Import Project="$(EnlistmentRoot)\build\Managed.targets" />
-  <Target Name="XsdGeneration" AfterTargets="PrepareForBuild" Inputs="@(XsdSchemaFile)" Outputs="@(XsdSchemaFile.OutputFile)" Condition="'@(XsdSchemaFile)' != ''">
+  <Target Name="XsdGeneration" 
+          AfterTargets="PrepareForBuild" 
+          Inputs="@(XsdSchemaFile)" 
+          Outputs="@(XsdSchemaFile.OutputFile)" 
+          Condition="$([MSBuild]::IsOSPlatform('Windows')) AND '@(XsdSchemaFile)' != ''">
     <Error Condition="'%(XsdSchemaFile.Namespace)' == ''" Text="Missing Namespace attribute for XsdSchemaFile %(XsdSchemaFile.FullPath)" />
     <PropertyGroup>
       <XsdToolPath Condition="!Exists('$(XsdToolPath)')">$(MSBuildProgramFiles32)\Microsoft SDKs\Windows\v10.0A\bin\NETFX 4.8 Tools\xsd.exe</XsdToolPath>

--- a/src/InstrumentationEngine/ProfilerManagerForInstrumentationMethod.cpp
+++ b/src/InstrumentationEngine/ProfilerManagerForInstrumentationMethod.cpp
@@ -24,9 +24,15 @@ CProfilerManagerForInstrumentationMethod::CProfilerManagerForInstrumentationMeth
         // 1 offset = trim start bracket
         // 36 length = keep only Guid portion
         m_wszInstrumentationMethodGuid = tstring(wszCurrentMethodGuid).substr(1, 36);
+        for (int i = 0; i < 36; i++)
+        {
+            m_wszInstrumentationMethodGuid[i] = std::toupper(m_wszInstrumentationMethodGuid[i]);
+        }
+
         m_instrumentationMethodGuid = instrumentationMethodGuid;
 
         // Get InstrumentationMethod-specific LogLevel Environment Variable
+        // Environment variables are case-insensitive on Windows and case-sensitive on Linux/Mac.
         tstring wszInstrumentationMethodLogLevelEnvVar = _T("MicrosoftInstrumentationEngine_LogLevel_") + m_wszInstrumentationMethodGuid;
         WCHAR wszEnvVar[MAX_PATH];
         if (GetEnvironmentVariable(wszInstrumentationMethodLogLevelEnvVar.c_str(), wszEnvVar, MAX_PATH) > 0)

--- a/src/Tests/InstrEngineTests/InstrEngineTests/InstrEngineTests.csproj
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/InstrEngineTests.csproj
@@ -20,6 +20,7 @@
     <EmbeddedResource Include="EmbeddedResources\**" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="RefStructsTests.cs" />
     <None Remove="EmbeddedResources\InvalidCSharp\readme.txt" />
   </ItemGroup>
   <ItemGroup Condition="!$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net7.0'))">

--- a/src/Tests/InstrEngineTests/InstrEngineTests/MaxStackSizeTests.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/MaxStackSizeTests.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class MaxStackSizeTests
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
@@ -13,7 +13,7 @@ namespace InstrEngineTests
         private const string TestScriptsFolder = "TestScripts";
         private const string ResourcesFolder = "ExtractedResources";
 
-        // All paths are relative to the AnyCPU binaries directory e.g. bin\Debug\AnyCPU
+        // All paths are relative to the AnyCPU binaries directory e.g. bin/Debug/AnyCPU/(framework)
         // Use forward slashes '/' to maintain compatibility between Windows and Linux
         public const string BaselinesBinPath = @"./" + BaselinesFolder;
         public const string TestScriptsBinPath = @"./" + TestScriptsFolder;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
@@ -24,7 +24,7 @@ namespace InstrEngineTests
         public const string NaglerInstrumentationMethodX64BinPath = @"../../x64/NaglerInstrumentationMethod_x64.dll";
         public const string NaglerInstrumentationMethodX86BinPath = @"../../x86/NaglerInstrumentationMethod_x86.dll";
         public const string LinuxInstrumentationEngineX64BinPath = @"../../../../out/Linux/bin/x64.Debug/ClrInstrumentationEngine/libInstrumentationEngine.so";
-        public const string LinuxNaglerInstrumentationConfigX64BinPath = @"../../x64/LinuxNaglerInstrumentationMethod.xml";
+        public const string LinuxNaglerInstrumentationConfigX64BinPath = @"../../../../out/Linux/bin/x64.Debug/ClrInstrumentationEngine/NaglerInstrumentationMethod/LinuxNaglerInstrumentationMethod.xml";
         public const string LinuxNaglerInstrumentationMethodX64BinPath = @"../../../../out/Linux/bin/x64.Debug/ClrInstrumentationEngine/libNaglerInstrumentationEngine.so";
 
         public static string GetAssetsPath()

--- a/src/Tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/PathUtils.cs
@@ -14,14 +14,18 @@ namespace InstrEngineTests
         private const string ResourcesFolder = "ExtractedResources";
 
         // All paths are relative to the AnyCPU binaries directory e.g. bin\Debug\AnyCPU
-        public const string BaselinesBinPath = @".\" + BaselinesFolder;
-        public const string TestScriptsBinPath = @".\" + TestScriptsFolder;
-        public const string InstrumentationEngineX64BinPath = @"..\..\x64\MicrosoftInstrumentationEngine_x64.dll";
-        public const string InstrumentationEngineX86BinPath = @"..\..\x86\MicrosoftInstrumentationEngine_x86.dll";
-        public const string NaglerInstrumentationConfigX64BinPath = @"..\..\x64\NaglerInstrumentationMethod_x64.xml";
-        public const string NaglerInstrumentationConfigX86BinPath = @"..\..\x86\NaglerInstrumentationMethod_x86.xml";
-        public const string NaglerInstrumentationMethodX64BinPath = @"..\..\x64\NaglerInstrumentationMethod_x64.dll";
-        public const string NaglerInstrumentationMethodX86BinPath = @"..\..\x86\NaglerInstrumentationMethod_x86.dll";
+        // Use forward slashes '/' to maintain compatibility between Windows and Linux
+        public const string BaselinesBinPath = @"./" + BaselinesFolder;
+        public const string TestScriptsBinPath = @"./" + TestScriptsFolder;
+        public const string InstrumentationEngineX64BinPath = @"../../x64/MicrosoftInstrumentationEngine_x64.dll";
+        public const string InstrumentationEngineX86BinPath = @"../../x86/MicrosoftInstrumentationEngine_x86.dll";
+        public const string NaglerInstrumentationConfigX64BinPath = @"../../x64/NaglerInstrumentationMethod_x64.xml";
+        public const string NaglerInstrumentationConfigX86BinPath = @"../../x86/NaglerInstrumentationMethod_x86.xml";
+        public const string NaglerInstrumentationMethodX64BinPath = @"../../x64/NaglerInstrumentationMethod_x64.dll";
+        public const string NaglerInstrumentationMethodX86BinPath = @"../../x86/NaglerInstrumentationMethod_x86.dll";
+        public const string LinuxInstrumentationEngineX64BinPath = @"../../../../out/Linux/bin/x64.Debug/ClrInstrumentationEngine/libInstrumentationEngine.so";
+        public const string LinuxNaglerInstrumentationConfigX64BinPath = @"../../x64/LinuxNaglerInstrumentationMethod.xml";
+        public const string LinuxNaglerInstrumentationMethodX64BinPath = @"../../../../out/Linux/bin/x64.Debug/ClrInstrumentationEngine/libNaglerInstrumentationEngine.so";
 
         public static string GetAssetsPath()
         {

--- a/src/Tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -44,6 +45,7 @@ namespace InstrEngineTests
         private const string ProfilerPathEnvVarName = "CORECLR_PROFILER_PATH";
         private const string DotnetExeX64EnvVarName = "DOTNET_EXE_X64";
         private const string DotnetExeX86EnvVarName = "DOTNET_EXE_X86";
+        private const string LinuxDotnetEnvVarName = "DOTNET_EXE";
 #else
         private const string EnableProfilingEnvVarName = "COR_ENABLE_PROFILING";
         private const string ProfilerEnvVarName = "COR_PROFILER";
@@ -52,7 +54,7 @@ namespace InstrEngineTests
 
         #endregion
 
-        public const int TestAppTimeoutMs = 25000;
+        public const int TestAppTimeoutMs = 25000; // int.MaxValue
 
         // In order to debug the host process, set this to true and a messagebox will be thrown early in the profiler
         // startup to allow attaching a debugger.
@@ -72,6 +74,7 @@ namespace InstrEngineTests
             ProfilerHelpers.DiffResultToBaseline(parameters.TestContext, fileName, fileName, regexCompare);
         }
 
+#pragma warning disable CA1502
         public static void LaunchAppUnderProfiler(TestParameters parameters, string testApp, string testScript, string output, bool isRejit = true, string args = null, int timeoutMs = TestAppTimeoutMs)
         {
             if (!BinaryRecompiled)
@@ -90,14 +93,25 @@ namespace InstrEngineTests
             bool is32bitTest = Is32bitTest(testScript);
             string bitnessSuffix = is32bitTest ? "x86" : "x64";
 
-            // TODO: call this only for 64bit OS
-            SetBitness(is32bitTest);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                // TODO: call this only for 64bit OS
+                SetBitness(is32bitTest);
+            }
 
             System.Diagnostics.ProcessStartInfo psi = new System.Diagnostics.ProcessStartInfo();
             psi.UseShellExecute = false;
             psi.EnvironmentVariables.Add(EnableProfilingEnvVarName, "1");
             psi.EnvironmentVariables.Add(ProfilerEnvVarName, ProfilerGuid.ToString("B", CultureInfo.InvariantCulture));
-            psi.EnvironmentVariables.Add(ProfilerPathEnvVarName, Path.Combine(PathUtils.GetAssetsPath(), string.Format(CultureInfo.InvariantCulture, "MicrosoftInstrumentationEngine_{0}.dll", bitnessSuffix)));
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                psi.EnvironmentVariables.Add(ProfilerPathEnvVarName, Path.Combine(PathUtils.GetAssetsPath(), string.Format(CultureInfo.InvariantCulture, "MicrosoftInstrumentationEngine_{0}.dll", bitnessSuffix)));
+            }
+            else
+            {
+                psi.EnvironmentVariables.Add(ProfilerPathEnvVarName, Path.Combine(PathUtils.GetAssetsPath(), "libInstrumentationEngine.so"));
+            }
+
             psi.RedirectStandardError = true;
 
             if (EnableRefRecording)
@@ -174,9 +188,19 @@ namespace InstrEngineTests
             }
 
             psi.EnvironmentVariables.Add(TestOutputEnvName, PathUtils.GetAssetsPath());
-            psi.EnvironmentVariables.Add(
-                is32bitTest ? HostConfig32PathEnvName : HostConfig64PathEnvName,
-                Path.Combine(PathUtils.GetAssetsPath(), string.Format(CultureInfo.InvariantCulture, "NaglerInstrumentationMethod_{0}.xml", bitnessSuffix)));
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                psi.EnvironmentVariables.Add(
+                    is32bitTest ? HostConfig32PathEnvName : HostConfig64PathEnvName,
+                    Path.Combine(PathUtils.GetAssetsPath(), string.Format(CultureInfo.InvariantCulture, "NaglerInstrumentationMethod_{0}.xml", bitnessSuffix)));
+            }
+            else // Linux
+            {
+                psi.EnvironmentVariables.Add(
+                    HostConfig64PathEnvName,
+                    Path.Combine(PathUtils.GetAssetsPath(), "LinuxNaglerInstrumentationMethod.xml"));
+            }
 
             string scriptPath = Path.Combine(PathUtils.GetTestScriptsPath(), testScript);
 
@@ -190,11 +214,13 @@ namespace InstrEngineTests
             string appPathWithoutExtension = Path.Combine(PathUtils.GetAssetsPath(), testApp);
 
 #if NETCOREAPP
-            string dotnetExeEnvVarName = is32bitTest ? DotnetExeX86EnvVarName : DotnetExeX64EnvVarName;
+            string dotnetExeEnvVarName = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ?
+                is32bitTest ? DotnetExeX86EnvVarName : DotnetExeX64EnvVarName
+                : LinuxDotnetEnvVarName;
+
             string hostPath = Environment.GetEnvironmentVariable(dotnetExeEnvVarName);
             if (string.IsNullOrEmpty(hostPath))
             {
-                
                 string programFilesFolder = is32bitTest ?
                     Environment.ExpandEnvironmentVariables("%ProgramFiles(x86)%") :
                     Environment.ExpandEnvironmentVariables("%ProgramW6432%");
@@ -237,8 +263,9 @@ namespace InstrEngineTests
                 Console.WriteLine($"stderr: {stderr}");
             }
             Assert.IsTrue(testCompleted, "Test process timed out during execution.");
-            Assert.AreEqual(0, testProcess.ExitCode, $"Test application failed. Error '0x{testProcess.ExitCode:X}");
+            Assert.AreEqual(0, testProcess.ExitCode, $"Test application failed. Error '0x{testProcess.ExitCode:X}'");
         }
+#pragma warning restore CA1502
 
         public static string[] SplitXmlDocuments(string content)
         {

--- a/src/Tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/ProfilerHelpers.cs
@@ -195,7 +195,13 @@ namespace InstrEngineTests
                     is32bitTest ? HostConfig32PathEnvName : HostConfig64PathEnvName,
                     Path.Combine(PathUtils.GetAssetsPath(), string.Format(CultureInfo.InvariantCulture, "NaglerInstrumentationMethod_{0}.xml", bitnessSuffix)));
             }
-            else // Linux
+#if NETCOREAPP
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.FreeBSD))
+            {
+                Console.Error.WriteLine($"{OSPlatform.FreeBSD:G} is not supported.");
+            }
+#endif
+            else
             {
                 psi.EnvironmentVariables.Add(
                     HostConfig64PathEnvName,

--- a/src/Tests/InstrEngineTests/InstrEngineTests/RefStructsTests.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/RefStructsTests.cs
@@ -29,105 +29,70 @@ namespace InstrEngineTests
             Context = context;
         }
 
-        [TestMethod]
+        [WindowsTestMethod]
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_RefStructWithRefField_Load()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
-            {
-                Assert.Inconclusive("RefStructs tests are only available on Windows");
-            }
-
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
                 "RefStructsTest_RefStructWithRefField_Load.xml");
         }
 
-        [TestMethod]
+        [WindowsTestMethod]
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_Create_RefField()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
-            {
-                Assert.Inconclusive("RefStructs tests are only available on Windows");
-            }
-
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
                 "RefStructsTest_Create_RefField.xml");
         }
 
-        [TestMethod]
+        [WindowsTestMethod]
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_Create_RefStructField()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
-            {
-                Assert.Inconclusive("RefStructs tests are only available on Windows");
-            }
-
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
                 "RefStructsTest_Create_RefStructField.xml");
         }
 
-        [TestMethod]
+        [WindowsTestMethod]
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_Create_TypedReferenceRefField()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
-            {
-                Assert.Inconclusive("RefStructs tests are only available on Windows");
-            }
-
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
                 "RefStructsTest_Create_TypedReferenceRefField.xml");
         }
 
-        [TestMethod]
+        [WindowsTestMethod]
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_Casting_Scenarios()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
-            {
-                Assert.Inconclusive("RefStructs tests are only available on Windows");
-            }
-
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
                 "RefStructsTest_Casting_Scenarios.xml");
         }
 
-        [TestMethod]
+        [WindowsTestMethod]
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_RecognizedOpCodeSequences_Scenarios()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
-            {
-                Assert.Inconclusive("RefStructs tests are only available on Windows");
-            }
-
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
                 "RefStructsTest_RecognizedOpCodeSequences_Scenarios.xml");
         }
 
-        [TestMethod]
+        [WindowsTestMethod]
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_Inlining_Behavior()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
-            {
-                Assert.Inconclusive("RefStructs tests are only available on Windows");
-            }
-
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",

--- a/src/Tests/InstrEngineTests/InstrEngineTests/RefStructsTests.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/RefStructsTests.cs
@@ -1,8 +1,10 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Runtime.InteropServices;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
+// This file is only compiled for net70
 namespace InstrEngineTests
 {
     [TestClass]
@@ -31,6 +33,11 @@ namespace InstrEngineTests
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_RefStructWithRefField_Load()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            {
+                Assert.Inconclusive("RefStructs tests are only available on Windows");
+            }
+
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
@@ -41,6 +48,11 @@ namespace InstrEngineTests
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_Create_RefField()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            {
+                Assert.Inconclusive("RefStructs tests are only available on Windows");
+            }
+
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
@@ -51,6 +63,11 @@ namespace InstrEngineTests
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_Create_RefStructField()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            {
+                Assert.Inconclusive("RefStructs tests are only available on Windows");
+            }
+
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
@@ -61,6 +78,11 @@ namespace InstrEngineTests
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_Create_TypedReferenceRefField()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            {
+                Assert.Inconclusive("RefStructs tests are only available on Windows");
+            }
+
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
@@ -71,6 +93,11 @@ namespace InstrEngineTests
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_Casting_Scenarios()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            {
+                Assert.Inconclusive("RefStructs tests are only available on Windows");
+            }
+
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
@@ -81,6 +108,11 @@ namespace InstrEngineTests
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_RecognizedOpCodeSequences_Scenarios()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            {
+                Assert.Inconclusive("RefStructs tests are only available on Windows");
+            }
+
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",
@@ -91,6 +123,11 @@ namespace InstrEngineTests
         [Timeout(TestConstants.TestTimeout)]
         public void TestRefStructs_Validate_Inlining_Behavior()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) 
+            {
+                Assert.Inconclusive("RefStructs tests are only available on Windows");
+            }
+
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "RefStructsTests_Release_x64",

--- a/src/Tests/InstrEngineTests/InstrEngineTests/RuntimeExceptionCallbacks.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/RuntimeExceptionCallbacks.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class RuntimeExceptionCallbacks
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TargetAppCompiler.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TargetAppCompiler.cs
@@ -73,7 +73,10 @@ namespace InstrEngineTests
         internal static void CompileTestCode(string directoryPath)
         {
 #if NET7_0_OR_GREATER
-            AssembleILTestCode(directoryPath);
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                AssembleILTestCode(directoryPath);
+            }
 #endif
             CompileCSharpTestCode(directoryPath);
         }

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestAddExceptionHandler.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestAddExceptionHandler.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestAddExceptionHandler
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestAddInstruction.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestAddInstruction.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Runtime.InteropServices;
 
 namespace InstrEngineTests
 {
@@ -21,6 +22,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestAddInstruction
     {
         private static TestContext Context;
@@ -35,6 +39,11 @@ namespace InstrEngineTests
         [Timeout(TestConstants.TestTimeout)]
         public void AddNop_IfTest_Debug()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Inconclusive("x86 tests are only available on Windows");
+            }
+
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "BasicManagedTests_Debug_x86",
@@ -75,6 +84,11 @@ namespace InstrEngineTests
         [Timeout(TestConstants.TestTimeout)]
         public void AddNop_ForTest_Debug()
         {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                Assert.Inconclusive("x86 tests are only available on Windows");
+            }
+
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "BasicManagedTests_Debug_x86",

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestAddInstruction.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestAddInstruction.cs
@@ -35,15 +35,10 @@ namespace InstrEngineTests
             Context = context;
         }
 
-        [TestMethod]
+        [WindowsTestMethod] // because of x86
         [Timeout(TestConstants.TestTimeout)]
         public void AddNop_IfTest_Debug()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Assert.Inconclusive("x86 tests are only available on Windows");
-            }
-
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "BasicManagedTests_Debug_x86",
@@ -80,15 +75,10 @@ namespace InstrEngineTests
                 "AddBranchTargets_SwitchTest.xml");
         }
 
-        [TestMethod]
+        [WindowsTestMethod] // because of x86
         [Timeout(TestConstants.TestTimeout)]
         public void AddNop_ForTest_Debug()
         {
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                Assert.Inconclusive("x86 tests are only available on Windows");
-            }
-
             ProfilerHelpers.LaunchAppAndCompareResult(
                 TestParameters.FromContext(Context),
                 "BasicManagedTests_Debug_x86",

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestDynamicCode.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestDynamicCode.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestDynamicCode
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestException.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestException.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestException
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestHttpMethods.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestHttpMethods.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestHttpMethods
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestInjectToMscorlib.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestInjectToMscorlib.cs
@@ -15,6 +15,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestInjectToMscorlib
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestInstruOperations.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestInstruOperations.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestInstruOperations
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestInstrumentationMethodLogging.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestInstrumentationMethodLogging.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestInstrumentationMethodLogging
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestLocals.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestLocals.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestLocals
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestMethodReplacement.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestMethodReplacement.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class MethodReplacement
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestMultiReturn.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestMultiReturn.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestMultiReturn
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestOperand.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestOperand.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class AddOperands
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestRejit.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestRejit.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestRejit
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/TestRoundTrip.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/TestRoundTrip.cs
@@ -21,6 +21,9 @@ namespace InstrEngineTests
     [DeploymentItem(PathUtils.NaglerInstrumentationConfigX86BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX64BinPath)]
     [DeploymentItem(PathUtils.NaglerInstrumentationMethodX86BinPath)]
+    [DeploymentItem(PathUtils.LinuxInstrumentationEngineX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationConfigX64BinPath)]
+    [DeploymentItem(PathUtils.LinuxNaglerInstrumentationMethodX64BinPath)]
     public class TestRoundTrip
     {
         private static TestContext Context;

--- a/src/Tests/InstrEngineTests/InstrEngineTests/WindowsTestMethodAttribute.cs
+++ b/src/Tests/InstrEngineTests/InstrEngineTests/WindowsTestMethodAttribute.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace InstrEngineTests
+{
+    /// <summary>
+    /// Use this attribute on TestMethods that should only run on Windows.
+    /// </summary>
+    internal class WindowsTestMethodAttribute : TestMethodAttribute
+    {
+        public override TestResult[] Execute(ITestMethod testMethod)
+        {
+            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return new[] {
+                    new TestResult()
+                    {
+                        Outcome = UnitTestOutcome.Inconclusive,
+                         TestFailureException = new AssertInconclusiveException("Test only runs on Windows")
+
+                    }};
+            }
+
+            return base.Execute(testMethod);
+        }
+    }
+}

--- a/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/CMakeLists.txt
+++ b/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/CMakeLists.txt
@@ -22,7 +22,7 @@ set(src_files
 )
 
 add_lib(${PROJECT_NAME}
-    STATIC
+    SHARED
     false # use_pal
     false # use_redefines
     true # hide_symbols
@@ -49,7 +49,6 @@ target_link_libraries(
     stdc++
     ${LIBXML2_LIBRARIES}
     Common.Lib
-    LibXml2
 )
 
 if (CMAKE_SYSTEM_NAME STREQUAL Linux)

--- a/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/CMakeLists.txt
+++ b/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/CMakeLists.txt
@@ -60,3 +60,8 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin)
         "-framework Security"
     )
 endif()
+
+configure_file(
+    ${REPOSITORY_ROOT}/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/LinuxNaglerInstrumentationMethod.xml 
+    ${CMAKE_INSTALL_PREFIX}/LinuxNaglerInstrumentationMethod.xml
+    COPYONLY)

--- a/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/LinuxNaglerInstrumentationMethod.xml
+++ b/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/LinuxNaglerInstrumentationMethod.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright (c) Microsoft Corporation. All rights reserved.
+     Licensed under the MIT License. -->
+<InstrumentationEngineConfiguration>
+  <InstrumentationMethod>
+    <Name>Instrumentation Method Test Harness</Name>
+    <Description>Enable testing instrumentation in the instrumentation engine</Description>
+    <Module>libNaglerInstrumentationEngine.so</Module>
+    <ClassGuid>{D2959618-F9B6-4CB6-80CF-F3B0E3263888}</ClassGuid>
+    <Priority>50</Priority>
+  </InstrumentationMethod>
+</InstrumentationEngineConfiguration>

--- a/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.cpp
+++ b/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.cpp
@@ -84,7 +84,7 @@ HRESULT CInstrumentationMethod::Initialize(_In_ IProfilerManager* pProfilerManag
     IfFailRet(m_pProfilerManager->QueryInterface(&m_pStringManager));
 
 #ifdef PLATFORM_UNIX
-    DWORD retVal = LoadInstrumentationMethodXml(nullptr);
+    DWORD retVal = LoadInstrumentationMethodXml(this);
 #else
     // On Windows, xml reading is done in a single-threaded apartment using 
     // COM, so we need to spin up a new thread for it.
@@ -163,7 +163,7 @@ HRESULT CInstrumentationMethod::LoadTestScript()
     if (hr != S_OK)
     {
         AssertFailed("Failed to load test configuration");
-        return -1;
+        return E_FAIL;
     }
 
     CComPtr<CXmlNode> pDocumentNode;
@@ -174,7 +174,7 @@ HRESULT CInstrumentationMethod::LoadTestScript()
 
     if (wcscmp(strDocumentNodeName.c_str(), _T("InstrumentationTestScript")) != 0)
     {
-        return -1;
+        return E_FAIL;
     }
 
 
@@ -214,8 +214,11 @@ HRESULT CInstrumentationMethod::LoadTestScript()
         }
         else
         {
+            std::string utf8NodeName;
+            SystemString::Convert(strCurrNodeName.c_str(), utf8NodeName);
             AssertFailed("Invalid configuration. Element should be InstrumentationMethod");
-            return -1;
+            AssertFailed(utf8NodeName.c_str());
+            return E_FAIL;
         }
 
         pChildNode = pChildNode->Next();
@@ -348,7 +351,10 @@ HRESULT CInstrumentationMethod::ProcessInstrumentMethodNode(CXmlNode* pNode)
         }
         else
         {
+            std::string utf8NodeName;
+            SystemString::Convert(strCurrNodeName.c_str(), utf8NodeName);
             AssertFailed("Invalid configuration. Unknown Element");
+            AssertFailed(utf8NodeName.c_str());
             return E_FAIL;
         }
 

--- a/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.vcxproj
+++ b/src/Tests/InstrEngineTests/NaglerInstrumentationMethod/NaglerInstrumentationMethod.vcxproj
@@ -144,6 +144,14 @@
     <Content Include="NaglerInstrumentationMethod_x86.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <Content Include="LinuxNaglerInstrumentationMethod.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Common.Lib\Common.Lib.vcxproj">
+      <Project>{a0585fab-548f-44b3-bcbe-9242cbc26a19}</Project>
+    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\Common.Lib\Common.Lib.vcxproj">

--- a/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
+++ b/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
@@ -20,8 +20,14 @@ RUN apt-get install -y --no-install-recommends apt-transport-https \
     && apt-get update \
     && apt-get install -y --no-install-recommends dotnet-sdk-2.1
 
+RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 7.0
+
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help
+
+RUN echo 'export DOTNET_ROOT=$HOME/.dotnet' >> ~/.bashrc
+RUN echo 'export DOTNET_EXE=$DOTNET_ROOT/dotnet' >> ~/.bashrc
+RUN echo 'export PATH=$DOTNET_ROOT:$DOTNET_ROOT/tools:$PATH' >> ~/.bashrc
 
 # get the signing key for the kitware (cmake) repository
 RUN curl https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null

--- a/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
+++ b/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get install -y --no-install-recommends apt-transport-https \
     && apt-get update \
     && apt-get install -y --no-install-recommends dotnet-sdk-2.1
 
+# Install .NET 7 SDK
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 7.0
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
@@ -46,3 +47,7 @@ RUN apt-get update \
         libxml2-dev \
         make \
         jq
+
+# Git now checks for repository ownership
+RUN git config --global --add safe.directory /root/ClrInstrumentationEngine/out/Linux/Intermediate/x64.Debug/_deps/googletest-src
+RUN git config --global --add safe.directory /root/ClrInstrumentationEngine


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

These changes fix InstrEngineTests.dll run on Linux.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
* Fix XmlNode to correctly parse comment nodes with LibXML2
* Fix InstrumentationMethod logging variable check since Linux has case-sensitive environment variables
* Add Nagler config & .so & update DeploymentItems for tests
* Update ProfilerHelper.cs to be OS-aware
* Minor fixes to Nagler's CMake
* Update InstrumentationEngineApi.cpp to log module load failures to stderrr
* Update Ubuntu DockerFile to install net7 dotnet
* Update PR.yaml to run linux tests - https://dev.azure.com/ms/CLRInstrumentationEngine/_build/results?buildId=382640&view=results

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->

Local build & test
