### PR TITLE
Bump version to 1.0.47

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Please format the changes as follows:
 + BugFixes:
 + Updates:
 
+## 1.0.47
+
 ## 1.0.46
 + BugFixes:
   + Check the values for configuration variables

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Please format the changes as follows:
 + Updates:
 
 ## 1.0.47
++ BugFixes:
+  + Fix libInstrumentationEngine.so loading on Ubuntu 26.04 (#599)
 
 ## 1.0.46
 + BugFixes:

--- a/build/Version.props
+++ b/build/Version.props
@@ -12,7 +12,7 @@
     -->
     <SemanticVersionMajor>1</SemanticVersionMajor>
     <SemanticVersionMinor>0</SemanticVersionMinor>
-    <SemanticVersionPatch>46</SemanticVersionPatch>
+    <SemanticVersionPatch>47</SemanticVersionPatch>
 
     <FileVersionMajor>15</FileVersionMajor>
     <FileVersionMinor>1</FileVersionMinor>
@@ -38,7 +38,7 @@
       Update for every public release.
       Format is YYYY-MM-DD
     -->
-    <SemanticVersionDate>2022-03-22</SemanticVersionDate>
+    <SemanticVersionDate>2026-08-27</SemanticVersionDate>
 
     <!--
       Build version is used to distinguish internally built NuGet packages.


### PR DESCRIPTION
Updates CLR Instrumentation Engine to version 1.0.47 and adds the corresponding changelog entry.