### PR TITLE
Pin BinSkim task to latest 4.x engine instead of legacy 1.9.5

### DIFF
--- a/build/yaml/jobs/codeanalysis/binskim.yaml
+++ b/build/yaml/jobs/codeanalysis/binskim.yaml
@@ -35,6 +35,7 @@ jobs:
       AnalyzeTarget: '$(Build.ArtifactStagingDirectory)\binaries-windows-Release\**\*.dll;$(Build.ArtifactStagingDirectory)\binaries-windows-Release\**\*.exe;'
       AnalyzeVerbose: true
       AnalyzeHashes: true
+      toolVersion: 'Latest'
     continueOnError: true
 
   # Publish SecurityAnalysis Logs


### PR DESCRIPTION
###### Summary <!-- REQUIRED -->
Fix BinSkim step to use the latest BinSkim tool

The BinSkim@4 task defaults to downloading Microsoft.CodeAnalysis.BinSkim 1.9.5, a deprecated engine. Add toolVersion: 'Latest' so the current 4.x BinSkim CLI is used.
