### PR TITLE
Install .NET 6 SDK instead of .NET Core 2.1 SDK

### DIFF
--- a/src/unix/docker/dockerfiles/build/alpine/Dockerfile
+++ b/src/unix/docker/dockerfiles/build/alpine/Dockerfile
@@ -3,38 +3,36 @@
 
 FROM mcr.microsoft.com/dotnet-buildtools/prereqs:alpine-3.13@sha256:1fdd7085cf4497b31fa1192f35c8e8cd7e9da343ebe4d969bd4ce977790a8a99
 
-WORKDIR /
+# Install .NET SDK
+# REFERENCE: https://github.com/dotnet/dotnet-docker/blob/main/src/sdk/6.0/alpine3.20/amd64/Dockerfile
 
-# Install .NET Core 2.1 SDK
-# REFERENCE: https://github.com/dotnet/dotnet-docker/blob/master/2.1/sdk/alpine3.10/amd64/Dockerfile
-
-# Disable the invariant mode (set in base image)
-RUN apk add --no-cache icu-libs
-ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
-    LC_ALL=en_US.UTF-8 \
-    LANG=en_US.UTF-8
-
-# Install .NET Core SDK
-ENV DOTNET_SDK_VERSION 2.1.805
-
-RUN apk add --no-cache --virtual .build-deps \
-        openssl \
-    && wget -O dotnet.tar.gz https://dotnetcli.blob.core.windows.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
-    && dotnet_sha512='6eb76f405c339d8d662ad152b9cd9d0a77957f5538d44bbdc0d2c66f5923bd3064ea9fddcd20e2c2e4a7a051f97e0e99fa0a30ca1649f2c0c6ddbfaaf11831d2' \
-    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
-    && mkdir -p /usr/share/dotnet \
-    && tar -C /usr/share/dotnet -xzf dotnet.tar.gz \
-    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
-    && rm dotnet.tar.gz \
-    && apk del .build-deps
-
-# Enable correct mode for dotnet watch (only mode supported in a container)
-ENV DOTNET_USE_POLLING_FILE_WATCHER=true \
+ENV \
+    # Do not generate certificate
+    DOTNET_GENERATE_ASPNET_CERTIFICATE=false \
+    # Do not show first run text
+    DOTNET_NOLOGO=true \
+    # SDK version
+    DOTNET_SDK_VERSION=6.0.427 \
+    # Disable the invariant mode (set in base image)
+    DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
+    # Enable correct mode for dotnet watch (only mode supported in a container)
+    DOTNET_USE_POLLING_FILE_WATCHER=true \
     # Skip extraction of XML docs - generally not useful within an image/container - helps performance
     NUGET_XMLDOC_MODE=skip
 
-# Trigger first run experience by running arbitrary cmd to populate local package cache
-RUN dotnet help
+RUN apk add --upgrade --no-cache \
+    curl \
+    icu-libs
+
+RUN wget -O dotnet.tar.gz https://dotnetcli.azureedge.net/dotnet/Sdk/$DOTNET_SDK_VERSION/dotnet-sdk-$DOTNET_SDK_VERSION-linux-musl-x64.tar.gz \
+    && dotnet_sha512='38e63bc2e94b5dfbaa5ffcc31e96eaaf9889a86ae03b2bba72ed73434d79857d56566345c65a20c7a5e62f444b8f13a3ed6a3e7e568a3c34c837cfcecd1ca68f' \
+    && echo "$dotnet_sha512  dotnet.tar.gz" | sha512sum -c - \
+    && mkdir -p /usr/share/dotnet \
+    && tar -oxzf dotnet.tar.gz -C /usr/share/dotnet \
+    && rm dotnet.tar.gz \
+    && ln -s /usr/share/dotnet/dotnet /usr/bin/dotnet \
+    # Trigger first run experience by running arbitrary cmd
+    && dotnet help
 
 # CLR Instrumentation Engine Build Prerequisites
 RUN apk update \

--- a/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
+++ b/src/unix/docker/dockerfiles/build/ubuntu/Dockerfile
@@ -10,18 +10,17 @@ RUN apt-get update \
         curl \
         software-properties-common
 
-# Install .NET Core 2.1 SDK
-# https://www.microsoft.com/net/download/linux-package-manager/ubuntu18-04/sdk-2.1.403
+# Install .NET SDKs
+# https://learn.microsoft.com/en-us/dotnet/core/install/linux-ubuntu#register-the-microsoft-package-repository
 RUN curl -SL --output packages-microsoft-prod.deb https://packages.microsoft.com/config/ubuntu/18.04/packages-microsoft-prod.deb \
     && dpkg -i packages-microsoft-prod.deb \
     && rm packages-microsoft-prod.deb
 
 RUN apt-get install -y --no-install-recommends apt-transport-https \
     && apt-get update \
-    && apt-get install -y --no-install-recommends dotnet-sdk-2.1
-
-# Install .NET 7 SDK
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -c 7.0
+    && apt-get install -y --no-install-recommends \
+        dotnet-sdk-6.0 \
+        dotnet-sdk-7.0
 
 # Trigger first run experience by running arbitrary cmd to populate local package cache
 RUN dotnet help


### PR DESCRIPTION
###### Summary <!-- REQUIRED -->
<!-- Quick explanation of the changes. -->

Update the .NET SDK usage from .NET Core 2.1 to .NET 6. The .NET installation within the Alpine Dockerfile was rewritten to match more closely with how `dotnet/dotnet-docker` writes their images.

###### Test Methodology

Internal build: https://dev.azure.com/devdiv/DevDiv/_build/results?buildId=10415307&view=results
