### PR TITLE
Remove Ubuntu builds from GitHub workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         # Note OSX isn't officially supported yet, but might be in the future.
         # The build here will help ensure no changes are introduced that
         # would make it difficult.
-        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-18.04, macos-latest ]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
         # Note OSX isn't officially supported yet, but might be in the future.
         # The build here will help ensure no changes are introduced that
         # would make it difficult.
-        os: [ ubuntu-18.04, macos-latest ]
+        os: [ macos-latest ]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Current GitHub workflow builds with latest Ubuntu (20.04 or 22.04) which appears to consistently fail. Our CI builds with Ubuntu 18.04 (unavailable) so for now unblock PRs with this chagne.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Remove Ubuntu-latest from `runs-on` matrix.

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
