### PR TITLE
Update build Dockerfile base images to latest within OS version

### DIFF
--- a/src/unix/docker/dockerfiles/build/alpine/Dockerfile
+++ b/src/unix/docker/dockerfiles/build/alpine/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright (c) Microsoft Corporation. All rights reserved.
 # Licensed under the MIT License.
 
-FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13-20211214164113-8a6f4f3@sha256:5ee23bef02e18237d1874a4f530e0b7d12ca803af87b2516717565f90540c25c
+FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13@sha256:1fdd7085cf4497b31fa1192f35c8e8cd7e9da343ebe4d969bd4ce977790a8a99
 
 WORKDIR /
 

--- a/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
+++ b/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
@@ -2,7 +2,7 @@
 # Licensed under the MIT License.
 
 # This image is based on the public Ubuntu 18.04 LTS image
-FROM mcr.microsoft.com/mirror/docker/library/ubuntu:18.04@sha256:8aa9c2798215f99544d1ce7439ea9c3a6dfd82de607da1cec3a8a2fae005931b
+FROM mcr.microsoft.com/mirror/docker/library/ubuntu:18.04@sha256:152dc042452c496007f07ca9127571cb9c29697f42acbfad72324b2bb2e43c98
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
###### Summary <!-- REQUIRED -->

Update the base images of the build Dockerfiles to the latest versions within the same OS version.

###### Test Methodology

Internal build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=10411454&view=results