### PR TITLE
Create internal CI & PR builds

### DIFF
--- a/build/yaml/jobs/linux/packages.yaml
+++ b/build/yaml/jobs/linux/packages.yaml
@@ -33,7 +33,7 @@ jobs:
   - checkout: self
     clean: true
 
-  - ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
+  - ${{ if and(eq('true', parameters.IsMicroBuildInternal), notIn(parameters.SignType, '', 'None')) }}:
     - template: ../../steps/microbuild/signing.yaml@self
       parameters:
         SignType: ${{ parameters.SignType }}
@@ -42,7 +42,7 @@ jobs:
     parameters:
       OneESPT: ${{ parameters.OneESPT }}
 
-  - ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
+  - ${{ if and(eq('true', parameters.IsMicroBuildInternal), notIn(parameters.SignType, '', 'None')) }}:
     - template: ../../steps/microbuild/codesignverify.yaml@self
       parameters:
         SignType: ${{ parameters.SignType }}

--- a/build/yaml/jobs/windows/binaries.yaml
+++ b/build/yaml/jobs/windows/binaries.yaml
@@ -41,7 +41,7 @@ jobs:
   
   - template: ../../steps/azuredevops/usedotnet.yaml@self
 
-  - ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
+  - ${{ if and(eq('true', parameters.IsMicroBuildInternal), notIn(parameters.SignType, '', 'None')) }}:
     - template: ../../steps/microbuild/signing.yaml@self
       parameters:
         SignType: ${{ parameters.SignType }}
@@ -51,7 +51,7 @@ jobs:
       IsMicroBuildInternal: ${{ parameters.IsMicroBuildInternal }}
       OneESPT: ${{ parameters.OneESPT }}
 
-  - ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
+  - ${{ if and(eq('true', parameters.IsMicroBuildInternal), notIn(parameters.SignType, '', 'None')) }}:
     - template: ../../steps/microbuild/codesignverify.yaml@self
       parameters:
         SignType: ${{ parameters.SignType }}

--- a/build/yaml/jobs/windows/packages.yaml
+++ b/build/yaml/jobs/windows/packages.yaml
@@ -33,7 +33,7 @@ jobs:
   - checkout: self
     clean: true
 
-  - ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
+  - ${{ if and(eq('true', parameters.IsMicroBuildInternal), notIn(parameters.SignType, '', 'None')) }}:
     - template: ../../steps/microbuild/signing.yaml@self
       parameters:
         SignType: ${{ parameters.SignType }}
@@ -47,7 +47,7 @@ jobs:
       WindowsBinRoot: $(Build.ArtifactStagingDirectory)\binaries-windows-$(Configuration)
       OneESPT: ${{ parameters.OneESPT }}
 
-  - ${{ if eq('true', parameters.IsMicroBuildInternal) }}:
+  - ${{ if and(eq('true', parameters.IsMicroBuildInternal), notIn(parameters.SignType, '', 'None')) }}:
     - template: ../../steps/microbuild/codesignverify.yaml@self
       parameters:
         SignType: ${{ parameters.SignType }}

--- a/build/yaml/pipelines/ci.yaml
+++ b/build/yaml/pipelines/ci.yaml
@@ -12,28 +12,7 @@ variables:
   TeamName: ClrInstrumentationEngine
 
 stages:
-- stage: Build
-  jobs:
-  # Binaries (Windows & Linux)
-  - template: ../jobs/binaries.yaml@self
-    parameters:
-      IndexSources: true
-      Configuration: Both
-      OneESPT: false
-
-- stage: Test
-  dependsOn: Build
-  jobs:
-  # Tests (Windows)
-  - template: ../jobs/tests.yaml@self
-    parameters:
-      Configuration: Both
-
-- stage: Package
-  dependsOn: Build
-  jobs:
-  # Packages (Windows & Linux)
-  - template: ../jobs/packages.yaml@self
-    parameters:
-      Configuration: Both
-      OneESPT: false
+- template: ../stages/build_and_package.yaml@self
+  parameters:
+    OneESPT: false
+    IsMicroBuildInternal: false

--- a/build/yaml/pipelines/ci_internal.yaml
+++ b/build/yaml/pipelines/ci_internal.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Build Pipeline: Continuous Integration (Internal)
+# Validates:
+# - binaries can be built for all platforms and configurations
+# - packages can be built for all platforms and configurations
+
+name: $(date:yyyyMMdd)$(rev:rr)
+
+variables:
+  TeamName: ClrInstrumentationEngine
+
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
+  parameters:
+    pool:
+      name: VSEngSS-Microbuild2022-1ES
+      os: windows
+    sdl:
+      sourceAnalysisPool:
+        name: VSEngSS-MicroBuild2022-1ES
+        os: windows 
+      binskim:
+        enabled: false
+        justificationForDisabling: 'Currently fails for debug builds. Disabling because we run binSkim in a separate pipeline.'
+
+    stages:
+    - template: ../stages/build_and_package.yaml@self
+      parameters:
+        OneESPT: true
+        IsMicroBuildInternal: true

--- a/build/yaml/pipelines/pr.yaml
+++ b/build/yaml/pipelines/pr.yaml
@@ -12,27 +12,7 @@ variables:
   TeamName: ClrInstrumentationEngine
 
 stages:
-- stage: Build
-  jobs:
-  # Binaries (Windows & Linux)
-  - template: ../jobs/binaries.yaml@self
-    parameters:
-      Configuration: Both
-      OneESPT: false
-
-- stage: Test
-  dependsOn: Build
-  jobs:
-  # Tests (Windows)
-  - template: ../jobs/tests.yaml@self
-    parameters:
-      Configuration: Both
-
-- stage: Package
-  dependsOn: Build
-  jobs:
-  # Packages (Windows & Linux)
-  - template: ../jobs/packages.yaml@self
-    parameters:
-      Configuration: Both
-      OneESPT: false
+- template: ../stages/build_and_package.yaml@self
+  parameters:
+    OneESPT: false
+    IsMicroBuildInternal: false

--- a/build/yaml/pipelines/pr_internal.yaml
+++ b/build/yaml/pipelines/pr_internal.yaml
@@ -1,0 +1,39 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Build Pipeline: Pull Request (Internal)
+# Validates:
+# - binaries can be built for all platforms and configurations
+# - packages can be built for all platforms and configurations
+
+name: $(date:yyyyMMdd)$(rev:rr)
+
+variables:
+  TeamName: ClrInstrumentationEngine
+
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Unofficial.yml@MicroBuildTemplate
+  parameters:
+    pool:
+      name: VSEngSS-Microbuild2022-1ES
+      os: windows
+    sdl:
+      sourceAnalysisPool:
+        name: VSEngSS-MicroBuild2022-1ES
+        os: windows 
+      binskim:
+        enabled: false
+        justificationForDisabling: 'Currently fails for debug builds. Disabling because we run binSkim in a separate pipeline.'
+
+    stages:
+    - template: ../stages/build_and_package.yaml@self
+      parameters:
+        OneESPT: true
+        IsMicroBuildInternal: true

--- a/build/yaml/pipelines/signed.yaml
+++ b/build/yaml/pipelines/signed.yaml
@@ -32,26 +32,13 @@ extends:
         scanOutputDirectoryOnly: true # BinSkim will complain about VC.Tools not being Spectre compliant, but we use that for builds. This toggles for BinSkim to only scan the output files/folders.
 
     stages:
-    - stage: Build
-      jobs:
-      # Binaries (Windows & Linux)
-      - template: /build/yaml/jobs/binaries.yaml@self
-        parameters:
-          IndexSources: true
-          SignType: $(SignType) # NOTE this string won't be replaced until runtime
-          Configuration: Release
-          IsMicroBuildInternal: true
-          OneESPT: true
-
-    - stage: Package
-      jobs:
-      # Packages (Windows & Linux)
-      - template: /build/yaml/jobs/packages.yaml@self
-        parameters:
-          SignType: $(SignType) # NOTE this string won't be replaced until runtime
-          Configuration: Release
-          IsMicroBuildInternal: true
-          OneESPT: true
+    - template: ../stages/build_and_package.yaml@self
+      parameters:
+        OneESPT: true
+        IsMicroBuildInternal: true
+        IncludeTests: false
+        Configuration: Release
+        SignType: $(SignType) # NOTE this string won't be replaced until runtime
 
     - stage: PostPackage
       jobs:

--- a/build/yaml/stages/build_and_package.yaml
+++ b/build/yaml/stages/build_and_package.yaml
@@ -1,0 +1,39 @@
+parameters:
+  OneESPT: false
+  IsMicroBuildInternal: false
+  IncludeTests: true
+  Configuration: Both
+  SignType: None
+
+stages:
+- stage: Build
+  jobs:
+  # Binaries (Windows & Linux)
+  - template: ../jobs/binaries.yaml@self
+    parameters:
+      SignType: ${{ parameters.SignType}}
+      IndexSources: true
+      Configuration: ${{ parameters.Configuration }}
+      OneESPT: ${{ parameters.OneESPT }}
+      IsMicroBuildInternal: ${{ parameters.IsMicroBuildInternal }}
+
+- ${{ if eq('true', parameters.IncludeTests) }}:
+  - stage: Test
+    dependsOn: Build
+    jobs:
+    # Tests (Windows)
+    - template: ../jobs/tests.yaml@self
+      parameters:
+        Configuration: ${{ parameters.Configuration }}
+        IsMicroBuildInternal: ${{ parameters.IsMicroBuildInternal }}
+
+- stage: Package
+  dependsOn: Build
+  jobs:
+  # Packages (Windows & Linux)
+  - template: ../jobs/packages.yaml@self
+    parameters:
+      SignType: ${{ parameters.SignType}}
+      Configuration: ${{ parameters.Configuration }}
+      OneESPT: ${{ parameters.OneESPT }}
+      IsMicroBuildInternal: ${{ parameters.IsMicroBuildInternal }}

--- a/src/Extensions.Base/Extensions.Base.vcxproj
+++ b/src/Extensions.Base/Extensions.Base.vcxproj
@@ -48,6 +48,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <TreatWarningAsError>true</TreatWarningAsError>
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Midl>
       <HeaderFileName>HostExtension_i.h</HeaderFileName>

--- a/src/InstrumentationEngine.ProfilerProxy.Lib/InstrumentationEngine.ProfilerProxy.Lib.vcxproj
+++ b/src/InstrumentationEngine.ProfilerProxy.Lib/InstrumentationEngine.ProfilerProxy.Lib.vcxproj
@@ -50,6 +50,7 @@
       <AdditionalIncludeDirectories>$(OutDir);..\..\inc;..\..\inc\clr\inc;$(InstrumentationEngineApiInc);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>

--- a/src/InstrumentationEngine.ProfilerProxy/InstrumentationEngine.ProfilerProxy.vcxproj
+++ b/src/InstrumentationEngine.ProfilerProxy/InstrumentationEngine.ProfilerProxy.vcxproj
@@ -78,6 +78,7 @@
       <PreprocessorDefinitions>_WINDOWS;_USRDLL;INSTRUMENTATIONENGINEPROFILERPROXY_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PreprocessorDefinitions Condition="'$(Platform)'=='Win32'">WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
@@ -96,6 +97,7 @@
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <TreatWarningAsError>true</TreatWarningAsError>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
     </ClCompile>
     <Link>
     </Link>

--- a/src/InstrumentationEngine/InstrumentationEngine.vcxproj
+++ b/src/InstrumentationEngine/InstrumentationEngine.vcxproj
@@ -74,6 +74,7 @@
       <PrecompiledHeaderFile>stdafx.h</PrecompiledHeaderFile>
       <ExceptionHandling>Async</ExceptionHandling>
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <CETCompat Condition="'$(Platform)'!='ARM64'">true</CETCompat>
@@ -113,7 +114,6 @@
       <PreprocessorDefinitions Condition="'$(Platform)'=='Win32'">X86;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <UseFullPaths>true</UseFullPaths>
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
       <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>

--- a/src/Tests/CommonLibTests/CommonLibTests.vcxproj
+++ b/src/Tests/CommonLibTests/CommonLibTests.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile>
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(EnlistmentRoot)\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
@@ -93,7 +94,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -109,7 +109,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -124,7 +123,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -141,7 +139,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/src/Tests/InstrumentationEngineLibTests/InstrumentationEngineLibTests.vcxproj
+++ b/src/Tests/InstrumentationEngineLibTests/InstrumentationEngineLibTests.vcxproj
@@ -78,6 +78,7 @@
     <ClCompile>
       <AdditionalOptions>/ZH:SHA_256 %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(EnlistmentRoot)\src;$(EnlistmentRoot)\inc\clr\prof;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
   </ItemDefinitionGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
@@ -108,7 +109,6 @@
       <BasicRuntimeChecks>EnableFastChecks</BasicRuntimeChecks>
       <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -123,7 +123,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -140,7 +139,6 @@
       <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
-      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
<!--
COMMENT BLOCKS WILL NOT BE INCLUDED IN THE PR.
-->

###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->
This change introduces internal builds that mirror our public builds in `dev.azure.com/ms` so that we can remove a cross-org PAT token (scoped to build-artifact-read, used by our test infrastructure) that was getting flagged.

###### Change Log  <!-- REQUIRED -->
<!-- Detail the changes made here. -->
- Consolidate stages into `build_and_package.yaml` template that all top-level pipeline yaml can consume
- Introduce `pr_internal.yaml` and `ci_internal.yaml` that rely on internal templates
- Fixed some binskim issues that popped up (disabled in CI/PR builds as we have a dedicated internal analysis pipeline)

###### Test Methodology
<!-- How was this change validated? i.e. local build, pipeline build etc. -->
Internal builds
* PR: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9314294&view=results
* CI: https://devdiv.visualstudio.com/DevDiv/_build?definitionId=11310&_a=summary
* StaticAnalysis: https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=9314357&view=results