### PR TITLE
Migrate release pipeline 901 to YAML + update deprecated GH actions

### DIFF
--- a/.github/workflows/build.yml.disabled
+++ b/.github/workflows/build.yml.disabled
@@ -28,7 +28,7 @@ jobs:
 
     - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
 
-    - uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+    - uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
       with:
         path: out/packages
         key: nuget
@@ -37,14 +37,14 @@ jobs:
 
     - name: archive so
       if: matrix.os == 'ubuntu-latest'
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: libInstrumentationEngine.so
         path: out/Linux/bin/x64.Release/ClrInstrumentationEngine/libInstrumentationEngine.so
 
     - name: archive dylib
       if: matrix.os == 'macos-latest'
-      uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: libInstrumentationEngine.dylib
         path: out/OSX/bin/x64.Release/ClrInstrumentationEngine/libInstrumentationEngine.dylib

--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -63,7 +63,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: SARIF file
           path: results.sarif

--- a/build/yaml/pipelines/release.yaml
+++ b/build/yaml/pipelines/release.yaml
@@ -1,0 +1,75 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Release Pipeline: CLR Instrumentation Engine Release
+#
+# Migrated from the classic release definition "CLR Instrumentation Engine Release"
+# (https://devdiv.visualstudio.com/DevDiv/_release?definitionId=901).
+#
+# Consumes the signed build artifacts produced by the "Signed" build
+# (build definition 11311 / ClrInstrumentationEngine-Signed-Yaml, see signed.yaml)
+# and publishes the release.
+#
+# Currently only the first classic stage is migrated:
+#   - Publish NuGets to the internal InstrumentationEngine feed (+ optional promote to Release view)
+# The remaining classic environments (preinstalled zip, drop upload/retain, NuGet.org headers,
+# VS feed, VS insertion, symbol/source archival) will be migrated separately.
+#
+# NOTE: This pipeline must be run manually after the Signed build completes.
+# Stage approvals are enforced via Azure DevOps Environment checks (see stages/release.yaml).
+
+name: $(date:yyyyMMdd)$(rev:rr)
+
+trigger: none
+pr: none
+
+variables:
+  TeamName: VS Production Diagnostics
+
+  # Map the classic $(System.ArtifactsDirectory) onto the YAML pipeline-resource workspace.
+  # Pipeline-resource artifacts download to $(Pipeline.Workspace)\<resource alias>\<artifact name>.
+  ArtifactsDirectory: $(Pipeline.Workspace)
+
+  # ---- Artifact path patterns (relative to ArtifactsDirectory) ----
+  WindowsInstrumentationEngineNuGetArtifactPathPattern: ClrInstrumentationEngine-Signed-Yaml\packages-windows-Release\**\Microsoft.InstrumentationEngine*.nupkg
+  LinuxInstrumentationEngineNuGetArtifactPathPattern: ClrInstrumentationEngine-Signed-Yaml\packages-linux-*-Release\**\Microsoft.InstrumentationEngine*.nupkg
+
+  # ---- Contacts ----
+  TeamContact: clrieowners@microsoft.com
+
+  # Set to 'True' (e.g. at queue time) to promote the published packages to the Release view.
+  PromoteToRelease: 'False'
+
+resources:
+  repositories:
+  - repository: MicroBuildTemplate
+    type: git
+    name: 1ESPipelineTemplates/MicroBuildTemplate
+    ref: refs/tags/release
+
+  pipelines:
+  # The signed build that produces the release artifacts (build definition 11311).
+  # The alias is kept identical to the classic release artifact alias so that the
+  # downloaded artifact paths line up with the patterns above.
+  - pipeline: ClrInstrumentationEngine-Signed-Yaml
+    project: DevDiv
+    source: ClrInstrumentationEngine-Signed-Yaml
+    trigger: none
+
+extends:
+  template: azure-pipelines/MicroBuild.1ES.Official.yml@MicroBuildTemplate
+  parameters:
+    pool:
+      name: VSEngSS-Microbuild2022-1ES
+      os: windows
+    sdl:
+      sourceAnalysisPool:
+        name: VSEngSS-MicroBuild2022-1ES
+        os: windows
+      # This pipeline only consumes already-signed/scanned artifacts and publishes them.
+      binskim:
+        enabled: false
+        justificationForDisabling: 'Release pipeline only consumes already-scanned signed artifacts; BinSkim runs in the build pipeline.'
+
+    stages:
+    - template: ../stages/release.yaml@self

--- a/build/yaml/stages/release.yaml
+++ b/build/yaml/stages/release.yaml
@@ -1,0 +1,85 @@
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+
+# Stages Template: CLR Instrumentation Engine Release
+#
+# Migrated from the classic release definition 901. Only the first classic environment,
+# "Publish NuGets to internal InstrumentationEngine Feed", is migrated for now; the
+# remaining environments (preinstalled zip, drop upload/retain, NuGet.org headers, VS feed,
+# VS insertion, symbol/source archival) will be migrated separately.
+#
+# The stage has a pre-deploy approval in the classic definition and is modeled as a
+# deployment job targeting an Azure DevOps Environment; configure the matching approval
+# check on that environment:
+#
+#   Environment                         Classic pre-deploy approver
+#   ----------------------------------  ----------------------------------------
+#   CLRIE-Release-Internal-NuGet-Feed   [DevDiv]\CLR Instrumentation Engine
+
+stages:
+
+# =====================================================================================
+# Publish NuGets to internal InstrumentationEngine Feed
+# =====================================================================================
+- stage: PublishNuGetsInternalFeed
+  displayName: Publish NuGets to internal InstrumentationEngine Feed
+  dependsOn: []
+  jobs:
+  - deployment: Publish
+    displayName: Publish NuGets to internal InstrumentationEngine Feed
+    environment: CLRIE-Release-Internal-NuGet-Feed
+    strategy:
+      runOnce:
+        deploy:
+          steps:
+          - download: none
+          - download: ClrInstrumentationEngine-Signed-Yaml
+            artifact: packages-windows-Release
+            patterns: '**/Microsoft.InstrumentationEngine*.nupkg'
+            displayName: Download Windows packages
+          - download: ClrInstrumentationEngine-Signed-Yaml
+            artifact: packages-linux-ubuntu-Release
+            patterns: '**/Microsoft.InstrumentationEngine*.nupkg'
+            displayName: Download Linux (ubuntu) packages
+          - download: ClrInstrumentationEngine-Signed-Yaml
+            artifact: packages-linux-alpine-Release
+            patterns: '**/Microsoft.InstrumentationEngine*.nupkg'
+            displayName: Download Linux (alpine) packages
+
+          - task: NuGetAuthenticate@1
+            displayName: NuGet Authenticate
+
+          - task: NuGetCommand@2
+            displayName: Push to DevDiv InstrumentationEngine feed
+            inputs:
+              command: push
+              nuGetFeedType: internal
+              publishVstsFeed: 59c1dfae-dea5-4ea5-ac83-c9abcb4ac339
+              packagesToPush: $(ArtifactsDirectory)\$(WindowsInstrumentationEngineNuGetArtifactPathPattern);$(ArtifactsDirectory)\$(LinuxInstrumentationEngineNuGetArtifactPathPattern)
+              allowPackageConflicts: true
+              publishPackageMetadata: true
+              verbosityPush: Detailed
+
+          # Classic equivalent: "Promote package to Release View" (deprecated marketplace task,
+          # gated on PromoteToRelease). Implemented here against the Azure Artifacts packaging
+          # REST API; only runs when PromoteToRelease is set to 'True'.
+          - task: PowerShell@2
+            displayName: Promote package to Release View
+            condition: and(succeeded(), eq(variables['PromoteToRelease'], 'True'))
+            env:
+              SYSTEM_ACCESSTOKEN: $(System.AccessToken)
+            inputs:
+              targetType: inline
+              script: |
+                $feedId = '59c1dfae-dea5-4ea5-ac83-c9abcb4ac339'
+                $headers = @{ Authorization = "Bearer $env:SYSTEM_ACCESSTOKEN" }
+                $root = Join-Path $env:ArtifactsDirectory 'ClrInstrumentationEngine-Signed-Yaml'
+                Get-ChildItem -Path $root -Recurse -Filter *.nupkg | ForEach-Object {
+                  if ($_.Name -match '^(?<id>.+?)\.(?<ver>\d+\..*)\.nupkg$') {
+                    $id = $Matches.id; $ver = $Matches.ver
+                    $uri = "https://pkgs.dev.azure.com/DevDiv/_apis/packaging/feeds/$feedId/nuget/packages/$id/versions/$ver?api-version=7.1-preview.1"
+                    $body = @{ views = @{ op = 'add'; path = '/views/-'; value = 'Release' } } | ConvertTo-Json -Depth 5
+                    Write-Host "Promoting $id $ver to Release view"
+                    Invoke-RestMethod -Uri $uri -Method Patch -Headers $headers -Body $body -ContentType 'application/json'
+                  }
+                }

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -18,9 +18,11 @@ Based on the changes and targeted platform releases, impacted scenarios and part
 ### Release Phase
 1.  Once testing completes, PR to merge `main` branch to `release` branch
 2.  Manually run the [Signed](https://devdiv.visualstudio.com/DevDiv/_build?definitionId=11311) build to create release artifacts
-3.  Manually run the
-[CLR Instrumentation Engine Release](https://devdiv.visualstudio.com/DevDiv/_releases2?view=all&definitionId=901)
-pipeline which publishes artifacts with release version (eg. 1.0.15)
+3.  Manually run the **CLR Instrumentation Engine Release** YAML pipeline
+([build/yaml/pipelines/release.yaml](../build/yaml/pipelines/release.yaml)) to publish NuGets to the internal
+InstrumentationEngine feed. This pipeline consumes the `Signed` build artifacts. The remaining release steps below
+are still performed via the legacy classic release definition
+([definitionId=901](https://devdiv.visualstudio.com/DevDiv/_releases2?view=all&definitionId=901)) until they are migrated.
     +  Publish NuGets to the internal NuGet feed and MSAzure (for Azure VM/VMSS WAD)
     +  Publish Preinstalled CLR Instrumentation Engine zip file to Azure App Service
     +  Publish msi/msm files to CDN and expose aka.ms links on this repo.


### PR DESCRIPTION
Ports the release-pipeline migration and CI deprecation fixes onto main. New release pipeline YAML (build/yaml/pipelines/release.yaml, build/yaml/stages/release.yaml - internal-feed publish stage only), docs/release_process.md update, and actions/cache v4.3.0 + actions/upload-artifact v4.6.2 bumps applied to build.yml.disabled (build.yml is disabled on main) and scorecards.yml.